### PR TITLE
Add deterministic-heavy workload generator

### DIFF
--- a/experiments/README.md
+++ b/experiments/README.md
@@ -10,6 +10,7 @@ Current contents:
 
 - `workloads/`: versioned workload definitions used by future runners.
 - `results/`: generated benchmark outputs. This directory is intentionally kept empty except for `.gitkeep`.
+- `generate_workload.py`: deterministic-heavy workload generator.
 - `run_benchmark.py`: minimal benchmark runner skeleton.
 
 ## Deterministic-Heavy Workloads
@@ -27,6 +28,26 @@ The first workload draft is:
 ```text
 experiments/workloads/deterministic_heavy_v0.json
 ```
+
+The first generated near-term workload is:
+
+```text
+experiments/workloads/deterministic_heavy_v1_100.json
+```
+
+It contains 100 deterministic-heavy tasks generated from seed `42`, with approximately 80 deterministic/no-model tasks and 20 fallback/model-candidate tasks.
+
+## Workload Generator
+
+The workload generator creates reproducible deterministic-heavy workload JSON from a fixed seed.
+
+Example:
+
+```bash
+python3 experiments/generate_workload.py --count 100 --seed 42 --benchmark-name deterministic_heavy_v1 --output experiments/workloads/deterministic_heavy_v1_100.json
+```
+
+Generated workloads are reproducible from the same seed, count, and benchmark name. Generated tasks should still be reviewed for category balance, expected outputs, and fallback-candidate clarity before benchmark claims are made.
 
 ## Dry-Run Runner
 

