### PR TITLE
Update technical preview results with v1 benchmark

### DIFF
--- a/docs/technical_preview_results.md
+++ b/docs/technical_preview_results.md
@@ -4,28 +4,30 @@ Date: 2026-05-04
 
 ## Status
 
-This document is an early technical preview results skeleton.
+This document is an early technical preview results document.
 
-The current evidence is based on KORA v0.1.1-alpha and the controlled benchmark skeleton merged into `origin/main`. The benchmark is simulated, deterministic-heavy, and intentionally small. It is not yet a production benchmark.
+The current primary evidence is the reproducible 100-task deterministic-heavy benchmark workload merged after KORA v0.1.1-alpha. The benchmark remains simulated, deterministic-heavy, and intentionally scoped. It is not yet a production benchmark.
 
-This document separates current v0.1.1-alpha evidence from planned v0.2.0-alpha and v0.3.0-alpha evidence so future results can be added without overstating the current benchmark.
+The earlier v0.1.1-alpha 20-task result is preserved as historical skeleton evidence. The current 100-task workload is the primary evidence for the path toward v0.2.0-alpha.
 
 ## Release Context
 
 | Item | Value |
 |---|---|
-| Current release | `v0.1.1-alpha` |
-| Public HEAD | `origin/main 14d5c40fa89d9872f748cb3a33aabfaccbdd70ea` |
+| Current released tag | `v0.1.1-alpha` |
+| Public HEAD | `origin/main de20e8c2a2f1b8e80d1260cccd638d18eff344fc` |
 | GitHub Release | `https://github.com/hkalbertkim/KORA/releases/tag/v0.1.1-alpha` |
-| Benchmark summary | `docs/benchmarks/kora_benchmark_result_v0_1_1_alpha.md` |
-| Workload | `experiments/workloads/deterministic_heavy_v0.json` |
+| Current benchmark summary | `docs/benchmarks/kora_benchmark_result_v1_100.md` |
+| Historical benchmark summary | `docs/benchmarks/kora_benchmark_result_v0_1_1_alpha.md` |
+| Current workload | `experiments/workloads/deterministic_heavy_v1_100.json` |
+| Workload generator | `experiments/generate_workload.py` |
 | Runner | `experiments/run_benchmark.py` |
 
 ## Current Evidence Summary
 
-KORA v0.1.1-alpha provides CI-backed validation and the first reproducible controlled benchmark skeleton. The current benchmark uses a 20-task deterministic-heavy workload and compares simulated direct-baseline execution with simulated KORA-controlled execution.
+KORA now has a reproducible 100-task deterministic-heavy benchmark workload generated from seed `42`. The current benchmark compares simulated direct-baseline execution with simulated KORA-controlled execution.
 
-The benchmark runner does not call a real model, does not use external APIs, and does not execute full KORA runtime integration. It uses workload metadata to count model-invocation candidates and deterministic resolutions.
+The benchmark runner does not call a real model, does not use external APIs, and does not execute full KORA runtime integration. It uses workload metadata to count model-invocation candidates and deterministic/no-model tasks.
 
 ## Benchmark Modes
 
@@ -33,25 +35,39 @@ The benchmark runner does not call a real model, does not use external APIs, and
 |---|---|---|
 | `dry-run` | Loads the workload, validates task shape, counts categories, and counts `requires_model` values. | No |
 | `direct-baseline` | Simulates a naive baseline where every task causes one model invocation. | No |
-| `kora-controlled` | Simulates deterministic-first execution by treating `requires_model: false` tasks as deterministic resolutions and `requires_model: true` tasks as fallback candidates. | No |
+| `kora-controlled` | Simulates deterministic-first execution by treating `requires_model: false` tasks as deterministic/no-model resolutions and `requires_model: true` tasks as fallback/model-candidate tasks. | No |
 
-## Current Result Table
+## Current Primary Result
 
 | Metric | Value |
 |---|---:|
+| Workload | `deterministic_heavy_v1_100` |
+| Total tasks | 100 |
+| Deterministic/no-model tasks | 80 |
+| Fallback/model-candidate tasks | 20 |
+| Direct-baseline simulated model invocations | 100 |
+| KORA-controlled simulated model invocations | 20 |
+| Avoided model invocations | 80 |
+| Avoided invocation rate | 80% |
+
+## Historical Skeleton Result
+
+The earlier v0.1.1-alpha benchmark skeleton used a smaller 20-task deterministic-heavy workload. It remains useful as historical context, but it is no longer the primary technical preview evidence.
+
+| Metric | Value |
+|---|---:|
+| Workload | `deterministic_heavy_v0` |
 | Total tasks | 20 |
 | Direct-baseline simulated model invocations | 20 |
 | KORA-controlled simulated model invocations | 4 |
