### PR TITLE
Add benchmark dry-run runner skeleton

### DIFF
--- a/experiments/README.md
+++ b/experiments/README.md
@@ -4,12 +4,13 @@ This directory holds benchmark workloads, generated results, and future experime
 
 ## Current Status
 
-The benchmark surface is currently a skeleton. It defines the directory layout and an initial deterministic-heavy workload draft, but it does not include a benchmark runner yet.
+The benchmark surface is currently a skeleton. It defines the directory layout, an initial deterministic-heavy workload draft, and a minimal dry-run runner, but it does not include direct baseline or KORA-controlled execution yet.
 
 Current contents:
 
 - `workloads/`: versioned workload definitions used by future runners.
 - `results/`: generated benchmark outputs. This directory is intentionally kept empty except for `.gitkeep`.
+- `run_benchmark.py`: minimal benchmark runner skeleton.
 
 ## Deterministic-Heavy Workloads
 
@@ -26,6 +27,18 @@ The first workload draft is:
 ```text
 experiments/workloads/deterministic_heavy_v0.json
 ```
+
+## Dry-Run Runner
+
+The current runner supports only `dry-run` mode. It loads a workload, validates that it contains a task list, counts tasks by category, counts `requires_model` values, and writes a result JSON artifact.
+
+Example:
+
+```bash
+python3 experiments/run_benchmark.py --mode dry-run --workload experiments/workloads/deterministic_heavy_v0.json --output experiments/results/deterministic_heavy_v0.dry_run.json
+```
+
+This is not yet a direct baseline versus KORA-controlled comparison. It is only the first executable skeleton for validating workload shape and result artifact structure.
 
 ## Future Runner
 

--- a/experiments/run_benchmark.py
+++ b/experiments/run_benchmark.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+import argparse
+import json
+from collections import Counter
+from pathlib import Path
+from typing import Any
+
+
+SUPPORTED_MODES = {"dry-run"}
+
+
+def load_workload(path: Path) -> dict[str, Any]:
+    with path.open("r", encoding="utf-8") as handle:
+        workload = json.load(handle)
+
+    tasks = workload.get("tasks")
+    if not isinstance(tasks, list):
+        raise ValueError("workload must contain a 'tasks' list")
+
+    return workload
+
+
+def build_dry_run_result(workload: dict[str, Any], workload_path: Path) -> dict[str, Any]:
+    tasks = workload["tasks"]
+    category_counts = Counter()
+    requires_model_true = 0
+    requires_model_false = 0
+
+    for index, task in enumerate(tasks):
+        if not isinstance(task, dict):
+            raise ValueError(f"task at index {index} must be an object")
+
+        category = task.get("category")
+        if not isinstance(category, str) or not category:
+            raise ValueError(f"task at index {index} must contain a non-empty category")
+        category_counts[category] += 1
+
+        requires_model = task.get("requires_model")
+        if requires_model is True:
+            requires_model_true += 1
+        elif requires_model is False:
+            requires_model_false += 1
+        else:
+            raise ValueError(f"task at index {index} must contain boolean requires_model")
+
+    return {
+        "benchmark_name": workload.get("name", workload_path.stem),
+        "mode": "dry-run",
+        "workload_path": str(workload_path),
+        "total_tasks": len(tasks),
+        "category_counts": dict(sorted(category_counts.items())),
+        "requires_model_true": requires_model_true,
+        "requires_model_false": requires_model_false,
+        "status": "ok",
+        "notes": [
+            "Dry-run only: no direct baseline execution was performed.",
+            "Dry-run only: no KORA-controlled execution was performed.",
+        ],
+    }
+
+
+def write_result(result: dict[str, Any], output_path: Path) -> None:
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    with output_path.open("w", encoding="utf-8") as handle:
+        json.dump(result, handle, indent=2, sort_keys=True)
+        handle.write("\n")
+
+
+def run_dry_run(workload_path: Path, output_path: Path) -> dict[str, Any]:
+    workload = load_workload(workload_path)
+    result = build_dry_run_result(workload, workload_path)
+    write_result(result, output_path)
+    return result
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run KORA benchmark skeleton modes.")
+    parser.add_argument("--workload", required=True, help="Path to workload JSON")
+    parser.add_argument("--output", required=True, help="Path for result JSON")
+    parser.add_argument("--mode", required=True, choices=sorted(SUPPORTED_MODES), help="Benchmark mode")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    workload_path = Path(args.workload)
+    output_path = Path(args.output)
+
+    if args.mode == "dry-run":
+        result = run_dry_run(workload_path, output_path)
+        print(
+            json.dumps(
+                {
+                    "status": result["status"],
+                    "benchmark_name": result["benchmark_name"],
+                    "mode": result["mode"],
+                    "total_tasks": result["total_tasks"],
+                    "output": str(output_path),
+                },
+                indent=2,
+                sort_keys=True,
+            )
+        )
+        return 0
+
+    raise ValueError(f"unsupported mode: {args.mode}")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_benchmark_runner.py
+++ b/tests/test_benchmark_runner.py
@@ -1,0 +1,46 @@
+import json
+from pathlib import Path
+
+from experiments.run_benchmark import load_workload, run_dry_run
+
+
+WORKLOAD_PATH = Path("experiments/workloads/deterministic_heavy_v0.json")
+
+
+def test_workload_json_can_be_loaded() -> None:
+    workload = load_workload(WORKLOAD_PATH)
+
+    assert workload["name"] == "deterministic_heavy_v0"
+    assert isinstance(workload["tasks"], list)
+    assert len(workload["tasks"]) == 20
+
+
+def test_dry_run_result_counts_workload(tmp_path: Path) -> None:
+    output_path = tmp_path / "deterministic_heavy_v0.dry_run.json"
+
+    result = run_dry_run(WORKLOAD_PATH, output_path)
+
+    assert result["benchmark_name"] == "deterministic_heavy_v0"
+    assert result["mode"] == "dry-run"
+    assert result["total_tasks"] == 20
+    assert result["requires_model_true"] == 4
+    assert result["requires_model_false"] == 16
+    assert set(result["category_counts"]) == {
+        "arithmetic",
+        "cache_lookup",
+        "json_validation",
+        "routing_decision",
+        "schema_check",
+        "string_normalization",
+    }
+
+
+def test_dry_run_writes_output_json(tmp_path: Path) -> None:
+    output_path = tmp_path / "result.json"
+
+    run_dry_run(WORKLOAD_PATH, output_path)
+
+    assert output_path.exists()
+    saved = json.loads(output_path.read_text(encoding="utf-8"))
+    assert saved["status"] == "ok"
+    assert saved["total_tasks"] == 20


### PR DESCRIPTION
Adds a minimal benchmark runner skeleton for KORA.

Included:
- experiments/run_benchmark.py
- tests/test_benchmark_runner.py
- experiments/README.md update

Current capability:
- dry-run mode
- workload loading
- task counting
- category counting
- requires_model true/false counting
- result JSON output

Validation run locally:
- python3 experiments/run_benchmark.py --mode dry-run --workload experiments/workloads/deterministic_heavy_v0.json --output /tmp/kora_deterministic_heavy_v0.dry_run.json
- python3 -m json.tool /tmp/kora_deterministic_heavy_v0.dry_run.json
- ./scripts/release_smoke.sh
- python3 -m pytest -q

No direct baseline, no KORA-controlled execution, and no runtime KORA code changes.