--- a/experiments/generate_workload.py
+++ b/experiments/generate_workload.py
@@ -1,0 +1,285 @@
+from __future__ import annotations
+
+import argparse
+import json
+import random
+from pathlib import Path
+from typing import Any, Callable
+
+
+DEFAULT_BENCHMARK_NAME = "deterministic_heavy_v1"
+DEFAULT_COUNT = 100
+DEFAULT_SEED = 42
+VERSION = "1.0"
+
+CATEGORIES = [
+    "arithmetic",
+    "string_normalization",
+    "json_validation",
+    "routing_decision",
+    "cache_lookup",
+    "schema_check",
+    "date_normalization",
+    "unit_conversion",
+    "config_validation",
+    "policy_rule_match",
+]
+
+
+def _fallback_output(reason: str) -> dict[str, Any]:
+    return {
+        "fallback_required": True,
+        "reason": reason,
+    }
+
+
+def build_arithmetic_task(index: int, rng: random.Random, requires_model: bool) -> dict[str, Any]:
+    left = rng.randint(10, 250)
+    right = rng.randint(1, 80)
+    operation = rng.choice(["add", "subtract", "multiply"])
+    result = {
+        "add": left + right,
+        "subtract": left - right,
+        "multiply": left * right,
+    }[operation]
+
+    return {
+        "id": f"arithmetic_{index:03d}",
+        "category": "arithmetic",
+        "input": {"left": left, "right": right, "operation": operation},
+        "expected_path": "deterministic_arithmetic" if not requires_model else "fallback_candidate",
+        "expected_output": result if not requires_model else _fallback_output("ambiguous arithmetic instruction"),
+        "requires_model": requires_model,
+        "notes": "Exact arithmetic case." if not requires_model else "Fallback candidate for ambiguous arithmetic wording.",
+    }
+
+
+def build_string_normalization_task(index: int, rng: random.Random, requires_model: bool) -> dict[str, Any]:
+    words = [" KORA ", "Benchmark", "  deterministic ", "CONTROLLED", " Result  "]
+    selected = rng.sample(words, k=3)
+    raw = "-".join(selected)
+    normalized = " ".join(part.strip().lower() for part in selected)
+
+    return {
+        "id": f"string_normalization_{index:03d}",
+        "category": "string_normalization",
+        "input": {"text": raw, "normalization": "strip_lower_join_spaces"},
+        "expected_path": "deterministic_string_normalization" if not requires_model else "fallback_candidate",
+        "expected_output": normalized if not requires_model else _fallback_output("requires semantic rewrite beyond normalization"),
+        "requires_model": requires_model,
+        "notes": "Deterministic string normalization." if not requires_model else "Fallback candidate for semantic rewriting.",
+    }
+
+
+def build_json_validation_task(index: int, rng: random.Random, requires_model: bool) -> dict[str, Any]:
+    include_required = rng.choice([True, True, False])
+    payload = {"id": f"item-{index}", "enabled": rng.choice([True, False])}
+    if include_required:
+        payload["kind"] = rng.choice(["alpha", "beta", "gamma"])
+    expected = {"valid": include_required, "missing": [] if include_required else ["kind"]}
+
+    return {
+        "id": f"json_validation_{index:03d}",
+        "category": "json_validation",
+        "input": {"payload": payload, "required_fields": ["id", "kind", "enabled"]},
+        "expected_path": "deterministic_json_validation" if not requires_model else "fallback_candidate",
+        "expected_output": expected if not requires_model else _fallback_output("requires policy decision for invalid payload"),
+        "requires_model": requires_model,
+        "notes": "Structured JSON validation." if not requires_model else "Fallback candidate for invalid payload handling policy.",
+    }
+
+
+def build_routing_decision_task(index: int, rng: random.Random, requires_model: bool) -> dict[str, Any]:
+    priority = rng.choice(["low", "normal", "high"])
+    kind = rng.choice(["billing", "support", "security"])
+    route = "security_review" if kind == "security" or priority == "high" else f"{kind}_queue"
+
+    return {
+        "id": f"routing_decision_{index:03d}",
+        "category": "routing_decision",
+        "input": {"kind": kind, "priority": priority},
+        "expected_path": "deterministic_routing" if not requires_model else "fallback_candidate",
+        "expected_output": {"route": route} if not requires_model else _fallback_output("route requires incomplete policy context"),
+        "requires_model": requires_model,
+        "notes": "Rule-based routing decision." if not requires_model else "Fallback candidate for incomplete routing rules.",
+    }
+
+
+def build_cache_lookup_task(index: int, rng: random.Random, requires_model: bool) -> dict[str, Any]:
+    cache = {"alpha": "cached-alpha", "beta": "cached-beta", "gamma": "cached-gamma"}
+    key = rng.choice(["alpha", "beta", "gamma", "missing"])
+    expected = {"hit": key in cache, "value": cache.get(key)}
+
+    return {
+        "id": f"cache_lookup_{index:03d}",
+        "category": "cache_lookup",
+        "input": {"key": key, "namespace": "deterministic_heavy_v1"},
+        "expected_path": "deterministic_cache_lookup" if not requires_model else "fallback_candidate",
+        "expected_output": expected if not requires_model else _fallback_output("cache miss requires external answer"),
+        "requires_model": requires_model,
+        "notes": "Deterministic cache hit/miss lookup." if not requires_model else "Fallback candidate after cache miss.",
+    }
+
+
+def build_schema_check_task(index: int, rng: random.Random, requires_model: bool) -> dict[str, Any]:
+    status = rng.choice(["draft", "active", "archived", "invalid"])
+    expected = {"valid": status in {"draft", "active", "archived"}, "field": "status"}
+
+    return {
+        "id": f"schema_check_{index:03d}",
+        "category": "schema_check",
+        "input": {"object": {"status": status}, "enum": ["draft", "active", "archived"]},
+        "expected_path": "deterministic_schema_check" if not requires_model else "fallback_candidate",
+        "expected_output": expected if not requires_model else _fallback_output("schema repair requires human or model judgment"),
+        "requires_model": requires_model,
+        "notes": "Enum schema check." if not requires_model else "Fallback candidate for schema repair.",
+    }
+
+
+def build_date_normalization_task(index: int, rng: random.Random, requires_model: bool) -> dict[str, Any]:
+    year = 2026
+    month = rng.randint(1, 12)
+    day = rng.randint(1, 28)
+    raw = f"{month}/{day}/{year}"
+    normalized = f"{year:04d}-{month:02d}-{day:02d}"
+
+    return {
+        "id": f"date_normalization_{index:03d}",
+        "category": "date_normalization",
+        "input": {"date": raw, "input_format": "M/D/YYYY", "output_format": "YYYY-MM-DD"},
+        "expected_path": "deterministic_date_normalization" if not requires_model else "fallback_candidate",
+        "expected_output": normalized if not requires_model else _fallback_output("date phrase is underspecified"),
+        "requires_model": requires_model,
+        "notes": "Exact date normalization." if not requires_model else "Fallback candidate for underspecified date phrase.",
+    }
+
+
+def build_unit_conversion_task(index: int, rng: random.Random, requires_model: bool) -> dict[str, Any]:
+    meters = rng.randint(1, 500)
+    centimeters = meters * 100
+
+    return {
+        "id": f"unit_conversion_{index:03d}",
+        "category": "unit_conversion",
+        "input": {"value": meters, "from": "m", "to": "cm"},
+        "expected_path": "deterministic_unit_conversion" if not requires_model else "fallback_candidate",
+        "expected_output": {"value": centimeters, "unit": "cm"} if not requires_model else _fallback_output("unit target is ambiguous"),
+        "requires_model": requires_model,
+        "notes": "Exact metric unit conversion." if not requires_model else "Fallback candidate for ambiguous unit conversion.",
+    }
+
+
+def build_config_validation_task(index: int, rng: random.Random, requires_model: bool) -> dict[str, Any]:
+    retries = rng.randint(0, 5)
+    timeout_ms = rng.choice([100, 500, 1000, 5000])
+    expected = {"valid": 0 <= retries <= 3 and timeout_ms <= 3000}
+
+    return {
+        "id": f"config_validation_{index:03d}",
+        "category": "config_validation",
+        "input": {"config": {"retries": retries, "timeout_ms": timeout_ms}},
+        "expected_path": "deterministic_config_validation" if not requires_model else "fallback_candidate",
+        "expected_output": expected if not requires_model else _fallback_output("config recommendation requires tradeoff judgment"),
+        "requires_model": requires_model,
+        "notes": "Deterministic config bounds validation." if not requires_model else "Fallback candidate for config recommendation.",
+    }
+
+
+def build_policy_rule_match_task(index: int, rng: random.Random, requires_model: bool) -> dict[str, Any]:
+    region = rng.choice(["us", "eu", "apac"])
+    data_class = rng.choice(["public", "internal", "restricted"])
+    allowed = not (region == "eu" and data_class == "restricted")
+
+    return {
+        "id": f"policy_rule_match_{index:03d}",
+        "category": "policy_rule_match",
+        "input": {"region": region, "data_class": data_class},
+        "expected_path": "deterministic_policy_rule_match" if not requires_model else "fallback_candidate",
+        "expected_output": {"allowed": allowed} if not requires_model else _fallback_output("policy text is incomplete"),
+        "requires_model": requires_model,
+        "notes": "Explicit policy table match." if not requires_model else "Fallback candidate for incomplete policy text.",
+    }
+
+
+BUILDERS: dict[str, Callable[[int, random.Random, bool], dict[str, Any]]] = {
+    "arithmetic": build_arithmetic_task,
+    "string_normalization": build_string_normalization_task,
+    "json_validation": build_json_validation_task,
+    "routing_decision": build_routing_decision_task,
+    "cache_lookup": build_cache_lookup_task,
+    "schema_check": build_schema_check_task,
+    "date_normalization": build_date_normalization_task,
+    "unit_conversion": build_unit_conversion_task,
+    "config_validation": build_config_validation_task,
+    "policy_rule_match": build_policy_rule_match_task,
+}
+
+
+def fallback_indices(count: int, rng: random.Random) -> set[int]:
+    fallback_count = round(count * 0.2)
+    return set(rng.sample(range(count), k=fallback_count))
+
+
+def generate_workload(count: int = DEFAULT_COUNT, seed: int = DEFAULT_SEED, benchmark_name: str = DEFAULT_BENCHMARK_NAME) -> dict[str, Any]:
+    if count < len(CATEGORIES):
+        raise ValueError(f"count must be at least {len(CATEGORIES)} to include every category")
+
+    rng = random.Random(seed)
+    fallback_set = fallback_indices(count, rng)
+    tasks = []
+
+    for index in range(count):
+        category = CATEGORIES[index % len(CATEGORIES)]
+        task_rng = random.Random(f"{seed}:{index}:{category}")
+        task = BUILDERS[category](index + 1, task_rng, index in fallback_set)
+        tasks.append(task)
+
+    return {
+        "benchmark_name": benchmark_name,
+        "name": benchmark_name,
+        "version": VERSION,
+        "generated_by": "experiments/generate_workload.py",
+        "seed": seed,
+        "task_count": count,
+        "tasks": tasks,
+    }
+
+
+def write_workload(workload: dict[str, Any], output_path: Path) -> None:
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    with output_path.open("w", encoding="utf-8") as handle:
+        json.dump(workload, handle, indent=2, sort_keys=True)
+        handle.write("\n")
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Generate deterministic-heavy KORA benchmark workloads.")
+    parser.add_argument("--output", required=True, help="Path for generated workload JSON")
+    parser.add_argument("--count", type=int, default=DEFAULT_COUNT, help="Number of tasks to generate")
+    parser.add_argument("--seed", type=int, default=DEFAULT_SEED, help="Deterministic generation seed")
+    parser.add_argument("--benchmark-name", default=DEFAULT_BENCHMARK_NAME, help="Benchmark name stored in workload metadata")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    output_path = Path(args.output)
+    workload = generate_workload(count=args.count, seed=args.seed, benchmark_name=args.benchmark_name)
+    write_workload(workload, output_path)
+    print(
+        json.dumps(
+            {
+                "benchmark_name": workload["benchmark_name"],
+                "output": str(output_path),
+                "seed": workload["seed"],
+                "task_count": workload["task_count"],
+            },
+            indent=2,
+            sort_keys=True,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/experiments/workloads/deterministic_heavy_v1_100.json
+++ b/experiments/workloads/deterministic_heavy_v1_100.json
@@ -1,0 +1,1601 @@
+{
+  "benchmark_name": "deterministic_heavy_v1",
+  "generated_by": "experiments/generate_workload.py",
+  "name": "deterministic_heavy_v1",
+  "seed": 42,
+  "task_count": 100,
+  "tasks": [
+    {
+      "category": "arithmetic",
+      "expected_output": 11609,
+      "expected_path": "deterministic_arithmetic",
+      "id": "arithmetic_001",
+      "input": {
+        "left": 247,
+        "operation": "multiply",
+        "right": 47
+      },
+      "notes": "Exact arithmetic case.",
+      "requires_model": false
+    },
+    {
+      "category": "string_normalization",
+      "expected_output": "controlled benchmark deterministic",
+      "expected_path": "deterministic_string_normalization",
+      "id": "string_normalization_002",
+      "input": {
+        "normalization": "strip_lower_join_spaces",
+        "text": "CONTROLLED-Benchmark-  deterministic "
+      },
+      "notes": "Deterministic string normalization.",
+      "requires_model": false
+    },
+    {
+      "category": "json_validation",
+      "expected_output": {
+        "missing": [],
+        "valid": true
+      },
+      "expected_path": "deterministic_json_validation",
+      "id": "json_validation_003",
+      "input": {
+        "payload": {
+          "enabled": false,
+          "id": "item-3",
+          "kind": "alpha"
+        },
+        "required_fields": [
+          "id",
+          "kind",
+          "enabled"
+        ]
+      },
+      "notes": "Structured JSON validation.",
+      "requires_model": false
+    },
+    {
+      "category": "routing_decision",
+      "expected_output": {
+        "fallback_required": true,
+        "reason": "route requires incomplete policy context"
+      },
+      "expected_path": "fallback_candidate",
+      "id": "routing_decision_004",
+      "input": {
+        "kind": "security",
+        "priority": "low"
+      },
+      "notes": "Fallback candidate for incomplete routing rules.",
+      "requires_model": true
+    },
+    {
+      "category": "cache_lookup",
+      "expected_output": {
+        "fallback_required": true,
+        "reason": "cache miss requires external answer"
+      },
+      "expected_path": "fallback_candidate",
+      "id": "cache_lookup_005",
+      "input": {
+        "key": "gamma",
+        "namespace": "deterministic_heavy_v1"
+      },
+      "notes": "Fallback candidate after cache miss.",
+      "requires_model": true
+    },
+    {
+      "category": "schema_check",
+      "expected_output": {
+        "field": "status",
+        "valid": false
+      },
+      "expected_path": "deterministic_schema_check",
+      "id": "schema_check_006",
+      "input": {
+        "enum": [
+          "draft",
+          "active",
+          "archived"
+        ],
+        "object": {
+          "status": "invalid"
+        }
+      },
+      "notes": "Enum schema check.",
+      "requires_model": false
+    },
+    {
+      "category": "date_normalization",
+      "expected_output": "2026-11-02",
+      "expected_path": "deterministic_date_normalization",
+      "id": "date_normalization_007",
+      "input": {
+        "date": "11/2/2026",
+        "input_format": "M/D/YYYY",
+        "output_format": "YYYY-MM-DD"
+      },
+      "notes": "Exact date normalization.",
+      "requires_model": false
+    },
+    {
+      "category": "unit_conversion",
+      "expected_output": {
+        "unit": "cm",
+        "value": 13000
+      },
+      "expected_path": "deterministic_unit_conversion",
+      "id": "unit_conversion_008",
+      "input": {
+        "from": "m",
+        "to": "cm",
+        "value": 130
+      },
+      "notes": "Exact metric unit conversion.",
+      "requires_model": false
+    },
+    {
+      "category": "config_validation",
+      "expected_output": {
+        "valid": false
+      },
+      "expected_path": "deterministic_config_validation",
+      "id": "config_validation_009",
+      "input": {
+        "config": {
+          "retries": 4,
+          "timeout_ms": 1000
+        }
+      },
+      "notes": "Deterministic config bounds validation.",
+      "requires_model": false
+    },
+    {
+      "category": "policy_rule_match",
+      "expected_output": {
+        "allowed": true
+      },
+      "expected_path": "deterministic_policy_rule_match",
+      "id": "policy_rule_match_010",
+      "input": {
+        "data_class": "internal",
+        "region": "us"
+      },
+      "notes": "Explicit policy table match.",
+      "requires_model": false
+    },
+    {
+      "category": "arithmetic",
+      "expected_output": 195,
+      "expected_path": "deterministic_arithmetic",
+      "id": "arithmetic_011",
+      "input": {
+        "left": 180,
+        "operation": "add",
+        "right": 15
+      },
+      "notes": "Exact arithmetic case.",
+      "requires_model": false
+    },
+    {
+      "category": "string_normalization",
+      "expected_output": {
+        "fallback_required": true,
+        "reason": "requires semantic rewrite beyond normalization"
+      },
+      "expected_path": "fallback_candidate",
+      "id": "string_normalization_012",
+      "input": {
+        "normalization": "strip_lower_join_spaces",
+        "text": " KORA -CONTROLLED-  deterministic "
+      },
+      "notes": "Fallback candidate for semantic rewriting.",
+      "requires_model": true
+    },
+    {
+      "category": "json_validation",
+      "expected_output": {
+        "missing": [],
+        "valid": true
+      },
+      "expected_path": "deterministic_json_validation",
+      "id": "json_validation_013",
+      "input": {
+        "payload": {
+          "enabled": true,
+          "id": "item-13",
+          "kind": "gamma"
+        },
+        "required_fields": [
+          "id",
+          "kind",
+          "enabled"
+        ]
+      },
+      "notes": "Structured JSON validation.",
+      "requires_model": false
+    },
+    {
+      "category": "routing_decision",
+      "expected_output": {
+        "fallback_required": true,
+        "reason": "route requires incomplete policy context"
+      },
+      "expected_path": "fallback_candidate",
+      "id": "routing_decision_014",
+      "input": {
+        "kind": "support",
+        "priority": "high"
+      },
+      "notes": "Fallback candidate for incomplete routing rules.",
+      "requires_model": true
+    },
+    {
+      "category": "cache_lookup",
+      "expected_output": {
+        "fallback_required": true,
+        "reason": "cache miss requires external answer"
+      },
+      "expected_path": "fallback_candidate",
+      "id": "cache_lookup_015",
+      "input": {
+        "key": "gamma",
+        "namespace": "deterministic_heavy_v1"
+      },
+      "notes": "Fallback candidate after cache miss.",
+      "requires_model": true
+    },
+    {
+      "category": "schema_check",
+      "expected_output": {
+        "field": "status",
+        "valid": false
+      },
+      "expected_path": "deterministic_schema_check",
+      "id": "schema_check_016",
+      "input": {
+        "enum": [
+          "draft",
+          "active",
+          "archived"
+        ],
+        "object": {
+          "status": "invalid"
+        }
+      },
+      "notes": "Enum schema check.",
+      "requires_model": false
+    },
+    {
+      "category": "date_normalization",
+      "expected_output": "2026-01-10",
+      "expected_path": "deterministic_date_normalization",
+      "id": "date_normalization_017",
+      "input": {
+        "date": "1/10/2026",
+        "input_format": "M/D/YYYY",
+        "output_format": "YYYY-MM-DD"
+      },
+      "notes": "Exact date normalization.",
+      "requires_model": false
+    },
+    {
+      "category": "unit_conversion",
+      "expected_output": {
+        "fallback_required": true,
+        "reason": "unit target is ambiguous"
+      },
+      "expected_path": "fallback_candidate",
+      "id": "unit_conversion_018",
+      "input": {
+        "from": "m",
+        "to": "cm",
+        "value": 397
+      },
+      "notes": "Fallback candidate for ambiguous unit conversion.",
+      "requires_model": true
+    },
+    {
+      "category": "config_validation",
+      "expected_output": {
+        "valid": true
+      },
+      "expected_path": "deterministic_config_validation",
+      "id": "config_validation_019",
+      "input": {
+        "config": {
+          "retries": 3,
+          "timeout_ms": 500
+        }
+      },
+      "notes": "Deterministic config bounds validation.",
+      "requires_model": false
+    },
+    {
+      "category": "policy_rule_match",
+      "expected_output": {
+        "allowed": true
+      },
+      "expected_path": "deterministic_policy_rule_match",
+      "id": "policy_rule_match_020",
+      "input": {
+        "data_class": "public",
+        "region": "us"
+      },
+      "notes": "Explicit policy table match.",
+      "requires_model": false
+    },
+    {
+      "category": "arithmetic",
+      "expected_output": 156,
+      "expected_path": "deterministic_arithmetic",
+      "id": "arithmetic_021",
+      "input": {
+        "left": 76,
+        "operation": "add",
+        "right": 80
+      },
+      "notes": "Exact arithmetic case.",
+      "requires_model": false
+    },
+    {
+      "category": "string_normalization",
+      "expected_output": "controlled kora deterministic",
+      "expected_path": "deterministic_string_normalization",
+      "id": "string_normalization_022",
+      "input": {
+        "normalization": "strip_lower_join_spaces",
+        "text": "CONTROLLED- KORA -  deterministic "
+      },
+      "notes": "Deterministic string normalization.",
+      "requires_model": false
+    },
+    {
+      "category": "json_validation",
+      "expected_output": {
+        "missing": [],
+        "valid": true
+      },
+      "expected_path": "deterministic_json_validation",
+      "id": "json_validation_023",
+      "input": {
+        "payload": {
+          "enabled": false,
+          "id": "item-23",
+          "kind": "beta"
+        },
+        "required_fields": [
+          "id",
+          "kind",
+          "enabled"
+        ]
+      },
+      "notes": "Structured JSON validation.",
+      "requires_model": false
+    },
+    {
+      "category": "routing_decision",
+      "expected_output": {
+        "route": "security_review"
+      },
+      "expected_path": "deterministic_routing",
+      "id": "routing_decision_024",
+      "input": {
+        "kind": "security",
+        "priority": "low"
+      },
+      "notes": "Rule-based routing decision.",
+      "requires_model": false
+    },
+    {
+      "category": "cache_lookup",
+      "expected_output": {
+        "hit": true,
+        "value": "cached-alpha"
+      },
+      "expected_path": "deterministic_cache_lookup",
+      "id": "cache_lookup_025",
+      "input": {
+        "key": "alpha",
+        "namespace": "deterministic_heavy_v1"
+      },
+      "notes": "Deterministic cache hit/miss lookup.",
+      "requires_model": false
+    },
+    {
+      "category": "schema_check",
+      "expected_output": {
+        "field": "status",
+        "valid": true
+      },
+      "expected_path": "deterministic_schema_check",
+      "id": "schema_check_026",
+      "input": {
+        "enum": [
+          "draft",
+          "active",
+          "archived"
+        ],
+        "object": {
+          "status": "archived"
+        }
+      },
+      "notes": "Enum schema check.",
+      "requires_model": false
+    },
+    {
+      "category": "date_normalization",
+      "expected_output": "2026-02-12",
+      "expected_path": "deterministic_date_normalization",
+      "id": "date_normalization_027",
+      "input": {
+        "date": "2/12/2026",
+        "input_format": "M/D/YYYY",
+        "output_format": "YYYY-MM-DD"
+      },
+      "notes": "Exact date normalization.",
+      "requires_model": false
+    },
+    {
+      "category": "unit_conversion",
+      "expected_output": {
+        "fallback_required": true,
+        "reason": "unit target is ambiguous"
+      },
+      "expected_path": "fallback_candidate",
+      "id": "unit_conversion_028",
+      "input": {
+        "from": "m",
+        "to": "cm",
+        "value": 362
+      },
+      "notes": "Fallback candidate for ambiguous unit conversion.",
+      "requires_model": true
+    },
+    {
+      "category": "config_validation",
+      "expected_output": {
+        "fallback_required": true,
+        "reason": "config recommendation requires tradeoff judgment"
+      },
+      "expected_path": "fallback_candidate",
+      "id": "config_validation_029",
+      "input": {
+        "config": {
+          "retries": 3,
+          "timeout_ms": 100
+        }
+      },
+      "notes": "Fallback candidate for config recommendation.",
+      "requires_model": true
+    },
+    {
+      "category": "policy_rule_match",
+      "expected_output": {
+        "fallback_required": true,
+        "reason": "policy text is incomplete"
+      },
+      "expected_path": "fallback_candidate",
+      "id": "policy_rule_match_030",
+      "input": {
+        "data_class": "restricted",
+        "region": "eu"
+      },
+      "notes": "Fallback candidate for incomplete policy text.",
+      "requires_model": true
+    },
+    {
+      "category": "arithmetic",
+      "expected_output": 2583,
+      "expected_path": "deterministic_arithmetic",
+      "id": "arithmetic_031",
+      "input": {
+        "left": 123,
+        "operation": "multiply",
+        "right": 21
+      },
+      "notes": "Exact arithmetic case.",
+      "requires_model": false
+    },
+    {
+      "category": "string_normalization",
+      "expected_output": {
+        "fallback_required": true,
+        "reason": "requires semantic rewrite beyond normalization"
+      },
+      "expected_path": "fallback_candidate",
+      "id": "string_normalization_032",
+      "input": {
+        "normalization": "strip_lower_join_spaces",
+        "text": " Result  -  deterministic - KORA "
+      },
+      "notes": "Fallback candidate for semantic rewriting.",
+      "requires_model": true
+    },
+    {
+      "category": "json_validation",
+      "expected_output": {
+        "missing": [],
+        "valid": true
+      },
+      "expected_path": "deterministic_json_validation",
+      "id": "json_validation_033",
+      "input": {
+        "payload": {
+          "enabled": true,
+          "id": "item-33",
+          "kind": "gamma"
+        },
+        "required_fields": [
+          "id",
+          "kind",
+          "enabled"
+        ]
+      },
+      "notes": "Structured JSON validation.",
+      "requires_model": false
+    },
+    {
+      "category": "routing_decision",
+      "expected_output": {
+        "route": "security_review"
+      },
+      "expected_path": "deterministic_routing",
+      "id": "routing_decision_034",
+      "input": {
+        "kind": "security",
+        "priority": "normal"
+      },
+      "notes": "Rule-based routing decision.",
+      "requires_model": false
+    },
+    {
+      "category": "cache_lookup",
+      "expected_output": {
+        "hit": true,
+        "value": "cached-gamma"
+      },
+      "expected_path": "deterministic_cache_lookup",
+      "id": "cache_lookup_035",
+      "input": {
+        "key": "gamma",
+        "namespace": "deterministic_heavy_v1"
+      },
+      "notes": "Deterministic cache hit/miss lookup.",
+      "requires_model": false
+    },
+    {
+      "category": "schema_check",
+      "expected_output": {
+        "fallback_required": true,
+        "reason": "schema repair requires human or model judgment"
+      },
+      "expected_path": "fallback_candidate",
+      "id": "schema_check_036",
+      "input": {
+        "enum": [
+          "draft",
+          "active",
+          "archived"
+        ],
+        "object": {
+          "status": "invalid"
+        }
+      },
+      "notes": "Fallback candidate for schema repair.",
+      "requires_model": true
+    },
+    {
+      "category": "date_normalization",
+      "expected_output": "2026-10-05",
+      "expected_path": "deterministic_date_normalization",
+      "id": "date_normalization_037",
+      "input": {
+        "date": "10/5/2026",
+        "input_format": "M/D/YYYY",
+        "output_format": "YYYY-MM-DD"
+      },
+      "notes": "Exact date normalization.",
+      "requires_model": false
+    },
+    {
+      "category": "unit_conversion",
+      "expected_output": {
+        "unit": "cm",
+        "value": 15000
+      },
+      "expected_path": "deterministic_unit_conversion",
+      "id": "unit_conversion_038",
+      "input": {
+        "from": "m",
+        "to": "cm",
+        "value": 150
+      },
+      "notes": "Exact metric unit conversion.",
+      "requires_model": false
+    },
+    {
+      "category": "config_validation",
+      "expected_output": {
+        "valid": true
+      },
+      "expected_path": "deterministic_config_validation",
+      "id": "config_validation_039",
+      "input": {
+        "config": {
+          "retries": 3,
+          "timeout_ms": 500
+        }
+      },
+      "notes": "Deterministic config bounds validation.",
+      "requires_model": false
+    },
+    {
+      "category": "policy_rule_match",
+      "expected_output": {
+        "allowed": true
+      },
+      "expected_path": "deterministic_policy_rule_match",
+      "id": "policy_rule_match_040",
+      "input": {
+        "data_class": "internal",
+        "region": "apac"
+      },
+      "notes": "Explicit policy table match.",
+      "requires_model": false
+    },
+    {
+      "category": "arithmetic",
+      "expected_output": 117,
+      "expected_path": "deterministic_arithmetic",
+      "id": "arithmetic_041",
+      "input": {
+        "left": 166,
+        "operation": "subtract",
+        "right": 49
+      },
+      "notes": "Exact arithmetic case.",
+      "requires_model": false
+    },
+    {
+      "category": "string_normalization",
+      "expected_output": "result benchmark deterministic",
+      "expected_path": "deterministic_string_normalization",
+      "id": "string_normalization_042",
+      "input": {
+        "normalization": "strip_lower_join_spaces",
+        "text": " Result  -Benchmark-  deterministic "
+      },
+      "notes": "Deterministic string normalization.",
+      "requires_model": false
+    },
+    {
+      "category": "json_validation",
+      "expected_output": {
+        "missing": [
+          "kind"
+        ],
+        "valid": false
+      },
+      "expected_path": "deterministic_json_validation",
+      "id": "json_validation_043",
+      "input": {
+        "payload": {
+          "enabled": false,
+          "id": "item-43"
+        },
+        "required_fields": [
+          "id",
+          "kind",
+          "enabled"
+        ]
+      },
+      "notes": "Structured JSON validation.",
+      "requires_model": false
+    },
+    {
+      "category": "routing_decision",
+      "expected_output": {
+        "route": "security_review"
+      },
+      "expected_path": "deterministic_routing",
+      "id": "routing_decision_044",
+      "input": {
+        "kind": "security",
+        "priority": "low"
+      },
+      "notes": "Rule-based routing decision.",
+      "requires_model": false
+    },
+    {
+      "category": "cache_lookup",
+      "expected_output": {
+        "hit": true,
+        "value": "cached-alpha"
+      },
+      "expected_path": "deterministic_cache_lookup",
+      "id": "cache_lookup_045",
+      "input": {
+        "key": "alpha",
+        "namespace": "deterministic_heavy_v1"
+      },
+      "notes": "Deterministic cache hit/miss lookup.",
+      "requires_model": false
+    },
+    {
+      "category": "schema_check",
+      "expected_output": {
+        "field": "status",
+        "valid": true
+      },
+      "expected_path": "deterministic_schema_check",
+      "id": "schema_check_046",
+      "input": {
+        "enum": [
+          "draft",
+          "active",
+          "archived"
+        ],
+        "object": {
+          "status": "draft"
+        }
+      },
+      "notes": "Enum schema check.",
+      "requires_model": false
+    },
+    {
+      "category": "date_normalization",
+      "expected_output": "2026-09-02",
+      "expected_path": "deterministic_date_normalization",
+      "id": "date_normalization_047",
+      "input": {
+        "date": "9/2/2026",
+        "input_format": "M/D/YYYY",
+        "output_format": "YYYY-MM-DD"
+      },
+      "notes": "Exact date normalization.",
+      "requires_model": false
+    },
+    {
+      "category": "unit_conversion",
+      "expected_output": {
+        "unit": "cm",
+        "value": 48700
+      },
+      "expected_path": "deterministic_unit_conversion",
+      "id": "unit_conversion_048",
+      "input": {
+        "from": "m",
+        "to": "cm",
+        "value": 487
+      },
+      "notes": "Exact metric unit conversion.",
+      "requires_model": false
+    },
+    {
+      "category": "config_validation",
+      "expected_output": {
+        "valid": false
+      },
+      "expected_path": "deterministic_config_validation",
+      "id": "config_validation_049",
+      "input": {
+        "config": {
+          "retries": 5,
+          "timeout_ms": 100
+        }
+      },
+      "notes": "Deterministic config bounds validation.",
+      "requires_model": false
+    },
+    {
+      "category": "policy_rule_match",
+      "expected_output": {
+        "allowed": true
+      },
+      "expected_path": "deterministic_policy_rule_match",
+      "id": "policy_rule_match_050",
+      "input": {
+        "data_class": "restricted",
+        "region": "apac"
+      },
+      "notes": "Explicit policy table match.",
+      "requires_model": false
+    },
+    {
+      "category": "arithmetic",
+      "expected_output": 46,
+      "expected_path": "deterministic_arithmetic",
+      "id": "arithmetic_051",
+      "input": {
+        "left": 123,
+        "operation": "subtract",
+        "right": 77
+      },
+      "notes": "Exact arithmetic case.",
+      "requires_model": false
+    },
+    {
+      "category": "string_normalization",
+      "expected_output": "benchmark kora deterministic",
+      "expected_path": "deterministic_string_normalization",
+      "id": "string_normalization_052",
+      "input": {
+        "normalization": "strip_lower_join_spaces",
+        "text": "Benchmark- KORA -  deterministic "
+      },
+      "notes": "Deterministic string normalization.",
+      "requires_model": false
+    },
+    {
+      "category": "json_validation",
+      "expected_output": {
+        "missing": [],
+        "valid": true
+      },
+      "expected_path": "deterministic_json_validation",
+      "id": "json_validation_053",
+      "input": {
+        "payload": {
+          "enabled": true,
+          "id": "item-53",
+          "kind": "alpha"
+        },
+        "required_fields": [
+          "id",
+          "kind",
+          "enabled"
+        ]
+      },
+      "notes": "Structured JSON validation.",
+      "requires_model": false
+    },
+    {
+      "category": "routing_decision",
+      "expected_output": {
+        "route": "support_queue"
+      },
+      "expected_path": "deterministic_routing",
+      "id": "routing_decision_054",
+      "input": {
+        "kind": "support",
+        "priority": "normal"
+      },
+      "notes": "Rule-based routing decision.",
+      "requires_model": false
+    },
+    {
+      "category": "cache_lookup",
+      "expected_output": {
+        "fallback_required": true,
+        "reason": "cache miss requires external answer"
+      },
+      "expected_path": "fallback_candidate",
+      "id": "cache_lookup_055",
+      "input": {
+        "key": "beta",
+        "namespace": "deterministic_heavy_v1"
+      },
+      "notes": "Fallback candidate after cache miss.",
+      "requires_model": true
+    },
+    {
+      "category": "schema_check",
+      "expected_output": {
+        "field": "status",
+        "valid": false
+      },
+      "expected_path": "deterministic_schema_check",
+      "id": "schema_check_056",
+      "input": {
+        "enum": [
+          "draft",
+          "active",
+          "archived"
+        ],
+        "object": {
+          "status": "invalid"
+        }
+      },
+      "notes": "Enum schema check.",
+      "requires_model": false
+    },
+    {
+      "category": "date_normalization",
+      "expected_output": "2026-06-19",
+      "expected_path": "deterministic_date_normalization",
+      "id": "date_normalization_057",
+      "input": {
+        "date": "6/19/2026",
+        "input_format": "M/D/YYYY",
+        "output_format": "YYYY-MM-DD"
+      },
+      "notes": "Exact date normalization.",
+      "requires_model": false
+    },
+    {
+      "category": "unit_conversion",
+      "expected_output": {
+        "unit": "cm",
+        "value": 39900
+      },
+      "expected_path": "deterministic_unit_conversion",
+      "id": "unit_conversion_058",
+      "input": {
+        "from": "m",
+        "to": "cm",
+        "value": 399
+      },
+      "notes": "Exact metric unit conversion.",
+      "requires_model": false
+    },
+    {
+      "category": "config_validation",
+      "expected_output": {
+        "valid": false
+      },
+      "expected_path": "deterministic_config_validation",
+      "id": "config_validation_059",
+      "input": {
+        "config": {
+          "retries": 4,
+          "timeout_ms": 5000
+        }
+      },
+      "notes": "Deterministic config bounds validation.",
+      "requires_model": false
+    },
+    {
+      "category": "policy_rule_match",
+      "expected_output": {
+        "allowed": true
+      },
+      "expected_path": "deterministic_policy_rule_match",
+      "id": "policy_rule_match_060",
+      "input": {
+        "data_class": "internal",
+        "region": "us"
+      },
+      "notes": "Explicit policy table match.",
+      "requires_model": false
+    },
+    {
+      "category": "arithmetic",
+      "expected_output": 300,
+      "expected_path": "deterministic_arithmetic",
+      "id": "arithmetic_061",
+      "input": {
+        "left": 235,
+        "operation": "add",
+        "right": 65
+      },
+      "notes": "Exact arithmetic case.",
+      "requires_model": false
+    },
+    {
+      "category": "string_normalization",
+      "expected_output": "benchmark result kora",
+      "expected_path": "deterministic_string_normalization",
+      "id": "string_normalization_062",
+      "input": {
+        "normalization": "strip_lower_join_spaces",
+        "text": "Benchmark- Result  - KORA "
+      },
+      "notes": "Deterministic string normalization.",
+      "requires_model": false
+    },
+    {
+      "category": "json_validation",
+      "expected_output": {
+        "missing": [],
+        "valid": true
+      },
+      "expected_path": "deterministic_json_validation",
+      "id": "json_validation_063",
+      "input": {
+        "payload": {
+          "enabled": false,
+          "id": "item-63",
+          "kind": "gamma"
+        },
+        "required_fields": [
+          "id",
+          "kind",
+          "enabled"
+        ]
+      },
+      "notes": "Structured JSON validation.",
+      "requires_model": false
+    },
+    {
+      "category": "routing_decision",
+      "expected_output": {
+        "route": "billing_queue"
+      },
+      "expected_path": "deterministic_routing",
+      "id": "routing_decision_064",
+      "input": {
+        "kind": "billing",
+        "priority": "low"
+      },
+      "notes": "Rule-based routing decision.",
+      "requires_model": false
+    },
+    {
+      "category": "cache_lookup",
+      "expected_output": {
+        "fallback_required": true,
+        "reason": "cache miss requires external answer"
+      },
+      "expected_path": "fallback_candidate",
+      "id": "cache_lookup_065",
+      "input": {
+        "key": "beta",
+        "namespace": "deterministic_heavy_v1"
+      },
+      "notes": "Fallback candidate after cache miss.",
+      "requires_model": true
+    },
+    {
+      "category": "schema_check",
+      "expected_output": {
+        "field": "status",
+        "valid": true
+      },
+      "expected_path": "deterministic_schema_check",
+      "id": "schema_check_066",
+      "input": {
+        "enum": [
+          "draft",
+          "active",
+          "archived"
+        ],
+        "object": {
+          "status": "active"
+        }
+      },
+      "notes": "Enum schema check.",
+      "requires_model": false
+    },
+    {
+      "category": "date_normalization",
+      "expected_output": "2026-02-04",
+      "expected_path": "deterministic_date_normalization",
+      "id": "date_normalization_067",
+      "input": {
+        "date": "2/4/2026",
+        "input_format": "M/D/YYYY",
+        "output_format": "YYYY-MM-DD"
+      },
+      "notes": "Exact date normalization.",
+      "requires_model": false
+    },
+    {
+      "category": "unit_conversion",
+      "expected_output": {
+        "unit": "cm",
+        "value": 12400
+      },
+      "expected_path": "deterministic_unit_conversion",
+      "id": "unit_conversion_068",
+      "input": {
+        "from": "m",
+        "to": "cm",
+        "value": 124
+      },
+      "notes": "Exact metric unit conversion.",
+      "requires_model": false
+    },
+    {
+      "category": "config_validation",
+      "expected_output": {
+        "valid": true
+      },
+      "expected_path": "deterministic_config_validation",
+      "id": "config_validation_069",
+      "input": {
+        "config": {
+          "retries": 0,
+          "timeout_ms": 100
+        }
+      },
+      "notes": "Deterministic config bounds validation.",
+      "requires_model": false
+    },
+    {
+      "category": "policy_rule_match",
+      "expected_output": {
+        "fallback_required": true,
+        "reason": "policy text is incomplete"
+      },
+      "expected_path": "fallback_candidate",
+      "id": "policy_rule_match_070",
+      "input": {
+        "data_class": "restricted",
+        "region": "apac"
+      },
+      "notes": "Fallback candidate for incomplete policy text.",
+      "requires_model": true
+    },
+    {
+      "category": "arithmetic",
+      "expected_output": 176,
+      "expected_path": "deterministic_arithmetic",
+      "id": "arithmetic_071",
+      "input": {
+        "left": 203,
+        "operation": "subtract",
+        "right": 27
+      },
+      "notes": "Exact arithmetic case.",
+      "requires_model": false
+    },
+    {
+      "category": "string_normalization",
+      "expected_output": {
+        "fallback_required": true,
+        "reason": "requires semantic rewrite beyond normalization"
+      },
+      "expected_path": "fallback_candidate",
+      "id": "string_normalization_072",
+      "input": {
+        "normalization": "strip_lower_join_spaces",
+        "text": " Result  -  deterministic -CONTROLLED"
+      },
+      "notes": "Fallback candidate for semantic rewriting.",
+      "requires_model": true
+    },
+    {
+      "category": "json_validation",
+      "expected_output": {
+        "missing": [],
+        "valid": true
+      },
+      "expected_path": "deterministic_json_validation",
+      "id": "json_validation_073",
+      "input": {
+        "payload": {
+          "enabled": false,
+          "id": "item-73",
+          "kind": "gamma"
+        },
+        "required_fields": [
+          "id",
+          "kind",
+          "enabled"
+        ]
+      },
+      "notes": "Structured JSON validation.",
+      "requires_model": false
+    },
+    {
+      "category": "routing_decision",
+      "expected_output": {
+        "route": "security_review"
+      },
+      "expected_path": "deterministic_routing",
+      "id": "routing_decision_074",
+      "input": {
+        "kind": "security",
+        "priority": "high"
+      },
+      "notes": "Rule-based routing decision.",
+      "requires_model": false
+    },
+    {
+      "category": "cache_lookup",
+      "expected_output": {
+        "hit": true,
+        "value": "cached-beta"
+      },
+      "expected_path": "deterministic_cache_lookup",
+      "id": "cache_lookup_075",
+      "input": {
+        "key": "beta",
+        "namespace": "deterministic_heavy_v1"
+      },
+      "notes": "Deterministic cache hit/miss lookup.",
+      "requires_model": false
+    },
+    {
+      "category": "schema_check",
+      "expected_output": {
+        "fallback_required": true,
+        "reason": "schema repair requires human or model judgment"
+      },
+      "expected_path": "fallback_candidate",
+      "id": "schema_check_076",
+      "input": {
+        "enum": [
+          "draft",
+          "active",
+          "archived"
+        ],
+        "object": {
+          "status": "active"
+        }
+      },
+      "notes": "Fallback candidate for schema repair.",
+      "requires_model": true
+    },
+    {
+      "category": "date_normalization",
+      "expected_output": "2026-04-26",
+      "expected_path": "deterministic_date_normalization",
+      "id": "date_normalization_077",
+      "input": {
+        "date": "4/26/2026",
+        "input_format": "M/D/YYYY",
+        "output_format": "YYYY-MM-DD"
+      },
+      "notes": "Exact date normalization.",
+      "requires_model": false
+    },
+    {
+      "category": "unit_conversion",
+      "expected_output": {
+        "fallback_required": true,
+        "reason": "unit target is ambiguous"
+      },
+      "expected_path": "fallback_candidate",
+      "id": "unit_conversion_078",
+      "input": {
+        "from": "m",
+        "to": "cm",
+        "value": 35
+      },
+      "notes": "Fallback candidate for ambiguous unit conversion.",
+      "requires_model": true
+    },
+    {
+      "category": "config_validation",
+      "expected_output": {
+        "valid": true
+      },
+      "expected_path": "deterministic_config_validation",
+      "id": "config_validation_079",
+      "input": {
+        "config": {
+          "retries": 3,
+          "timeout_ms": 100
+        }
+      },
+      "notes": "Deterministic config bounds validation.",
+      "requires_model": false
+    },
+    {
+      "category": "policy_rule_match",
+      "expected_output": {
+        "allowed": true
+      },
+      "expected_path": "deterministic_policy_rule_match",
+      "id": "policy_rule_match_080",
+      "input": {
+        "data_class": "internal",
+        "region": "apac"
+      },
+      "notes": "Explicit policy table match.",
+      "requires_model": false
+    },
+    {
+      "category": "arithmetic",
+      "expected_output": 16,
+      "expected_path": "deterministic_arithmetic",
+      "id": "arithmetic_081",
+      "input": {
+        "left": 92,
+        "operation": "subtract",
+        "right": 76
+      },
+      "notes": "Exact arithmetic case.",
+      "requires_model": false
+    },
+    {
+      "category": "string_normalization",
+      "expected_output": {
+        "fallback_required": true,
+        "reason": "requires semantic rewrite beyond normalization"
+      },
+      "expected_path": "fallback_candidate",
+      "id": "string_normalization_082",
+      "input": {
+        "normalization": "strip_lower_join_spaces",
+        "text": "  deterministic - KORA -Benchmark"
+      },
+      "notes": "Fallback candidate for semantic rewriting.",
+      "requires_model": true
+    },
+    {
+      "category": "json_validation",
+      "expected_output": {
+        "missing": [],
+        "valid": true
+      },
+      "expected_path": "deterministic_json_validation",
+      "id": "json_validation_083",
+      "input": {
+        "payload": {
+          "enabled": false,
+          "id": "item-83",
+          "kind": "alpha"
+        },
+        "required_fields": [
+          "id",
+          "kind",
+          "enabled"
+        ]
+      },
+      "notes": "Structured JSON validation.",
+      "requires_model": false
+    },
+    {
+      "category": "routing_decision",
+      "expected_output": {
+        "route": "security_review"
+      },
+      "expected_path": "deterministic_routing",
+      "id": "routing_decision_084",
+      "input": {
+        "kind": "security",
+        "priority": "high"
+      },
+      "notes": "Rule-based routing decision.",
+      "requires_model": false
+    },
+    {
+      "category": "cache_lookup",
+      "expected_output": {
+        "hit": false,
+        "value": null
+      },
+      "expected_path": "deterministic_cache_lookup",
+      "id": "cache_lookup_085",
+      "input": {
+        "key": "missing",
+        "namespace": "deterministic_heavy_v1"
+      },
+      "notes": "Deterministic cache hit/miss lookup.",
+      "requires_model": false
+    },
+    {
+      "category": "schema_check",
+      "expected_output": {
+        "field": "status",
+        "valid": true
+      },
+      "expected_path": "deterministic_schema_check",
+      "id": "schema_check_086",
+      "input": {
+        "enum": [
+          "draft",
+          "active",
+          "archived"
+        ],
+        "object": {
+          "status": "active"
+        }
+      },
+      "notes": "Enum schema check.",
+      "requires_model": false
+    },
+    {
+      "category": "date_normalization",
+      "expected_output": {
+        "fallback_required": true,
+        "reason": "date phrase is underspecified"
+      },
+      "expected_path": "fallback_candidate",
+      "id": "date_normalization_087",
+      "input": {
+        "date": "10/3/2026",
+        "input_format": "M/D/YYYY",
+        "output_format": "YYYY-MM-DD"
+      },
+      "notes": "Fallback candidate for underspecified date phrase.",
+      "requires_model": true
+    },
+    {
+      "category": "unit_conversion",
+      "expected_output": {
+        "unit": "cm",
+        "value": 27700
+      },
+      "expected_path": "deterministic_unit_conversion",
+      "id": "unit_conversion_088",
+      "input": {
+        "from": "m",
+        "to": "cm",
+        "value": 277
+      },
+      "notes": "Exact metric unit conversion.",
+      "requires_model": false
+    },
+    {
+      "category": "config_validation",
+      "expected_output": {
+        "valid": false
+      },
+      "expected_path": "deterministic_config_validation",
+      "id": "config_validation_089",
+      "input": {
+        "config": {
+          "retries": 3,
+          "timeout_ms": 5000
+        }
+      },
+      "notes": "Deterministic config bounds validation.",
+      "requires_model": false
+    },
+    {
+      "category": "policy_rule_match",
+      "expected_output": {
+        "allowed": true
+      },
+      "expected_path": "deterministic_policy_rule_match",
+      "id": "policy_rule_match_090",
+      "input": {
+        "data_class": "public",
+        "region": "eu"
+      },
+      "notes": "Explicit policy table match.",
+      "requires_model": false
+    },
+    {
+      "category": "arithmetic",
+      "expected_output": 140,
+      "expected_path": "deterministic_arithmetic",
+      "id": "arithmetic_091",
+      "input": {
+        "left": 68,
+        "operation": "add",
+        "right": 72
+      },
+      "notes": "Exact arithmetic case.",
+      "requires_model": false
+    },
+    {
+      "category": "string_normalization",
+      "expected_output": "result controlled deterministic",
+      "expected_path": "deterministic_string_normalization",
+      "id": "string_normalization_092",
+      "input": {
+        "normalization": "strip_lower_join_spaces",
+        "text": " Result  -CONTROLLED-  deterministic "
+      },
+      "notes": "Deterministic string normalization.",
+      "requires_model": false
+    },
+    {
+      "category": "json_validation",
+      "expected_output": {
+        "missing": [],
+        "valid": true
+      },
+      "expected_path": "deterministic_json_validation",
+      "id": "json_validation_093",
+      "input": {
+        "payload": {
+          "enabled": true,
+          "id": "item-93",
+          "kind": "alpha"
+        },
+        "required_fields": [
+          "id",
+          "kind",
+          "enabled"
+        ]
+      },
+      "notes": "Structured JSON validation.",
+      "requires_model": false
+    },
+    {
+      "category": "routing_decision",
+      "expected_output": {
+        "route": "security_review"
+      },
+      "expected_path": "deterministic_routing",
+      "id": "routing_decision_094",
+      "input": {
+        "kind": "security",
+        "priority": "high"
+      },
+      "notes": "Rule-based routing decision.",
+      "requires_model": false
+    },
+    {
+      "category": "cache_lookup",
+      "expected_output": {
+        "fallback_required": true,
+        "reason": "cache miss requires external answer"
+      },
+      "expected_path": "fallback_candidate",
+      "id": "cache_lookup_095",
+      "input": {
+        "key": "alpha",
+        "namespace": "deterministic_heavy_v1"
+      },
+      "notes": "Fallback candidate after cache miss.",
+      "requires_model": true
+    },
+    {
+      "category": "schema_check",
+      "expected_output": {
+        "field": "status",
+        "valid": true
+      },
+      "expected_path": "deterministic_schema_check",
+      "id": "schema_check_096",
+      "input": {
+        "enum": [
+          "draft",
+          "active",
+          "archived"
+        ],
+        "object": {
+          "status": "archived"
+        }
+      },
+      "notes": "Enum schema check.",
+      "requires_model": false
+    },
+    {
+      "category": "date_normalization",
+      "expected_output": "2026-06-19",
+      "expected_path": "deterministic_date_normalization",
+      "id": "date_normalization_097",
+      "input": {
+        "date": "6/19/2026",
+        "input_format": "M/D/YYYY",
+        "output_format": "YYYY-MM-DD"
+      },
+      "notes": "Exact date normalization.",
+      "requires_model": false
+    },
+    {
+      "category": "unit_conversion",
+      "expected_output": {
+        "unit": "cm",
+        "value": 43600
+      },
+      "expected_path": "deterministic_unit_conversion",
+      "id": "unit_conversion_098",
+      "input": {
+        "from": "m",
+        "to": "cm",
+        "value": 436
+      },
+      "notes": "Exact metric unit conversion.",
+      "requires_model": false
+    },
+    {
+      "category": "config_validation",
+      "expected_output": {
+        "valid": false
+      },
+      "expected_path": "deterministic_config_validation",
+      "id": "config_validation_099",
+      "input": {
+        "config": {
+          "retries": 4,
+          "timeout_ms": 100
+        }
+      },
+      "notes": "Deterministic config bounds validation.",
+      "requires_model": false
+    },
+    {
+      "category": "policy_rule_match",
+      "expected_output": {
+        "allowed": true
+      },
+      "expected_path": "deterministic_policy_rule_match",
+      "id": "policy_rule_match_100",
+      "input": {
+        "data_class": "internal",
+        "region": "eu"
+      },
+      "notes": "Explicit policy table match.",
+      "requires_model": false
+    }
+  ],
+  "version": "1.0"
+}

--- a/tests/test_workload_generator.py
+++ b/tests/test_workload_generator.py
@@ -1,0 +1,81 @@
+import json
+from pathlib import Path
+
+from experiments.generate_workload import CATEGORIES, generate_workload, write_workload
+
+
+REQUIRED_TASK_FIELDS = {
+    "id",
+    "category",
+    "input",
+    "expected_path",
+    "expected_output",
+    "requires_model",
+    "notes",
+}
+
+
+def test_generator_can_create_workload_file(tmp_path: Path) -> None:
+    output_path = tmp_path / "deterministic_heavy_v1_100.json"
+    workload = generate_workload(count=100, seed=42, benchmark_name="deterministic_heavy_v1")
+
+    write_workload(workload, output_path)
+
+    assert output_path.exists()
+    saved = json.loads(output_path.read_text(encoding="utf-8"))
+    assert saved["benchmark_name"] == "deterministic_heavy_v1"
+    assert saved["name"] == "deterministic_heavy_v1"
+    assert saved["seed"] == 42
+    assert saved["task_count"] == 100
+
+
+def test_generated_workload_has_100_tasks() -> None:
+    workload = generate_workload(count=100, seed=42, benchmark_name="deterministic_heavy_v1")
+
+    assert len(workload["tasks"]) == 100
+    assert workload["task_count"] == 100
+
+
+def test_generated_workload_is_reproducible_with_same_seed() -> None:
+    first = generate_workload(count=100, seed=42, benchmark_name="deterministic_heavy_v1")
+    second = generate_workload(count=100, seed=42, benchmark_name="deterministic_heavy_v1")
+
+    assert first == second
+
+
+def test_generated_workload_contains_all_expected_categories() -> None:
+    workload = generate_workload(count=100, seed=42, benchmark_name="deterministic_heavy_v1")
+    categories = {task["category"] for task in workload["tasks"]}
+
+    assert categories == set(CATEGORIES)
+
+
+def test_generated_workload_has_expected_model_requirement_split() -> None:
+    workload = generate_workload(count=100, seed=42, benchmark_name="deterministic_heavy_v1")
+    deterministic_count = sum(task["requires_model"] is False for task in workload["tasks"])
+    fallback_count = sum(task["requires_model"] is True for task in workload["tasks"])
+
+    assert deterministic_count == 80
+    assert fallback_count == 20
+
+
+def test_every_generated_task_has_required_schema_fields() -> None:
+    workload = generate_workload(count=100, seed=42, benchmark_name="deterministic_heavy_v1")
+
+    for task in workload["tasks"]:
+        assert set(task) == REQUIRED_TASK_FIELDS
+        assert isinstance(task["id"], str)
+        assert isinstance(task["category"], str)
+        assert isinstance(task["input"], dict)
+        assert isinstance(task["expected_path"], str)
+        assert isinstance(task["requires_model"], bool)
+        assert isinstance(task["notes"], str)
+
+
+def test_deterministic_tasks_have_expected_output_values() -> None:
+    workload = generate_workload(count=100, seed=42, benchmark_name="deterministic_heavy_v1")
+
+    for task in workload["tasks"]:
+        if task["requires_model"] is False:
+            assert task["expected_output"] is not None
+            assert task["expected_output"] != {}


### PR DESCRIPTION
Adds a deterministic-heavy workload generator and a reproducible 100-task v1 workload.

Included:
- experiments/generate_workload.py
- experiments/workloads/deterministic_heavy_v1_100.json
- tests/test_workload_generator.py
- experiments/README.md update

Generator:
- standard-library only
- supports --output, --count, --seed, and --benchmark-name
- defaults to count 100, seed 42, benchmark deterministic_heavy_v1
- regenerated output matches committed workload byte-for-byte with seed 42

Generated workload:
- total tasks: 100
- deterministic/no-model tasks: 80
- fallback/model-candidate tasks: 20
- categories: arithmetic, cache_lookup, config_validation, date_normalization, json_validation, policy_rule_match, routing_decision, schema_check, string_normalization, unit_conversion

Current simulated benchmark result on v1 workload:
- direct-baseline simulated model invocations: 100
- KORA-controlled simulated model invocations: 20
- avoided model invocations: 80
- avoided invocation rate: 80%

Validation run locally:
- regeneration comparison
- generated workload JSON validation
- dry-run benchmark
- direct-baseline benchmark
- kora-controlled benchmark
- benchmark output JSON validation
- ./scripts/release_smoke.sh
- python3 -m pytest -q