-| Deterministic resolutions | 16 |
-| Fallback candidates | 4 |
 | Avoided model invocations | 16 |
 | Avoided invocation rate | 80% |
 
-## What The Result Means
+## What The Current Result Means
 
-In a deterministic-heavy controlled benchmark skeleton, KORA-controlled execution avoided 16 of 20 simulated model invocations versus a naive direct baseline.
+In a reproducible 100-task deterministic-heavy benchmark workload, KORA-controlled execution avoided 80 of 100 simulated model invocations versus a naive direct baseline.
 
-This means the current workload and runner can reproduce a metadata-based simulated comparison where deterministic-first handling avoids unnecessary simulated model invocations. It is useful as a benchmark scaffold and as a baseline for future hardening.
+This means the current generator, workload, and runner can reproduce a metadata-based simulated comparison where deterministic-first handling avoids unnecessary simulated model invocations. It is useful as a benchmark scaffold and as a baseline for v0.2.0-alpha hardening.
 
 ## What It Does Not Mean
 
@@ -70,34 +86,40 @@ The current result is:
 ## Reproducibility Commands
 
 ```bash
+python3 experiments/generate_workload.py --count 100 --seed 42 --benchmark-name deterministic_heavy_v1 --output /tmp/kora_deterministic_heavy_v1_100.regenerated.json
+cmp experiments/workloads/deterministic_heavy_v1_100.json /tmp/kora_deterministic_heavy_v1_100.regenerated.json
+
+python3 experiments/run_benchmark.py --mode dry-run --workload experiments/workloads/deterministic_heavy_v1_100.json --output /tmp/kora_deterministic_heavy_v1_100.dry_run.json
+python3 experiments/run_benchmark.py --mode direct-baseline --workload experiments/workloads/deterministic_heavy_v1_100.json --output /tmp/kora_deterministic_heavy_v1_100.direct_baseline.json
+python3 experiments/run_benchmark.py --mode kora-controlled --workload experiments/workloads/deterministic_heavy_v1_100.json --output /tmp/kora_deterministic_heavy_v1_100.kora_controlled.json
+
 ./scripts/release_smoke.sh
 python3 -m pytest -q
-python3 experiments/run_benchmark.py --mode dry-run --workload experiments/workloads/deterministic_heavy_v0.json --output /tmp/kora_deterministic_heavy_v0.dry_run.json
-python3 experiments/run_benchmark.py --mode direct-baseline --workload experiments/workloads/deterministic_heavy_v0.json --output /tmp/kora_deterministic_heavy_v0.direct_baseline.json
-python3 experiments/run_benchmark.py --mode kora-controlled --workload experiments/workloads/deterministic_heavy_v0.json --output /tmp/kora_deterministic_heavy_v0.kora_controlled.json
 ```
 
 Optional JSON validation:
 
 ```bash
-python3 -m json.tool /tmp/kora_deterministic_heavy_v0.dry_run.json > /tmp/kora_dry_run_check.json
-python3 -m json.tool /tmp/kora_deterministic_heavy_v0.direct_baseline.json > /tmp/kora_direct_baseline_check.json
-python3 -m json.tool /tmp/kora_deterministic_heavy_v0.kora_controlled.json > /tmp/kora_kora_controlled_check.json
+python3 -m json.tool experiments/workloads/deterministic_heavy_v1_100.json > /tmp/kora_generated_workload_check.json
+python3 -m json.tool /tmp/kora_deterministic_heavy_v1_100.dry_run.json > /tmp/kora_v1_dry_run_check.json
+python3 -m json.tool /tmp/kora_deterministic_heavy_v1_100.direct_baseline.json > /tmp/kora_v1_direct_baseline_check.json
+python3 -m json.tool /tmp/kora_deterministic_heavy_v1_100.kora_controlled.json > /tmp/kora_v1_kora_controlled_check.json
 ```
 
 ## Planned Evidence Path To v0.2.0-alpha
 
-The v0.2.0-alpha evidence path should strengthen the controlled benchmark without making production claims.
+The project has reached the near-term 100-task deterministic-heavy workload target. The v0.2.0-alpha evidence path should now strengthen that controlled benchmark without making production claims.
 
 Planned work:
 
-1. Expand the deterministic-heavy workload from 20 tasks to 100-500 tasks.
-2. Add correctness checks against `expected_output` and `expected_path`.
-3. Decide whether generated result JSON artifacts remain generated-only or become committed artifacts.
-4. Add a stable benchmark result artifact policy.
-5. Add benchmark summary generation from structured JSON outputs.
+1. Add stronger expected-output correctness checks against deterministic `expected_output` and `expected_path`.
+2. Add result summary generation automation from structured benchmark result JSON.
+3. Decide whether raw generated result JSON artifacts remain generated-only or become committed artifacts.
+4. Add expanded correctness, error, and fallback cases.
+5. Add additional deterministic-heavy workload variants.
 6. Add failure-case coverage for malformed workload tasks and invalid benchmark modes.
