### PR TITLE
Add direct baseline benchmark mode

### DIFF
--- a/experiments/README.md
+++ b/experiments/README.md
@@ -4,7 +4,7 @@ This directory holds benchmark workloads, generated results, and future experime
 
 ## Current Status
 
-The benchmark surface is currently a skeleton. It defines the directory layout, an initial deterministic-heavy workload draft, and a minimal dry-run runner, but it does not include direct baseline or KORA-controlled execution yet.
+The benchmark surface is currently a skeleton. It defines the directory layout, an initial deterministic-heavy workload draft, a minimal dry-run runner, and a simulated direct baseline mode, but it does not include KORA-controlled execution yet.
 
 Current contents:
 
@@ -30,7 +30,7 @@ experiments/workloads/deterministic_heavy_v0.json
 
 ## Dry-Run Runner
 
-The current runner supports only `dry-run` mode. It loads a workload, validates that it contains a task list, counts tasks by category, counts `requires_model` values, and writes a result JSON artifact.
+The runner supports `dry-run` mode for workload shape validation. It loads a workload, validates that it contains a task list, counts tasks by category, counts `requires_model` values, and writes a result JSON artifact.
 
 Example:
 
@@ -39,6 +39,18 @@ python3 experiments/run_benchmark.py --mode dry-run --workload experiments/workl
 ```
 
 This is not yet a direct baseline versus KORA-controlled comparison. It is only the first executable skeleton for validating workload shape and result artifact structure.
+
+## Direct Baseline Runner
+
+The runner also supports `direct-baseline` mode. This mode simulates a naive baseline where every task is counted as one model invocation. It does not call a real model, use external APIs, or measure actual API cost.
+
+Example:
+
+```bash
+python3 experiments/run_benchmark.py --mode direct-baseline --workload experiments/workloads/deterministic_heavy_v0.json --output experiments/results/deterministic_heavy_v0.direct_baseline.json
+```
+
+This gives the future benchmark a baseline model-invocation count to compare against. KORA-controlled execution will be added next.
 
 ## Future Runner
 

--- a/experiments/run_benchmark.py
+++ b/experiments/run_benchmark.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from typing import Any
 
 
-SUPPORTED_MODES = {"dry-run"}
+SUPPORTED_MODES = {"direct-baseline", "dry-run"}
 
 
 def load_workload(path: Path) -> dict[str, Any]:
@@ -21,7 +21,7 @@ def load_workload(path: Path) -> dict[str, Any]:
     return workload
 
 
-def build_dry_run_result(workload: dict[str, Any], workload_path: Path) -> dict[str, Any]:
+def summarize_workload(workload: dict[str, Any]) -> dict[str, Any]:
     tasks = workload["tasks"]
     category_counts = Counter()
     requires_model_true = 0
@@ -45,17 +45,45 @@ def build_dry_run_result(workload: dict[str, Any], workload_path: Path) -> dict[
             raise ValueError(f"task at index {index} must contain boolean requires_model")
 
     return {
-        "benchmark_name": workload.get("name", workload_path.stem),
-        "mode": "dry-run",
-        "workload_path": str(workload_path),
         "total_tasks": len(tasks),
         "category_counts": dict(sorted(category_counts.items())),
         "requires_model_true": requires_model_true,
         "requires_model_false": requires_model_false,
+    }
+
+
+def build_dry_run_result(workload: dict[str, Any], workload_path: Path) -> dict[str, Any]:
+    summary = summarize_workload(workload)
+
+    return {
+        "benchmark_name": workload.get("name", workload_path.stem),
+        "mode": "dry-run",
+        "workload_path": str(workload_path),
+        **summary,
         "status": "ok",
         "notes": [
             "Dry-run only: no direct baseline execution was performed.",
             "Dry-run only: no KORA-controlled execution was performed.",
+        ],
+    }
+
+
+def build_direct_baseline_result(workload: dict[str, Any], workload_path: Path) -> dict[str, Any]:
+    summary = summarize_workload(workload)
+
+    return {
+        "benchmark_name": workload.get("name", workload_path.stem),
+        "mode": "direct-baseline",
+        "workload_path": str(workload_path),
+        **summary,
+        "simulated_model_invocations": summary["total_tasks"],
+        "deterministic_tasks_sent_to_model": summary["requires_model_false"],
+        "fallback_candidate_tasks_sent_to_model": summary["requires_model_true"],
+        "status": "ok",
+        "notes": [
+            "Simulated naive baseline: every task is counted as one model invocation.",
+            "No real model calls or external APIs were used.",
+            "No KORA-controlled execution was performed.",
         ],
     }
 
@@ -70,6 +98,13 @@ def write_result(result: dict[str, Any], output_path: Path) -> None:
 def run_dry_run(workload_path: Path, output_path: Path) -> dict[str, Any]:
     workload = load_workload(workload_path)
     result = build_dry_run_result(workload, workload_path)
+    write_result(result, output_path)
+    return result
+
+
+def run_direct_baseline(workload_path: Path, output_path: Path) -> dict[str, Any]:
+    workload = load_workload(workload_path)
+    result = build_direct_baseline_result(workload, workload_path)
     write_result(result, output_path)
     return result
 
@@ -89,22 +124,25 @@ def main(argv: list[str] | None = None) -> int:
 
     if args.mode == "dry-run":
         result = run_dry_run(workload_path, output_path)
-        print(
-            json.dumps(
-                {
-                    "status": result["status"],
-                    "benchmark_name": result["benchmark_name"],
-                    "mode": result["mode"],
-                    "total_tasks": result["total_tasks"],
-                    "output": str(output_path),
-                },
-                indent=2,
-                sort_keys=True,
-            )
-        )
-        return 0
+    elif args.mode == "direct-baseline":
+        result = run_direct_baseline(workload_path, output_path)
+    else:
+        raise ValueError(f"unsupported mode: {args.mode}")
 
-    raise ValueError(f"unsupported mode: {args.mode}")
+    print(
+        json.dumps(
+            {
+                "status": result["status"],
+                "benchmark_name": result["benchmark_name"],
+                "mode": result["mode"],
+                "total_tasks": result["total_tasks"],
+                "output": str(output_path),
+            },
+            indent=2,
+            sort_keys=True,
+        )
+    )
+    return 0
 
 
 if __name__ == "__main__":

--- a/tests/test_benchmark_runner.py
+++ b/tests/test_benchmark_runner.py
@@ -1,7 +1,7 @@
 import json
 from pathlib import Path
 
-from experiments.run_benchmark import load_workload, run_dry_run
+from experiments.run_benchmark import load_workload, run_direct_baseline, run_dry_run
 
 
 WORKLOAD_PATH = Path("experiments/workloads/deterministic_heavy_v0.json")
@@ -44,3 +44,28 @@ def test_dry_run_writes_output_json(tmp_path: Path) -> None:
     saved = json.loads(output_path.read_text(encoding="utf-8"))
     assert saved["status"] == "ok"
     assert saved["total_tasks"] == 20
+
+
+def test_direct_baseline_result_counts_simulated_model_invocations(tmp_path: Path) -> None:
+    output_path = tmp_path / "deterministic_heavy_v0.direct_baseline.json"
+
+    result = run_direct_baseline(WORKLOAD_PATH, output_path)
+
+    assert result["benchmark_name"] == "deterministic_heavy_v0"
+    assert result["mode"] == "direct-baseline"
+    assert result["total_tasks"] == 20
+    assert result["simulated_model_invocations"] == 20
+    assert result["deterministic_tasks_sent_to_model"] == 16
+    assert result["fallback_candidate_tasks_sent_to_model"] == 4
+
+
+def test_direct_baseline_writes_output_json(tmp_path: Path) -> None:
+    output_path = tmp_path / "direct_baseline.json"
+
+    run_direct_baseline(WORKLOAD_PATH, output_path)
+
+    assert output_path.exists()
+    saved = json.loads(output_path.read_text(encoding="utf-8"))
+    assert saved["status"] == "ok"
+    assert saved["mode"] == "direct-baseline"
+    assert saved["simulated_model_invocations"] == 20


### PR DESCRIPTION
Adds a simulated direct-baseline mode to the KORA benchmark runner.

Included:
- experiments/run_benchmark.py update
- tests/test_benchmark_runner.py update
- experiments/README.md update

Current capability:
- dry-run mode remains supported
- direct-baseline mode simulates the naive baseline where every task causes one model invocation
- no real model calls
- no external APIs
- no KORA-controlled execution yet

Current deterministic-heavy workload result:
- total tasks: 20
- simulated model invocations: 20
- deterministic tasks sent to model: 16
- fallback candidate tasks sent to model: 4

Validation run locally:
- dry-run benchmark
- direct-baseline benchmark
- JSON validation
- ./scripts/release_smoke.sh
- python3 -m pytest -q

No runtime KORA code changes.