### PR TITLE
Add 2026-05-04 KORA EOD report

### DIFF
--- a/docs/eod/kora_eod_2026_05_04.md
+++ b/docs/eod/kora_eod_2026_05_04.md
@@ -1,0 +1,205 @@
+# KORA End-of-Day Report - 2026-05-04
+
+Date: 2026-05-04
+
+Current public HEAD:
+
+```text
+origin/main 0f4c761847822f4456bd8b4521a33f65c34f5830
+```
+
+Published release:
+
+```text
+v0.1.1-alpha
+```
+
+GitHub Release:
+
+```text
+https://github.com/hkalbertkim/KORA/releases/tag/v0.1.1-alpha
+```
+
+## Executive Summary
+
+KORA completed the 2026-05-04 alpha maintenance milestone ahead of the original development plan. The day started with `v0.1.0-alpha` already published and ended with `v0.1.1-alpha` tagged and published as a GitHub Release.
+
+The release added CI-backed validation and the first controlled benchmark skeleton. The benchmark path now includes a deterministic-heavy workload, a dry-run mode, a simulated direct baseline, and a simulated KORA-controlled mode. On the current 20-task deterministic-heavy workload, the KORA-controlled simulation avoids 16 of 20 simulated model invocations versus the naive direct baseline.
+
+This is a benchmark skeleton milestone, not a production benchmark or cost-reduction claim.
+
+## Starting State
+
+- Public truth was `origin/main`.
+- `v0.1.0-alpha` was already published.
+- The local `main` worktree was dirty and had to remain untouched.
+- There was no merged GitHub Actions CI workflow.
+- There was no committed benchmark experiment skeleton.
+- There was no benchmark runner for dry-run, direct-baseline, or KORA-controlled modes.
+- There was no `v0.1.1-alpha` release note, tag, or GitHub Release.
+
+## Final State
+
+- `origin/main` is at `0f4c761847822f4456bd8b4521a33f65c34f5830`.
+- GitHub Actions CI is merged and green.
+- Benchmark experiment skeleton is merged.
+- Benchmark runner supports:
+  - `dry-run`
+  - `direct-baseline`
+  - `kora-controlled`
+- Progress report is merged.
+- `v0.1.1-alpha` release note is merged.
+- Annotated tag `v0.1.1-alpha` is published.
+- GitHub Release for `v0.1.1-alpha` is published.
+- Final verification passed:
+  - release smoke
+  - pytest, 35 tests
+  - latest `main` CI
+
+## Completed Tasks
+
+| Task | Result |
+|---|---|
+| Task 034 | Added minimal GitHub Actions CI workflow. |
+| Task 035 | Committed and pushed CI workflow branch. |
+| Task 036 | Opened CI PR and confirmed GitHub Actions green. |
+| Task 037 | Merged CI PR and verified `origin/main`. |
+| Task 038 | Designed benchmark skeleton structure. |
+| Task 039 | Committed and pushed benchmark skeleton branch. |
+| Task 040 | Opened benchmark skeleton PR and confirmed CI green. |
+| Task 041 | Merged benchmark skeleton PR and verified `origin/main`. |
+| Task 042 | Added dry-run benchmark runner skeleton. |
+| Task 043 | Committed and pushed dry-run runner branch. |
+| Task 044 | Opened dry-run runner PR and confirmed CI green. |
+| Task 045 | Merged dry-run runner PR and verified `origin/main`. |
+| Task 046 | Added simulated direct-baseline benchmark mode. |
+| Task 047 | Committed and pushed direct-baseline branch. |
+| Task 048 | Opened direct-baseline PR and confirmed CI green. |
+| Task 049 | Merged direct-baseline PR and verified `origin/main`. |
+| Task 050 | Added simulated KORA-controlled benchmark mode. |
+| Task 051 | Committed and pushed KORA-controlled branch. |
+| Task 052 | Opened KORA-controlled PR and confirmed CI green. |
+| Task 053 | Merged KORA-controlled PR and verified `origin/main`. |
+| Task 054 | Added local progress report draft. |
+| Task 055 | Moved progress report into tracked docs path. |
+| Task 056 | Committed and pushed progress report branch. |
+| Task 057 | Opened progress report PR and confirmed CI green. |
+| Task 058 | Merged progress report PR and verified `origin/main`. |
+| Task 059 | Drafted `v0.1.1-alpha` release note. |
+| Task 060 | Committed and pushed release note branch. |
+| Task 061 | Opened release note PR and confirmed CI green. |
+| Task 062 | Merged release note PR and verified `origin/main`. |
+| Task 063 | Performed final release readiness check. |
+| Task 064 | Created and pushed annotated tag `v0.1.1-alpha`. |
+| Task 065 | Drafted GitHub Release body. |
+| Task 066 | Published GitHub Release for `v0.1.1-alpha`. |
+
+## Merged PRs
+
+| PR | Scope | Merge Commit |
+|---|---|---|
+| #2 | GitHub Actions CI | `804704006235463b6d85fc28b40077182212ed78` |
+| #3 | Benchmark skeleton | `0ea5421111d9f2d9f668c88e0053adc31a1c36b4` |
+| #4 | Dry-run benchmark runner | `0ee771d8daa8ebf083c76d56770ed3559ddb4f9d` |
+| #5 | Direct baseline benchmark mode | `46ba4445955157722363188d86d61b2287cd1215` |
+| #6 | KORA-controlled benchmark mode | `d9761245d2eb5a59a07c6bde5295a98582945f11` |
+| #7 | 2026-05-04 progress report | `f1cfd0a0a77cef92621678304afaf93ae0045ae8` |
+| #8 | `v0.1.1-alpha` release note | `0f4c761847822f4456bd8b4521a33f65c34f5830` |
+
+## Release Publication
+
+| Item | Status |
+|---|---|
+| Annotated tag `v0.1.1-alpha` | Published |
+| Tag object | `acb7bc2601e8f0e15f8287dea01024877113d582` |
+| Peeled tag commit | `0f4c761847822f4456bd8b4521a33f65c34f5830` |
+| GitHub Release | Published |
+| GitHub Release URL | `https://github.com/hkalbertkim/KORA/releases/tag/v0.1.1-alpha` |
+
+## Current Benchmark Result
+
+Workload:
+
+```text
+experiments/workloads/deterministic_heavy_v0.json
+```
+
+| Metric | Value |
+|---|---:|
+| Total tasks | 20 |
+| Direct-baseline simulated model invocations | 20 |
+| KORA-controlled simulated model invocations | 4 |
+| Deterministic resolutions | 16 |
+| Fallback candidates | 4 |
+| Avoided model invocations vs direct baseline | 16 |
+| Avoided model invocation rate | 0.8 |
+
+## Safe Public Claim
+
+```text
+KORA v0.1.1-alpha adds CI-backed validation and the first controlled benchmark skeleton. In a deterministic-heavy benchmark skeleton, KORA-controlled execution avoided 16 of 20 simulated model invocations versus a naive direct baseline.
+```
+
+Use the word `simulated` when describing the benchmark result.
+
+## Claims Not To Make Yet
+
+Do not claim:
+
+- production cost reduction
+- real API cost reduction
+- production benchmark proof
+- full runtime-integrated benchmark evidence
+- latency improvement
+- energy reduction
+- broad benchmark superiority
+- paper-grade evaluation completeness
+
+## Final Validation Results
+
+| Check | Result |
+|---|---|
+| Release smoke | Passed |
+| Pytest | Passed, 35 tests |
+| Latest `main` CI | Passed |
+| Dry-run benchmark | Passed |
+| Direct-baseline benchmark | Passed |
+| KORA-controlled benchmark | Passed |
+| Benchmark JSON validation | Passed |
+
+## Artifacts Created
+
+- `.github/workflows/ci.yml`
+- `experiments/README.md`
+- `experiments/run_benchmark.py`
+- `experiments/workloads/deterministic_heavy_v0.json`
+- `experiments/results/.gitkeep`
+- `tests/test_benchmark_runner.py`
+- `docs/progress/kora_progress_2026_05_04.md`
+- `docs/release_note_v0_1_1_alpha.md`
+- annotated tag `v0.1.1-alpha`
+- GitHub Release `v0.1.1-alpha`
+
+## Known Limitations
+
+- The benchmark is simulated.
+- No real model calls are made.
+- No external API calls are made.
+- No real API-cost measurement is included.
+- No production cost reduction claim is supported.
+- No full KORA runtime integration is implemented yet.
+- The workload is intentionally small and deterministic-heavy.
+- The current avoided invocation rate is based on workload metadata, not measured runtime routing.
+
+## Next Recommended Development Tasks
+
+1. Define the benchmark result artifact generation policy.
+2. Add a technical preview results document for controlled benchmark outputs.
+3. Expand the deterministic-heavy workload beyond the initial 20-task draft.
+4. Plan full KORA runtime integration for future benchmark modes.
+5. Draft the `v0.2.0-alpha` roadmap.
+
+## Worktree Notes
+
+- Dirty local `main` remained untouched.
+- All implementation, verification, PR, merge, tag, and release work was done through clean worktrees and task branches.


### PR DESCRIPTION
Adds the tracked EOD report for KORA development on 2026-05-04.

Included:
- docs/eod/kora_eod_2026_05_04.md

The report documents:
- Task 034 through Task 066
- merged PRs #2 through #8
- v0.1.1-alpha tag publication
- GitHub Release publication
- CI-backed validation
- benchmark skeleton
- dry-run mode
- direct-baseline mode
- KORA-controlled mode
- current controlled benchmark skeleton result
- limitations and next recommended tasks

Current controlled benchmark skeleton result:
- total tasks: 20
- direct-baseline simulated model invocations: 20
- KORA-controlled simulated model invocations: 4
- deterministic resolutions: 16
- fallback candidates: 4
- avoided model invocations: 16
- avoided invocation rate: 80%

Validation run locally:
- ./scripts/release_smoke.sh
- python3 -m pytest -q