### PR TITLE
Add KORA-controlled benchmark mode

### DIFF
--- a/experiments/README.md
+++ b/experiments/README.md
@@ -4,7 +4,7 @@ This directory holds benchmark workloads, generated results, and future experime
 
 ## Current Status
 
-The benchmark surface is currently a skeleton. It defines the directory layout, an initial deterministic-heavy workload draft, a minimal dry-run runner, and a simulated direct baseline mode, but it does not include KORA-controlled execution yet.
+The benchmark surface is currently a skeleton. It defines the directory layout, an initial deterministic-heavy workload draft, a minimal dry-run runner, a simulated direct baseline mode, and a simulated KORA-controlled mode.
 
 Current contents:
 
@@ -50,7 +50,29 @@ Example:
 python3 experiments/run_benchmark.py --mode direct-baseline --workload experiments/workloads/deterministic_heavy_v0.json --output experiments/results/deterministic_heavy_v0.direct_baseline.json
 ```
 
-This gives the future benchmark a baseline model-invocation count to compare against. KORA-controlled execution will be added next.
+This gives the benchmark a baseline model-invocation count to compare against the simulated KORA-controlled mode.
+
+## KORA-Controlled Runner
+
+The runner also supports `kora-controlled` mode. This mode simulates deterministic-first KORA execution using workload metadata:
+
+- tasks with `requires_model: false` are counted as deterministic resolutions
+- tasks with `requires_model: true` are counted as fallback/model-invocation candidates
+
+Example:
+
+```bash
+python3 experiments/run_benchmark.py --mode kora-controlled --workload experiments/workloads/deterministic_heavy_v0.json --output experiments/results/deterministic_heavy_v0.kora_controlled.json
+```
+
+For the current deterministic-heavy workload, the simulated comparison is:
+
+- direct-baseline simulated model invocations: 20
+- kora-controlled simulated model invocations: 4
+- avoided model invocations: 16
+- avoided invocation rate: 80%
+
+This is not production cost reduction, not a real API measurement, and not full KORA runtime integration.
 
 ## Future Runner
 

--- a/experiments/run_benchmark.py
+++ b/experiments/run_benchmark.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from typing import Any
 
 
-SUPPORTED_MODES = {"direct-baseline", "dry-run"}
+SUPPORTED_MODES = {"direct-baseline", "dry-run", "kora-controlled"}
 
 
 def load_workload(path: Path) -> dict[str, Any]:
@@ -88,6 +88,33 @@ def build_direct_baseline_result(workload: dict[str, Any], workload_path: Path) 
     }
 
 
+def build_kora_controlled_result(workload: dict[str, Any], workload_path: Path) -> dict[str, Any]:
+    summary = summarize_workload(workload)
+    direct_baseline_invocations = summary["total_tasks"]
+    simulated_model_invocations = summary["requires_model_true"]
+    avoided_invocations = direct_baseline_invocations - simulated_model_invocations
+    avoided_rate = avoided_invocations / direct_baseline_invocations if direct_baseline_invocations else 0.0
+
+    return {
+        "benchmark_name": workload.get("name", workload_path.stem),
+        "mode": "kora-controlled",
+        "workload_path": str(workload_path),
+        **summary,
+        "deterministic_resolutions": summary["requires_model_false"],
+        "fallback_candidates": summary["requires_model_true"],
+        "simulated_model_invocations": simulated_model_invocations,
+        "avoided_model_invocations_vs_direct_baseline": avoided_invocations,
+        "avoided_model_invocation_rate": avoided_rate,
+        "status": "ok",
+        "notes": [
+            "Simulated deterministic-first KORA-controlled mode based on workload metadata.",
+            "Tasks with requires_model=false are counted as deterministic resolutions.",
+            "Tasks with requires_model=true are counted as fallback/model-invocation candidates.",
+            "No real model calls, external APIs, or full KORA runtime integration were used.",
+        ],
+    }
+
+
 def write_result(result: dict[str, Any], output_path: Path) -> None:
     output_path.parent.mkdir(parents=True, exist_ok=True)
     with output_path.open("w", encoding="utf-8") as handle:
@@ -109,6 +136,13 @@ def run_direct_baseline(workload_path: Path, output_path: Path) -> dict[str, Any
     return result
 
 
+def run_kora_controlled(workload_path: Path, output_path: Path) -> dict[str, Any]:
+    workload = load_workload(workload_path)
+    result = build_kora_controlled_result(workload, workload_path)
+    write_result(result, output_path)
+    return result
+
+
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Run KORA benchmark skeleton modes.")
     parser.add_argument("--workload", required=True, help="Path to workload JSON")
@@ -126,6 +160,8 @@ def main(argv: list[str] | None = None) -> int:
         result = run_dry_run(workload_path, output_path)
     elif args.mode == "direct-baseline":
         result = run_direct_baseline(workload_path, output_path)
+    elif args.mode == "kora-controlled":
+        result = run_kora_controlled(workload_path, output_path)
     else:
         raise ValueError(f"unsupported mode: {args.mode}")
 

--- a/tests/test_benchmark_runner.py
+++ b/tests/test_benchmark_runner.py
@@ -1,7 +1,12 @@
 import json
 from pathlib import Path
 
-from experiments.run_benchmark import load_workload, run_direct_baseline, run_dry_run
+from experiments.run_benchmark import (
+    load_workload,
+    run_direct_baseline,
+    run_dry_run,
+    run_kora_controlled,
+)
 
 
 WORKLOAD_PATH = Path("experiments/workloads/deterministic_heavy_v0.json")
@@ -69,3 +74,30 @@ def test_direct_baseline_writes_output_json(tmp_path: Path) -> None:
     assert saved["status"] == "ok"
     assert saved["mode"] == "direct-baseline"
     assert saved["simulated_model_invocations"] == 20
+
+
+def test_kora_controlled_result_counts_avoided_model_invocations(tmp_path: Path) -> None:
+    output_path = tmp_path / "deterministic_heavy_v0.kora_controlled.json"
+
+    result = run_kora_controlled(WORKLOAD_PATH, output_path)
+
+    assert result["benchmark_name"] == "deterministic_heavy_v0"
+    assert result["mode"] == "kora-controlled"
+    assert result["total_tasks"] == 20
+    assert result["deterministic_resolutions"] == 16
+    assert result["fallback_candidates"] == 4
+    assert result["simulated_model_invocations"] == 4
+    assert result["avoided_model_invocations_vs_direct_baseline"] == 16
+    assert result["avoided_model_invocation_rate"] == 0.8
+
+
+def test_kora_controlled_writes_output_json(tmp_path: Path) -> None:
+    output_path = tmp_path / "kora_controlled.json"
+
+    run_kora_controlled(WORKLOAD_PATH, output_path)
+
+    assert output_path.exists()
+    saved = json.loads(output_path.read_text(encoding="utf-8"))
+    assert saved["status"] == "ok"
+    assert saved["mode"] == "kora-controlled"
+    assert saved["simulated_model_invocations"] == 4


### PR DESCRIPTION
Adds simulated KORA-controlled benchmark mode to the KORA benchmark runner.

Included:
- experiments/run_benchmark.py update
- tests/test_benchmark_runner.py update
- experiments/README.md update

Current capability:
- dry-run mode
- direct-baseline mode
- kora-controlled mode

Current deterministic-heavy controlled benchmark result:
- total tasks: 20
- direct-baseline simulated model invocations: 20
- kora-controlled simulated model invocations: 4
- deterministic resolutions: 16
- fallback candidates: 4
- avoided model invocations vs direct baseline: 16
- avoided invocation rate: 80%

Important limitations:
- simulated benchmark mode only
- no real model calls
- no external APIs
- no full KORA runtime integration
- no production cost reduction claim

Validation run locally:
- dry-run benchmark
- direct-baseline benchmark
- kora-controlled benchmark
- JSON validation
- ./scripts/release_smoke.sh
- python3 -m pytest -q

No runtime KORA code changes.