-7. Keep benchmark wording limited to simulated controlled benchmark evidence.
+7. Prepare the v0.2.0-alpha release note and final readiness check.
+8. Keep benchmark wording limited to simulated controlled benchmark evidence.
 
 ## Planned Evidence Path To v0.3.0-alpha
 
@@ -107,31 +129,34 @@ Planned work:
 
 1. Design a KORA runtime-integrated benchmark path.
 2. Compare direct-baseline execution with actual KORA-controlled execution semantics.
-3. Add structured telemetry for deterministic resolution, fallback, validation, retry, and cache paths.
-4. Add ablation modes such as deterministic-only, fallback-only, cache-disabled, and verifier-disabled.
-5. Add broader workload families beyond deterministic-heavy tasks.
-6. Report correctness and invocation-count metrics together.
-7. Preserve explicit non-claims until real model/API measurements exist.
+3. Add mixed workload coverage beyond deterministic-heavy cases.
+4. Add retry and verifier workload coverage.
+5. Add structured telemetry for deterministic resolution, fallback, validation, retry, and cache paths.
+6. Add ablation modes such as deterministic-only, fallback-only, cache-disabled, and verifier-disabled.
+7. Add a paper reproducibility document that records workload generation, benchmark commands, result interpretation, and claim boundaries.
+8. Harden claim wording before any broader public technical preview claims.
+9. Report correctness and invocation-count metrics together.
+10. Preserve explicit non-claims until real model/API measurements exist.
 
 ## Open Benchmark Gaps
 
-- The workload is small and manually written.
-- The current benchmark is deterministic-heavy by design.
-- Correctness scoring is not yet implemented as a benchmark metric.
+- Correctness scoring against deterministic `expected_output` is not yet reported as a benchmark metric.
 - Generated JSON outputs are not committed as stable artifacts.
 - No real model calls are measured.
 - No external API cost is measured.
 - No latency or energy metrics are measured.
 - No full KORA runtime integration is benchmarked yet.
+- The current workload is larger than the initial skeleton but remains deterministic-heavy by design.
 - No broad workload suite exists yet.
 
 ## Claim Ladder
 
 | Evidence level | Status | Claim boundary |
 |---|---|---|
-| Benchmark skeleton exists | Current, v0.1.1-alpha | KORA has a reproducible simulated benchmark scaffold. |
-| Simulated deterministic-heavy result | Current, v0.1.1-alpha | KORA-controlled simulation avoided 16 of 20 simulated model invocations on the current deterministic-heavy workload. |
-| Larger controlled workload | Planned, v0.2.0-alpha | KORA can report simulated controlled benchmark results over a broader deterministic-heavy workload. |
+| Benchmark skeleton exists | Historical, v0.1.1-alpha | KORA has a reproducible simulated benchmark scaffold. |
+| 20-task simulated deterministic-heavy result | Historical, v0.1.1-alpha | KORA-controlled simulation avoided 16 of 20 simulated model invocations on the initial deterministic-heavy workload. |
+| 100-task reproducible deterministic-heavy result | Current | KORA-controlled simulation avoided 80 of 100 simulated model invocations on the reproducible generated workload. |
+| Correctness-checked controlled workload | Planned, v0.2.0-alpha | KORA can report simulated invocation counts together with deterministic correctness checks. |
 | Runtime-integrated benchmark | Planned, v0.3.0-alpha | KORA can compare direct baseline and KORA-controlled runtime behavior under documented benchmark conditions. |
 | Real API-cost evidence | Future, not current | Requires real model/API calls, measured cost, and reproducible methodology. |
 | Production cost reduction | Future, not current | Requires production-like workloads, measured costs, correctness controls, and external validation. |


### PR DESCRIPTION
Updates the technical preview results document to make the reproducible v1 100-task deterministic-heavy benchmark the current primary evidence.

Included:
- docs/technical_preview_results.md

The update documents:
- v1 100-task workload as current primary evidence
- historical v0.1.1-alpha 20-task result as skeleton evidence
- safe current claim
- explicit non-claims
- reproducibility commands
- v0.2.0-alpha path with remaining gaps
- v0.3.0-alpha path

Current primary benchmark result:
- workload: deterministic_heavy_v1_100
- total tasks: 100
- direct-baseline simulated model invocations: 100
- KORA-controlled simulated model invocations: 20
- avoided model invocations: 80
- avoided invocation rate: 80%

Validation run locally:
- regeneration comparison
- dry-run benchmark
- direct-baseline benchmark
- kora-controlled benchmark
- ./scripts/release_smoke.sh
- python3 -m pytest -q