### PR TITLE
Prepare v0.2.0-alpha benchmark evidence expansion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,12 +6,16 @@ dist/
 .venv/
 .DS_Store
 .env
-docs/reports/
+docs/reports/*.json
+docs/reports/*.jsonl
+docs/reports/generated/
 docs/experiments/
 logs/
 logs/debug/
 logs/experiments/
 *experiment*.json
+experiments/results/*.json
+experiments/results/*.jsonl
 studio/backend/.venv_tmp/
 artifacts/*.jsonl
 artifacts/*.json

--- a/docs/reports/benchmark_artifact_policy.md
+++ b/docs/reports/benchmark_artifact_policy.md
@@ -1,0 +1,98 @@
+# Benchmark Artifact Policy
+
+This policy covers raw benchmark result artifacts and generated Markdown summaries for the deterministic-heavy benchmark evidence path.
+
+## Current Policy
+
+Raw benchmark JSON artifacts are reproducible execution outputs. They should generally not be committed to the repository.
+
+Raw JSON artifacts should remain ephemeral unless they are explicitly selected as frozen release evidence. Use `/tmp` or another ignored path for routine benchmark runs.
+
+Markdown summaries generated from raw artifacts may be committed when they support release notes, public evidence, or reviewed technical reports. Summaries should be generated from result JSON artifacts rather than manually assembled.
+
+Tracked workload definitions, benchmark scripts, summary scripts, tests, and documentation remain source artifacts and should stay trackable. For example, `experiments/workloads/deterministic_heavy_v1_100.json` is a tracked workload definition, not a raw benchmark result output.
+
+## Frozen Raw Artifact Requirements
+
+If raw benchmark JSON artifacts are ever committed as frozen release evidence, the accompanying documentation must include:
+
+- workload id or workload path
+- generator seed and generation command
+- benchmark command used for each raw artifact
+- date generated
+- code commit used to generate the artifact
+- claim boundary and non-claims
+
+Frozen raw artifacts should be intentionally named and reviewed. They should not be added as incidental outputs from local runs.
+
+## Claim Boundary
+
+Current safe claim:
+
+> In a reproducible 100-task deterministic-heavy benchmark workload, KORA-controlled execution avoided 80 of 100 simulated model invocations versus a naive direct baseline.
+
+Forbidden claims:
+
+- production cost reduction
+- real API-cost reduction
+- production benchmark proof
+- full runtime-integrated benchmark evidence
+- broad workload superiority
+- energy reduction evidence
+
+Benchmark summaries must state that the current evidence is reproducible benchmark evidence from simulated benchmark artifacts, not production cost/API/energy proof.
+
+## Regeneration Guide
+
+Use `/tmp` paths for raw generated outputs unless a release process explicitly selects frozen artifacts.
+
+Regenerate the workload from seed `42`:
+
+```bash
+python3 experiments/generate_workload.py \
+  --count 100 \
+  --seed 42 \
+  --benchmark-name deterministic_heavy_v1 \
+  --output /tmp/kora_deterministic_heavy_v1_100.regenerated.json
+
+cmp experiments/workloads/deterministic_heavy_v1_100.json \
+  /tmp/kora_deterministic_heavy_v1_100.regenerated.json
+```
+
+Run the dry-run benchmark:
+
+```bash
+python3 experiments/run_benchmark.py \
+  --mode dry-run \
+  --workload experiments/workloads/deterministic_heavy_v1_100.json \
+  --output /tmp/kora_deterministic_heavy_v1_100.dry_run.json
+```
+
+Run the direct-baseline benchmark:
+
+```bash
+python3 experiments/run_benchmark.py \
+  --mode direct-baseline \
+  --workload experiments/workloads/deterministic_heavy_v1_100.json \
+  --output /tmp/kora_deterministic_heavy_v1_100.direct_baseline.json
+```
+
+Run the KORA-controlled benchmark:
+
+```bash
+python3 experiments/run_benchmark.py \
+  --mode kora-controlled \
+  --workload experiments/workloads/deterministic_heavy_v1_100.json \
+  --output /tmp/kora_deterministic_heavy_v1_100.kora_controlled.json
+```
+
+Generate a Markdown summary from raw result artifacts:
+
+```bash
+python3 experiments/summarize_benchmark_results.py \
+  --direct-baseline /tmp/kora_deterministic_heavy_v1_100.direct_baseline.json \
+  --kora-controlled /tmp/kora_deterministic_heavy_v1_100.kora_controlled.json \
+  --output /tmp/kora_deterministic_heavy_v1_100.summary.md
+```
+
+If a generated Markdown summary is selected for public evidence, review it for the claim boundary before committing it under `docs/reports/` or another reviewed documentation location.

--- a/docs/reports/v0.2.0-alpha-merge-candidate-validation.md
+++ b/docs/reports/v0.2.0-alpha-merge-candidate-validation.md
@@ -1,0 +1,132 @@
+# KORA v0.2.0-alpha Merge Candidate Validation
+
+Status: merge candidate validation / not released
+
+Base `origin/main` commit: `17d0665b6e9eb48bd54a83ae2dda2e59f416a40f`
+
+Merge source branch: `origin/task108_pre_merge_self_review`
+
+Merge source commit: `77e2279ebc40a6f10185bbbdef4701ddb6704022`
+
+Merge candidate branch: `task109_v020_alpha_merge_candidate`
+
+Merge candidate merge commit: `94eafafa2fc45f773fb6e00c4e64645693f7fcbc`
+
+Report date: 2026-05-05
+
+## Summary
+
+This report validates a clean merge candidate branch created from `origin/main` and merged with the Task 101-108 branch chain. The merge completed without conflicts and was validated from the merge candidate branch.
+
+No merge to `main`, Git tag, GitHub Release, package version update, or raw benchmark artifact commit was performed.
+
+## Included Task Chain
+
+| Task | Commit | Included |
+|---|---|---|
+| Task 101 | `04d6dd6710ff202765d6debc034c2dfa2557cdad` | Yes |
+| Task 102 | `c35fd7a6f5f6bed40e65c76217ee453f066cdddb` | Yes |
+| Task 103 | `b7e9d59533056e900fcaa3b272878138936f099a` | Yes |
+| Task 104 | `37b4cbd71b086e2b161a874dbc255972d1bb28c9` | Yes |
+| Task 105 | `7fc346976be6502d87cb8108a2670ea163215659` | Yes |
+| Task 106 | `5eeba65f1c17901c16a978f3615f2882a03e2049` | Yes |
+| Task 107 | `4ac9c2c8b4359ac023bf415ed838a996c84e898d` | Yes |
+| Task 108 | `77e2279ebc40a6f10185bbbdef4701ddb6704022` | Yes |
+
+## Validation Results
+
+| Command | Result |
+|---|---|
+| `python3 -m pytest` | Passed, `50 passed` |
+| `python3 -m kora --help` | Passed |
+| `python3 -m kora examples list` | Passed |
+| `python3 -m kora run hello_kora` | Passed |
+| `python3 -m kora run retry_demo` | Passed |
+| `python3 -m kora run direct_vs_kora -- --offline` | Passed |
+| Regenerate `deterministic_heavy_v1_100` under `/tmp` and compare with tracked workload | Passed |
+| `experiments/run_benchmark.py --mode dry-run` for `deterministic_heavy_v1_100` | Passed |
+| `experiments/run_benchmark.py --mode direct-baseline` for `deterministic_heavy_v1_100` | Passed |
+| `experiments/run_benchmark.py --mode kora-controlled` for `deterministic_heavy_v1_100` | Passed |
+| `experiments/summarize_benchmark_results.py` using `/tmp` artifacts | Passed |
+
+Fresh generated summary path:
+
+```text
+/tmp/kora_deterministic_heavy_v1_100.summary.task109.md
+```
+
+## Benchmark Evidence Counters
+
+| Metric | Value |
+|---|---:|
+| Workload | `experiments/workloads/deterministic_heavy_v1_100.json` |
+| Generator | `experiments/generate_workload.py` |
+| Seed | `42` |
+| Total tasks | `100` |
+| Deterministic/no-model tasks | `80` |
+| Fallback/model-candidate tasks | `20` |
+| Direct-baseline simulated model invocations | `100` |
+| KORA-controlled simulated model invocations | `20` |
+| Avoided simulated model invocations | `80` |
+| Avoided invocation rate | `80%` |
+| Deterministic outputs checked | `80` |
+| Deterministic expected-output mismatches | `0` |
+| Fallback/model-candidate tasks skipped for deterministic output validation | `20` |
+
+## Artifact and Release Hygiene Checks
+
+| Check | Result |
+|---|---|
+| Merge candidate created from latest fetched `origin/main` | Passed |
+| Task 101-108 commits included | Passed |
+| Local dirty `main` worktree untouched | Passed |
+| No merge or push to `main` | Passed |
+| No Git tag created | Passed |
+| No GitHub Release created | Passed |
+| No package version update | Passed |
+| No `CHANGELOG.md` update in this task | Passed |
+| No raw generated benchmark JSON artifacts tracked | Passed |
+| Generated benchmark result JSON/JSONL paths remain ignored | Passed |
+| Workload definitions remain trackable | Passed |
+
+Tracked benchmark-related JSON files remain source fixtures or workload definitions, including `experiments/workloads/deterministic_heavy_v1_100.json`.
+
+Raw generated benchmark artifacts used for validation were written under `/tmp` and were not committed.
+
+## Safe Claim Boundary
+
+Safe claim:
+
+> In a reproducible 100-task deterministic-heavy benchmark workload, KORA-controlled execution avoided 80 of 100 simulated model invocations versus a naive direct baseline.
+
+## Explicit Non-Claims
+
+This merge candidate validation does not claim:
+
+- production cost reduction proof
+- real API-cost reduction proof
+- production benchmark proof
+- full runtime-integrated benchmark evidence
+- broad workload superiority proof
+- energy reduction evidence
+
+## Remaining Blockers
+
+- Merge candidate still needs PR review before any merge to `main`.
+- Final validation still needs to run from public `origin/main` after merge.
+- `CHANGELOG.md` still needs reviewed `v0.2.0-alpha` wording after merge readiness is confirmed.
+- Raw artifact freeze decision remains open.
+- Git tag approval remains open.
+- GitHub Release approval remains open.
+
+## Recommended Next Action
+
+Open a PR from `task109_v020_alpha_merge_candidate` to `main`. After PR review and merge, run final validation from public `origin/main` before changelog, tag, or GitHub Release work.
+
+## Release Actions Not Performed
+
+- No merge to `main`.
+- No Git tag.
+- No GitHub Release.
+- No package version update.
+- No raw benchmark JSON artifacts committed.

--- a/docs/reports/v0.2.0-alpha-merge-readiness-pr-packet.md
+++ b/docs/reports/v0.2.0-alpha-merge-readiness-pr-packet.md
@@ -1,0 +1,243 @@
+# KORA v0.2.0-alpha Merge Readiness PR Packet
+
+Status: merge-readiness packet / not released
+
+Source branch: `task107_merge_readiness_pr_packet`
+
+Base branch for this packet: `origin/task106_v020_alpha_readiness_check`
+
+Target branch for eventual PR merge: `main`
+
+Current public truth checked: `origin/main 17d0665b6e9eb48bd54a83ae2dda2e59f416a40f`
+
+## PR Title Suggestion
+
+Prepare v0.2.0-alpha benchmark evidence expansion
+
+## PR Summary
+
+This PR packet prepares the Task 101-106 branch chain for review and eventual merge. The chain expands the deterministic-heavy benchmark evidence path while keeping claims limited to reproducible simulated benchmark evidence.
+
+The chain adds deterministic expected-output validation, benchmark summary generation, raw artifact policy documentation, expanded correctness/error/fallback test coverage, a draft `v0.2.0-alpha` release note, and a readiness-check report.
+
+This packet does not merge to `main`, create a Git tag, create a GitHub Release, update package version metadata, or commit raw benchmark JSON artifacts.
+
+## Included Task Chain
+
+| Task | Commit | Summary |
+|---|---|---|
+| Task 101 | `04d6dd6710ff202765d6debc034c2dfa2557cdad` | Added deterministic expected-output correctness checks and counters. |
+| Task 102 | `c35fd7a6f5f6bed40e65c76217ee453f066cdddb` | Added Markdown benchmark summary generation from result JSON artifacts. |
+| Task 103 | `b7e9d59533056e900fcaa3b272878138936f099a` | Documented raw benchmark artifact policy and narrowed generated-output ignores. |
+| Task 104 | `37b4cbd71b086e2b161a874dbc255972d1bb28c9` | Expanded correctness/error/fallback benchmark case coverage. |
+| Task 105 | `7fc346976be6502d87cb8108a2670ea163215659` | Drafted `v0.2.0-alpha` release notes. |
+| Task 106 | `5eeba65f1c17901c16a978f3615f2882a03e2049` | Added `v0.2.0-alpha` readiness-check report. |
+
+The chain is linear on top of `origin/main 17d0665b6e9eb48bd54a83ae2dda2e59f416a40f`.
+
+## Expected Files Added or Modified
+
+| Path | Status | Purpose |
+|---|---|---|
+| `.gitignore` | Modified | Keeps raw generated benchmark outputs ignored while allowing Markdown reports to be tracked. |
+| `docs/reports/benchmark_artifact_policy.md` | Added | Documents raw artifact and summary policy. |
+| `docs/reports/v0.2.0-alpha-release-notes-draft.md` | Added | Draft release notes only; not a release. |
+| `docs/reports/v0.2.0-alpha-readiness-check.md` | Added | Readiness report only; not a release. |
+| `experiments/run_benchmark.py` | Modified | Adds deterministic expected-output validation and clearer errors. |
+| `experiments/summarize_benchmark_results.py` | Added | Generates Markdown summaries from raw benchmark result JSON. |
+| `tests/test_benchmark_runner.py` | Modified | Adds correctness/error/fallback and stable counter coverage. |
+| `tests/test_benchmark_summary.py` | Added | Tests summary generation and claim boundary text. |
+
+## Branch-Chain Integrity Checks
+
+- `origin/main` remained at `17d0665b6e9eb48bd54a83ae2dda2e59f416a40f` during this packet preparation.
+- `origin/task106_v020_alpha_readiness_check` resolved to `5eeba65f1c17901c16a978f3615f2882a03e2049`.
+- The chain from `origin/main` to this packet includes Task 101 through Task 106 commits in order.
+- No merge to `main` was performed.
+- No tag was created.
+- No GitHub Release was created.
+- No package version update was performed.
+
+## Raw Artifact Tracking Check
+
+No generated benchmark result JSON artifacts are expected to be tracked.
+
+Tracked benchmark-related JSON files remain source fixtures or workload definitions:
+
+- `experiments/workloads/deterministic_heavy_v0.json`
+- `experiments/workloads/deterministic_heavy_v1_100.json`
+- `docs/reports/sample_telemetry_input.json`
+- example graph JSON files
+
+Generated raw benchmark outputs remain ignored by `.gitignore`:
+
+- `experiments/results/*.json`
+- `experiments/results/*.jsonl`
+- `docs/reports/*.json`
+- `docs/reports/*.jsonl`
+- `docs/reports/generated/`
+
+Markdown reports under `docs/reports/` remain trackable.
+
+## Benchmark Evidence Counters
+
+| Metric | Value |
+|---|---:|
+| Workload | `experiments/workloads/deterministic_heavy_v1_100.json` |
+| Generator | `experiments/generate_workload.py` |
+| Seed | `42` |
+| Total tasks | `100` |
+| Deterministic/no-model tasks | `80` |
+| Fallback/model-candidate tasks | `20` |
+| Direct-baseline simulated model invocations | `100` |
+| KORA-controlled simulated model invocations | `20` |
+| Avoided simulated model invocations | `80` |
+| Avoided invocation rate | `80%` |
+| Deterministic outputs checked | `80` |
+| Deterministic expected-output mismatches | `0` |
+| Fallback/model-candidate tasks skipped for deterministic output validation | `20` |
+
+## Validation Commands
+
+Run before opening or merging the PR:
+
+```bash
+python3 -m pytest
+python3 -m kora --help
+python3 -m kora examples list
+python3 -m kora run hello_kora
+python3 -m kora run retry_demo
+python3 -m kora run direct_vs_kora -- --offline
+
+python3 experiments/generate_workload.py \
+  --count 100 \
+  --seed 42 \
+  --benchmark-name deterministic_heavy_v1 \
+  --output /tmp/kora_deterministic_heavy_v1_100.regenerated.json
+
+cmp experiments/workloads/deterministic_heavy_v1_100.json \
+  /tmp/kora_deterministic_heavy_v1_100.regenerated.json
+
+python3 experiments/run_benchmark.py \
+  --mode dry-run \
+  --workload experiments/workloads/deterministic_heavy_v1_100.json \
+  --output /tmp/kora_deterministic_heavy_v1_100.dry_run.json
+
+python3 experiments/run_benchmark.py \
+  --mode direct-baseline \
+  --workload experiments/workloads/deterministic_heavy_v1_100.json \
+  --output /tmp/kora_deterministic_heavy_v1_100.direct_baseline.json
+
+python3 experiments/run_benchmark.py \
+  --mode kora-controlled \
+  --workload experiments/workloads/deterministic_heavy_v1_100.json \
+  --output /tmp/kora_deterministic_heavy_v1_100.kora_controlled.json
+
+python3 experiments/summarize_benchmark_results.py \
+  --direct-baseline /tmp/kora_deterministic_heavy_v1_100.direct_baseline.json \
+  --kora-controlled /tmp/kora_deterministic_heavy_v1_100.kora_controlled.json \
+  --output /tmp/kora_deterministic_heavy_v1_100.summary.md
+```
+
+## Safe Claim Boundary
+
+Safe claim:
+
+> In a reproducible 100-task deterministic-heavy benchmark workload, KORA-controlled execution avoided 80 of 100 simulated model invocations versus a naive direct baseline.
+
+Use `simulated` when describing model invocations in this evidence path.
+
+## Explicit Non-Claims
+
+This PR packet does not claim:
+
+- production cost reduction proof
+- real API-cost reduction proof
+- production benchmark proof
+- full runtime-integrated benchmark evidence
+- broad workload superiority proof
+- energy reduction evidence
+
+## Suggested PR Body
+
+```markdown
+## Summary
+
+This PR prepares the v0.2.0-alpha benchmark evidence expansion for review.
+
+It expands the deterministic-heavy benchmark evidence path while keeping claims limited to reproducible simulated benchmark evidence. It adds deterministic expected-output validation, Markdown summary generation from benchmark result JSON, a raw artifact policy, expanded correctness/error/fallback coverage, and draft release/readiness documentation.
+
+## Included work
+
+- Deterministic expected-output checks for `requires_model: false` benchmark tasks
+- Correctness counters for checked deterministic outputs, mismatches, and fallback/model-candidate skips
+- Markdown summary generation from direct-baseline and KORA-controlled result JSON artifacts
+- Raw benchmark artifact policy covering ephemeral `/tmp` outputs and frozen evidence requirements
+- Expanded benchmark tests for success, mismatch, fallback skip, unsupported category, malformed input, and stable `v1_100` counters
+- Draft `v0.2.0-alpha` release notes
+- `v0.2.0-alpha` readiness-check report
+
+## Benchmark evidence
+
+Current deterministic-heavy benchmark evidence:
+
+| Metric | Value |
+|---|---:|
+| Workload | `experiments/workloads/deterministic_heavy_v1_100.json` |
+| Seed | `42` |
+| Total tasks | `100` |
+| Deterministic/no-model tasks | `80` |
+| Fallback/model-candidate tasks | `20` |
+| Direct-baseline simulated model invocations | `100` |
+| KORA-controlled simulated model invocations | `20` |
+| Avoided simulated model invocations | `80` |
+| Avoided invocation rate | `80%` |
+| Deterministic outputs checked | `80` |
+| Mismatches | `0` |
+| Fallback/model-candidate skipped | `20` |
+
+Safe claim:
+
+> In a reproducible 100-task deterministic-heavy benchmark workload, KORA-controlled execution avoided 80 of 100 simulated model invocations versus a naive direct baseline.
+
+## Non-claims
+
+This PR does not claim production cost reduction proof, real API-cost reduction proof, production benchmark proof, full runtime-integrated benchmark evidence, broad workload superiority proof, or energy reduction evidence.
+
+## Validation
+
+- [ ] `python3 -m pytest`
+- [ ] `python3 -m kora --help`
+- [ ] `python3 -m kora examples list`
+- [ ] `python3 -m kora run hello_kora`
+- [ ] `python3 -m kora run retry_demo`
+- [ ] `python3 -m kora run direct_vs_kora -- --offline`
+- [ ] Regenerate `deterministic_heavy_v1_100` under `/tmp` and compare with tracked workload
+- [ ] Run dry-run, direct-baseline, and kora-controlled benchmark modes
+- [ ] Generate Markdown summary from `/tmp` benchmark artifacts
+
+## Release actions not performed
+
+- No merge to `main`
+- No Git tag
+- No GitHub Release
+- No package version update
+- No raw benchmark JSON artifacts committed
+```
+
+## Release Blockers Remaining After This PR Packet
+
+- Task 101-107 chain still needs PR review and merge into `main`.
+- Final validation still needs to be run from merged public `origin/main`.
+- `CHANGELOG.md` still needs a reviewed `v0.2.0-alpha` update after merge readiness is confirmed.
+- Any decision to freeze raw benchmark artifacts remains open.
+- Git tag and GitHub Release still require explicit approval.
+
+## Post-Merge Checklist
+
+- [ ] Validate merged `origin/main`.
+- [ ] Update `CHANGELOG.md`.
+- [ ] Run final release smoke from public HEAD.
+- [ ] Decide whether to freeze any raw artifacts.
+- [ ] Create tag only after final approval.
+- [ ] Create GitHub Release only after tag approval.

--- a/docs/reports/v0.2.0-alpha-pre-merge-self-review.md
+++ b/docs/reports/v0.2.0-alpha-pre-merge-self-review.md
@@ -1,0 +1,193 @@
+# KORA v0.2.0-alpha Pre-Merge Self-Review
+
+Status: internal pre-merge self-review / not released
+
+Source branch: `task108_pre_merge_self_review`
+
+Base branch: `origin/task107_merge_readiness_pr_packet`
+
+Target branch for eventual PR: `main`
+
+Public truth checked: `origin/main 17d0665b6e9eb48bd54a83ae2dda2e59f416a40f`
+
+Report date: 2026-05-05
+
+## Scope Reviewed
+
+This review covers the Task 101-107 branch chain for the `v0.2.0-alpha` benchmark evidence expansion path.
+
+Reviewed areas:
+
+- benchmark runner changes
+- deterministic expected-output validation
+- benchmark summary generation
+- tests for correctness/error/fallback coverage
+- `.gitignore` generated-artifact rules
+- raw benchmark artifact policy
+- draft release notes
+- readiness check report
+- merge-readiness PR packet
+- package/version metadata
+- tracked JSON and JSONL artifacts
+- claim hygiene in new scripts, tests, and docs
+
+## Branch Chain Reviewed
+
+| Task | Commit | Review status |
+|---|---|---|
+| Task 101 | `04d6dd6710ff202765d6debc034c2dfa2557cdad` | Included |
+| Task 102 | `c35fd7a6f5f6bed40e65c76217ee453f066cdddb` | Included |
+| Task 103 | `b7e9d59533056e900fcaa3b272878138936f099a` | Included |
+| Task 104 | `37b4cbd71b086e2b161a874dbc255972d1bb28c9` | Included |
+| Task 105 | `7fc346976be6502d87cb8108a2670ea163215659` | Included |
+| Task 106 | `5eeba65f1c17901c16a978f3615f2882a03e2049` | Included |
+| Task 107 | `4ac9c2c8b4359ac023bf415ed838a996c84e898d` | Included |
+
+The chain is linear on top of `origin/main 17d0665b6e9eb48bd54a83ae2dda2e59f416a40f`.
+
+## Files Added or Modified by the Chain
+
+| Path | Status |
+|---|---|
+| `.gitignore` | Modified |
+| `docs/reports/benchmark_artifact_policy.md` | Added |
+| `docs/reports/v0.2.0-alpha-merge-readiness-pr-packet.md` | Added |
+| `docs/reports/v0.2.0-alpha-readiness-check.md` | Added |
+| `docs/reports/v0.2.0-alpha-release-notes-draft.md` | Added |
+| `experiments/run_benchmark.py` | Modified |
+| `experiments/summarize_benchmark_results.py` | Added |
+| `tests/test_benchmark_runner.py` | Modified |
+| `tests/test_benchmark_summary.py` | Added |
+
+No package/version file changes were found.
+
+## Claim Hygiene Review
+
+Result: pass for pre-merge review.
+
+The safe claim is present and bounded where needed:
+
+> In a reproducible 100-task deterministic-heavy benchmark workload, KORA-controlled execution avoided 80 of 100 simulated model invocations versus a naive direct baseline.
+
+New docs and summary generation text consistently frame the benchmark as reproducible simulated benchmark evidence.
+
+Forbidden claims were searched and reviewed. The new materials explicitly avoid or negate the following claims:
+
+- production cost reduction proof
+- real API-cost reduction proof
+- production benchmark proof
+- full runtime-integrated benchmark evidence
+- broad workload superiority proof
+- energy reduction evidence
+
+No unsupported production/API-cost/energy claim was found in the Task 101-107 changed files.
+
+## Artifact Policy Review
+
+Result: pass for pre-merge review.
+
+Raw generated benchmark result artifacts are not tracked.
+
+Tracked benchmark-related JSON files are source fixtures or workload definitions:
+
+- `experiments/workloads/deterministic_heavy_v0.json`
+- `experiments/workloads/deterministic_heavy_v1_100.json`
+- `docs/reports/sample_telemetry_input.json`
+- example graph JSON files
+
+Generated benchmark outputs remain ignored:
+
+- `experiments/results/*.json`
+- `experiments/results/*.jsonl`
+- `docs/reports/*.json`
+- `docs/reports/*.jsonl`
+- `docs/reports/generated/`
+
+Markdown reports under `docs/reports/` remain trackable, which is needed for policy, release-note draft, readiness-check, merge-packet, and this self-review report.
+
+## Test and Validation Review
+
+Result: pass for branch-chain validation.
+
+Validation commands run in this self-review:
+
+| Command | Result |
+|---|---|
+| `python3 -m pytest` | Passed, `50 passed` |
+| `python3 -m kora --help` | Passed |
+| `python3 -m kora examples list` | Passed |
+| `python3 -m kora run hello_kora` | Passed |
+| `python3 -m kora run retry_demo` | Passed |
+| `python3 -m kora run direct_vs_kora -- --offline` | Passed |
+| Regenerate `deterministic_heavy_v1_100` under `/tmp` and compare with tracked workload | Passed |
+| `experiments/run_benchmark.py --mode dry-run` for `deterministic_heavy_v1_100` | Passed |
+| `experiments/run_benchmark.py --mode direct-baseline` for `deterministic_heavy_v1_100` | Passed |
+| `experiments/run_benchmark.py --mode kora-controlled` for `deterministic_heavy_v1_100` | Passed |
+| `experiments/summarize_benchmark_results.py` using `/tmp` artifacts | Passed |
+
+Fresh generated summary path:
+
+```text
+/tmp/kora_deterministic_heavy_v1_100.summary.task108.md
+```
+
+Benchmark counters confirmed:
+
+| Metric | Value |
+|---|---:|
+| Total tasks | `100` |
+| Deterministic/no-model tasks | `80` |
+| Fallback/model-candidate tasks | `20` |
+| Direct-baseline simulated model invocations | `100` |
+| KORA-controlled simulated model invocations | `20` |
+| Avoided simulated model invocations | `80` |
+| Avoided invocation rate | `80%` |
+| Deterministic outputs checked | `80` |
+| Deterministic expected-output mismatches | `0` |
+| Fallback/model-candidate tasks skipped for deterministic output validation | `20` |
+
+## Risk Register
+
+| Risk | Status | Mitigation |
+|---|---|---|
+| Branch chain has not yet been merged into public `origin/main`. | Open | Open PR and review/merge the chain intentionally. |
+| Final validation from merged public HEAD is still pending. | Open | Rerun full validation after merge to `origin/main`. |
+| Benchmark is deterministic-heavy and simulated-invocation based, not production evidence. | Open by design | Keep claim boundary and non-claims in release materials. |
+| Raw artifact freeze decision is unresolved. | Open | Decide after merge whether any raw artifacts should become frozen release evidence. |
+| `CHANGELOG.md` is not yet updated. | Open | Update only after merge readiness is confirmed. |
+| Git tag/GitHub Release approval is not yet granted. | Open | Tag/release only after explicit final approval. |
+
+## Release-Readiness Gaps
+
+- Task 101-108 branch chain still needs PR review.
+- Task 101-108 branch chain still needs merge into `main`.
+- Final public HEAD validation still needs to run after merge.
+- `CHANGELOG.md` needs a reviewed `v0.2.0-alpha` update after merge readiness is confirmed.
+- Raw artifact freeze policy decision remains open.
+- Git tag approval remains open.
+- GitHub Release approval remains open.
+
+## Go/No-Go Recommendation
+
+Recommendation: go for opening a PR; no-go for release/tag creation.
+
+Rationale:
+
+- The branch chain is coherent and linear.
+- The implementation remains minimal and evidence-bound.
+- Validation passes.
+- Raw generated benchmark artifacts are not tracked.
+- Claim hygiene is acceptable for alpha release preparation.
+- Remaining blockers are release-process blockers, not validation failures in the branch chain.
+
+## Required Next Action
+
+Open the PR using the merge-readiness packet, review the Task 101-108 chain, and merge only after review. After merge, run final validation from public `origin/main` before updating `CHANGELOG.md`, tagging, or creating a GitHub Release.
+
+## Release Actions Not Performed
+
+- No merge to `main`.
+- No Git tag.
+- No GitHub Release.
+- No package version update.
+- No raw benchmark JSON artifacts committed.

--- a/docs/reports/v0.2.0-alpha-readiness-check.md
+++ b/docs/reports/v0.2.0-alpha-readiness-check.md
@@ -1,0 +1,116 @@
+# KORA v0.2.0-alpha Readiness Check
+
+Version candidate: `v0.2.0-alpha`
+
+Status: not yet released
+
+Base branch used for this report: `origin/task105_v020_alpha_release_notes`
+
+Source branch: `task106_v020_alpha_readiness_check`
+
+Report date: 2026-05-05
+
+## Summary
+
+This report records a readiness check for the `v0.2.0-alpha` candidate evidence path. It does not create a Git tag, GitHub Release, or package version change.
+
+The readiness state is positive for the current Task 101-106 branch chain, with all requested validation commands passing. The main remaining release blocker is process-related: the Task 101-106 chain is not yet merged into `origin/main`, so final public HEAD validation has not been performed.
+
+## Evidence Chain
+
+The current branch includes the Task 101-105 evidence expansion chain:
+
+| Task | Evidence contribution |
+|---|---|
+| Task 101 | Added deterministic expected-output correctness checks and counters. |
+| Task 102 | Added automated Markdown summary generation from benchmark result JSON artifacts. |
+| Task 103 | Documented raw benchmark artifact policy and `/tmp` regeneration flow. |
+| Task 104 | Expanded correctness/error/fallback benchmark case coverage. |
+| Task 105 | Drafted `v0.2.0-alpha` release notes without tagging or releasing. |
+
+## Validation Results
+
+| Command | Result |
+|---|---|
+| `python3 -m pytest` | Passed, `50 passed` |
+| `python3 -m kora --help` | Passed |
+| `python3 -m kora examples list` | Passed |
+| `python3 -m kora run hello_kora` | Passed |
+| `python3 -m kora run retry_demo` | Passed |
+| `python3 -m kora run direct_vs_kora -- --offline` | Passed |
+| Regenerate `deterministic_heavy_v1_100` under `/tmp` and compare with tracked workload | Passed |
+| `experiments/run_benchmark.py --mode dry-run` for `deterministic_heavy_v1_100` | Passed |
+| `experiments/run_benchmark.py --mode direct-baseline` for `deterministic_heavy_v1_100` | Passed |
+| `experiments/run_benchmark.py --mode kora-controlled` for `deterministic_heavy_v1_100` | Passed |
+| `experiments/summarize_benchmark_results.py` using `/tmp` artifacts | Passed |
+
+Fresh generated summary path:
+
+```text
+/tmp/kora_deterministic_heavy_v1_100.summary.task106.md
+```
+
+Raw benchmark JSON artifacts were generated under `/tmp` and were not committed.
+
+## Benchmark Evidence
+
+| Metric | Value |
+|---|---:|
+| Workload | `experiments/workloads/deterministic_heavy_v1_100.json` |
+| Generator | `experiments/generate_workload.py` |
+| Seed | `42` |
+| Total tasks | `100` |
+| Deterministic/no-model tasks | `80` |
+| Fallback/model-candidate tasks | `20` |
+| Direct-baseline simulated model invocations | `100` |
+| KORA-controlled simulated model invocations | `20` |
+| Avoided simulated model invocations | `80` |
+| Avoided invocation rate | `80%` |
+| Deterministic outputs checked | `80` |
+| Deterministic expected-output mismatches | `0` |
+| Fallback/model-candidate tasks skipped for deterministic output validation | `20` |
+
+## Safe Claim Boundary
+
+Safe claim:
+
+> In a reproducible 100-task deterministic-heavy benchmark workload, KORA-controlled execution avoided 80 of 100 simulated model invocations versus a naive direct baseline.
+
+Use `simulated` when describing model invocations in this evidence path.
+
+## Explicit Non-Claims
+
+This readiness check does not claim:
+
+- production cost reduction proof
+- real API-cost reduction proof
+- production benchmark proof
+- full runtime-integrated benchmark evidence
+- broad workload superiority proof
+- energy reduction evidence
+
+## Release Blockers
+
+Current blockers before a public `v0.2.0-alpha` release:
+
+- Task 101-106 branch chain is not yet merged into `origin/main`.
+- Final validation has not yet been run from the public `origin/main` release candidate.
+- `CHANGELOG.md` has not yet been updated for `v0.2.0-alpha`.
+- No explicit approval has been given to create a Git tag or GitHub Release.
+
+No validation-command blocker was found in this readiness check.
+
+## Recommended Next Actions
+
+1. Merge the Task 101-106 chain through PR review or sequential branch merge.
+2. After merge readiness is confirmed, update `CHANGELOG.md` with reviewed `v0.2.0-alpha` wording.
+3. Run final validation from the public `origin/main` release candidate.
+4. Create a Git tag only after explicit release approval.
+5. Create a GitHub Release only after explicit release approval.
+
+## Release Actions Not Performed
+
+- No Git tag was created.
+- No GitHub Release was created.
+- No package version was changed.
+- No raw benchmark JSON artifacts were committed.

--- a/docs/reports/v0.2.0-alpha-release-notes-draft.md
+++ b/docs/reports/v0.2.0-alpha-release-notes-draft.md
@@ -1,0 +1,159 @@
+# KORA v0.2.0-alpha Release Notes Draft
+
+Version: `v0.2.0-alpha`
+
+Status: draft / not yet released
+
+Previous published release: `v0.1.1-alpha`
+
+## Summary
+
+KORA v0.2.0-alpha is planned as an alpha benchmark-evidence expansion release.
+
+This draft focuses on the deterministic-heavy benchmark evidence path added after `v0.1.1-alpha`: stronger deterministic expected-output checks, automated Markdown summary generation from result JSON, a raw benchmark artifact policy, and expanded correctness/error/fallback test coverage.
+
+This is a draft document only. It does not create a Git tag, GitHub Release, or final public release asset.
+
+## What Changed Since v0.1.1-alpha
+
+- Expanded the deterministic-heavy workload evidence path from the original 20-task benchmark skeleton to the reproducible 100-task `deterministic_heavy_v1_100` workload.
+- Added deterministic expected-output correctness checks for benchmark tasks marked `requires_model: false`.
+- Added correctness counters for deterministic output checks, mismatches, and fallback/model-candidate skips.
+- Added automated Markdown summary generation from raw benchmark result JSON artifacts.
+- Added a raw benchmark artifact policy for deciding which generated outputs remain ephemeral and which summaries may be committed.
+- Added focused correctness/error/fallback coverage for deterministic success, deterministic mismatch, fallback skip behavior, unsupported categories, malformed deterministic input, and stable `v1_100` evidence counters.
+
+## Scope
+
+This release draft covers:
+
+- benchmark evidence expansion
+- deterministic expected-output checks
+- summary generation automation
+- raw artifact policy
+- expanded correctness/error/fallback benchmark coverage
+
+This release draft does not cover production runtime integration, real model/API measurements, production cost analysis, or energy measurement.
+
+## Benchmark Evidence Summary
+
+Current deterministic-heavy benchmark evidence:
+
+| Metric | Value |
+|---|---:|
+| Workload | `experiments/workloads/deterministic_heavy_v1_100.json` |
+| Generator | `experiments/generate_workload.py` |
+| Seed | `42` |
+| Total tasks | `100` |
+| Deterministic/no-model tasks | `80` |
+| Fallback/model-candidate tasks | `20` |
+| Direct-baseline simulated model invocations | `100` |
+| KORA-controlled simulated model invocations | `20` |
+| Avoided simulated model invocations | `80` |
+| Avoided invocation rate | `80%` |
+| Deterministic outputs checked | `80` |
+| Deterministic expected-output mismatches | `0` |
+| Fallback/model-candidate tasks skipped for deterministic output validation | `20` |
+
+## Safe Claim Boundary
+
+Safe claim:
+
+> In a reproducible 100-task deterministic-heavy benchmark workload, KORA-controlled execution avoided 80 of 100 simulated model invocations versus a naive direct baseline.
+
+Use `simulated` when describing model invocations in this evidence path.
+
+## Explicit Non-Claims
+
+This draft does not claim:
+
+- production cost reduction proof
+- real API-cost reduction proof
+- production benchmark proof
+- full runtime-integrated benchmark evidence
+- broad workload superiority proof
+- energy reduction evidence
+
+## Regeneration
+
+Raw benchmark result artifacts should generally be generated under `/tmp` or another ignored path. See:
+
+```text
+docs/reports/benchmark_artifact_policy.md
+```
+
+That policy includes commands to regenerate:
+
+- the `deterministic_heavy_v1_100` workload from seed `42`
+- dry-run result JSON
+- direct-baseline result JSON
+- KORA-controlled result JSON
+- generated Markdown summary output
+
+## Suggested Release Readiness Checklist
+
+- [ ] Confirm Tasks 101-105 are merged into `origin/main` in order.
+- [ ] Run a clean validation from the final `origin/main` release candidate.
+- [ ] Regenerate `deterministic_heavy_v1_100` under `/tmp` and confirm it matches the tracked workload.
+- [ ] Run `dry-run`, `direct-baseline`, and `kora-controlled` benchmark modes under `/tmp`.
+- [ ] Generate the Markdown benchmark summary from raw `/tmp` result artifacts.
+- [ ] Confirm expected-output counters remain: 80 checked, 0 mismatches, 20 fallback/model-candidate skips.
+- [ ] Review `docs/reports/benchmark_artifact_policy.md` for consistency with release evidence handling.
+- [ ] Review this draft for claim boundary compliance.
+- [ ] Decide whether a generated Markdown benchmark summary should be committed as public evidence.
+- [ ] Update final release note location if this draft is promoted.
+- [ ] Create a Git tag only after explicit release approval.
+- [ ] Create a GitHub Release only after explicit release approval.
+
+## Validation Commands
+
+Recommended validation before promoting this draft:
+
+```bash
+python3 -m pytest
+python3 -m kora --help
+python3 -m kora examples list
+python3 -m kora run hello_kora
+python3 -m kora run retry_demo
+python3 -m kora run direct_vs_kora -- --offline
+
+python3 experiments/generate_workload.py \
+  --count 100 \
+  --seed 42 \
+  --benchmark-name deterministic_heavy_v1 \
+  --output /tmp/kora_deterministic_heavy_v1_100.regenerated.json
+
+cmp experiments/workloads/deterministic_heavy_v1_100.json \
+  /tmp/kora_deterministic_heavy_v1_100.regenerated.json
+
+python3 experiments/run_benchmark.py \
+  --mode dry-run \
+  --workload experiments/workloads/deterministic_heavy_v1_100.json \
+  --output /tmp/kora_deterministic_heavy_v1_100.dry_run.json
+
+python3 experiments/run_benchmark.py \
+  --mode direct-baseline \
+  --workload experiments/workloads/deterministic_heavy_v1_100.json \
+  --output /tmp/kora_deterministic_heavy_v1_100.direct_baseline.json
+
+python3 experiments/run_benchmark.py \
+  --mode kora-controlled \
+  --workload experiments/workloads/deterministic_heavy_v1_100.json \
+  --output /tmp/kora_deterministic_heavy_v1_100.kora_controlled.json
+
+python3 experiments/summarize_benchmark_results.py \
+  --direct-baseline /tmp/kora_deterministic_heavy_v1_100.direct_baseline.json \
+  --kora-controlled /tmp/kora_deterministic_heavy_v1_100.kora_controlled.json \
+  --output /tmp/kora_deterministic_heavy_v1_100.summary.md
+```
+
+## Limitations
+
+- The benchmark evidence is simulated.
+- No real model calls are made.
+- No external APIs are used for benchmark execution.
+- No real API-cost measurement is included.
+- No production benchmark evidence is included.
+- No full runtime-integrated benchmark evidence is included.
+- The workload is deterministic-heavy by design.
+- The current result should be treated as alpha-stage reproducible benchmark evidence, not production proof.

--- a/experiments/run_benchmark.py
+++ b/experiments/run_benchmark.py
@@ -200,19 +200,23 @@ def summarize_workload(workload: dict[str, Any]) -> dict[str, Any]:
 
 
 def resolve_deterministic_task(task: dict[str, Any]) -> Any:
+    task_id = task.get("id", "<unknown>")
     category = task.get("category")
-    if not isinstance(category, str):
-        raise ValueError("deterministic task must contain a category")
+    if not isinstance(category, str) or not category:
+        raise ValueError(f"deterministic task {task_id} must contain a non-empty string category")
 
     resolver = DETERMINISTIC_RESOLVERS.get(category)
     if resolver is None:
-        raise ValueError(f"no deterministic resolver for category: {category}")
+        raise ValueError(f"no deterministic resolver for task {task_id} category: {category}")
 
     input_data = task.get("input")
     if not isinstance(input_data, dict):
-        raise ValueError(f"deterministic task {task.get('id', '<unknown>')} must contain object input")
+        raise ValueError(f"deterministic task {task_id} category {category} must contain object input")
 
-    return resolver(input_data)
+    try:
+        return resolver(input_data)
+    except ValueError as exc:
+        raise ValueError(f"deterministic task {task_id} category {category} failed: {exc}") from exc
 
 
 def validate_expected_outputs(workload: dict[str, Any]) -> dict[str, int]:
@@ -220,6 +224,9 @@ def validate_expected_outputs(workload: dict[str, Any]) -> dict[str, int]:
     skipped_fallback_candidates = 0
 
     for index, task in enumerate(workload["tasks"]):
+        if not isinstance(task, dict):
+            raise ValueError(f"task at index {index} must be an object")
+
         if task["requires_model"] is True:
             skipped_fallback_candidates += 1
             continue

--- a/experiments/run_benchmark.py
+++ b/experiments/run_benchmark.py
@@ -3,11 +3,158 @@ from __future__ import annotations
 import argparse
 import json
 from collections import Counter
+from datetime import datetime
 from pathlib import Path
 from typing import Any
 
 
 SUPPORTED_MODES = {"direct-baseline", "dry-run", "kora-controlled"}
+
+
+class DeterministicOutputMismatch(ValueError):
+    """Raised when a deterministic workload task does not match its expected output."""
+
+
+def _normalize_whitespace(value: str) -> str:
+    return " ".join(value.strip().lower().split())
+
+
+def _resolve_arithmetic(input_data: dict[str, Any]) -> Any:
+    operation = input_data.get("operation")
+
+    if "left" in input_data and "right" in input_data:
+        left = input_data["left"]
+        right = input_data["right"]
+        if operation == "add":
+            return left + right
+        if operation == "subtract":
+            return left - right
+        if operation == "multiply":
+            return left * right
+
+    values = input_data.get("values")
+    if operation == "add" and isinstance(values, list):
+        return {"result": sum(values)}
+    if operation == "multiply" and isinstance(values, list):
+        result = 1
+        for value in values:
+            result *= value
+        return {"result": result}
+    if operation == "percent_change":
+        old = input_data["old"]
+        new = input_data["new"]
+        return {"result": ((new - old) / old) * 100, "unit": "percent"}
+    if operation == "divide":
+        denominator = input_data["denominator"]
+        if denominator == 0:
+            return {"error": "division_by_zero"}
+        return {"result": input_data["numerator"] / denominator}
+
+    raise ValueError(f"unsupported deterministic arithmetic input: {input_data!r}")
+
+
+def _resolve_string_normalization(input_data: dict[str, Any]) -> Any:
+    text = input_data["text"]
+    style = input_data.get("style")
+    normalization = input_data.get("normalization")
+
+    if normalization == "strip_lower_join_spaces":
+        return " ".join(part.strip().lower() for part in text.split("-"))
+    if style == "slug":
+        slug = "".join(character.lower() if character.isalnum() else "-" for character in text).strip("-")
+        return {"text": slug}
+    if style == "email_domain":
+        return {"domain": text.split("@", maxsplit=1)[1]}
+    return {"text": _normalize_whitespace(text)}
+
+
+def _resolve_json_validation(input_data: dict[str, Any]) -> dict[str, Any]:
+    payload = input_data["payload"]
+
+    if input_data.get("parse") is True:
+        parsed = json.loads(payload)
+        return {"valid_json": True, **parsed}
+
+    if "required_fields" in input_data:
+        required = input_data["required_fields"]
+        missing = [field for field in required if field not in payload]
+        return {"valid": not missing, "missing": missing}
+
+    required_keys = input_data["required_keys"]
+    missing_keys = [key for key in required_keys if key not in payload]
+    return {"valid": not missing_keys, "missing_keys": missing_keys}
+
+
+def _resolve_routing_decision(input_data: dict[str, Any]) -> dict[str, Any]:
+    if "kind" in input_data and "priority" in input_data:
+        kind = input_data["kind"]
+        priority = input_data["priority"]
+        route = "security_review" if kind == "security" or priority == "high" else f"{kind}_queue"
+        return {"route": route}
+
+    request_type = input_data.get("request_type")
+    if request_type == "telemetry_summary" and input_data.get("has_run_json") is True:
+        return {"route": "telemetry"}
+    if request_type == "run_example":
+        return {"route": "examples.run", "example": input_data["example"]}
+
+    raise ValueError(f"unsupported deterministic routing input: {input_data!r}")
+
+
+def _resolve_cache_lookup(input_data: dict[str, Any]) -> dict[str, Any]:
+    key = input_data["key"]
+    cache = input_data.get("cache", {"alpha": "cached-alpha", "beta": "cached-beta", "gamma": "cached-gamma"})
+    return {"hit": key in cache, "value": cache.get(key)}
+
+
+def _resolve_schema_check(input_data: dict[str, Any]) -> dict[str, Any]:
+    if "enum" in input_data:
+        status = input_data["object"].get("status")
+        return {"valid": status in input_data["enum"], "field": "status"}
+
+    if input_data.get("schema") == "task_event_minimal":
+        task_id = input_data["object"].get("task_id")
+        if isinstance(task_id, str):
+            return {"valid": True}
+        return {"valid": False, "errors": ["task_id_type"]}
+
+    raise ValueError(f"unsupported deterministic schema input: {input_data!r}")
+
+
+def _resolve_date_normalization(input_data: dict[str, Any]) -> str:
+    if input_data.get("input_format") == "M/D/YYYY" and input_data.get("output_format") == "YYYY-MM-DD":
+        return datetime.strptime(input_data["date"], "%m/%d/%Y").strftime("%Y-%m-%d")
+    raise ValueError(f"unsupported deterministic date normalization input: {input_data!r}")
+
+
+def _resolve_unit_conversion(input_data: dict[str, Any]) -> dict[str, Any]:
+    if input_data.get("from") == "m" and input_data.get("to") == "cm":
+        return {"value": input_data["value"] * 100, "unit": "cm"}
+    raise ValueError(f"unsupported deterministic unit conversion input: {input_data!r}")
+
+
+def _resolve_config_validation(input_data: dict[str, Any]) -> dict[str, Any]:
+    config = input_data["config"]
+    return {"valid": 0 <= config["retries"] <= 3 and config["timeout_ms"] <= 3000}
+
+
+def _resolve_policy_rule_match(input_data: dict[str, Any]) -> dict[str, Any]:
+    allowed = not (input_data["region"] == "eu" and input_data["data_class"] == "restricted")
+    return {"allowed": allowed}
+
+
+DETERMINISTIC_RESOLVERS = {
+    "arithmetic": _resolve_arithmetic,
+    "string_normalization": _resolve_string_normalization,
+    "json_validation": _resolve_json_validation,
+    "routing_decision": _resolve_routing_decision,
+    "cache_lookup": _resolve_cache_lookup,
+    "schema_check": _resolve_schema_check,
+    "date_normalization": _resolve_date_normalization,
+    "unit_conversion": _resolve_unit_conversion,
+    "config_validation": _resolve_config_validation,
+    "policy_rule_match": _resolve_policy_rule_match,
+}
 
 
 def load_workload(path: Path) -> dict[str, Any]:
@@ -52,6 +199,48 @@ def summarize_workload(workload: dict[str, Any]) -> dict[str, Any]:
     }
 
 
+def resolve_deterministic_task(task: dict[str, Any]) -> Any:
+    category = task.get("category")
+    if not isinstance(category, str):
+        raise ValueError("deterministic task must contain a category")
+
+    resolver = DETERMINISTIC_RESOLVERS.get(category)
+    if resolver is None:
+        raise ValueError(f"no deterministic resolver for category: {category}")
+
+    input_data = task.get("input")
+    if not isinstance(input_data, dict):
+        raise ValueError(f"deterministic task {task.get('id', '<unknown>')} must contain object input")
+
+    return resolver(input_data)
+
+
+def validate_expected_outputs(workload: dict[str, Any]) -> dict[str, int]:
+    checked = 0
+    skipped_fallback_candidates = 0
+
+    for index, task in enumerate(workload["tasks"]):
+        if task["requires_model"] is True:
+            skipped_fallback_candidates += 1
+            continue
+
+        actual_output = resolve_deterministic_task(task)
+        expected_output = task.get("expected_output")
+        if actual_output != expected_output:
+            task_id = task.get("id", f"index {index}")
+            raise DeterministicOutputMismatch(
+                f"deterministic expected output mismatch for task {task_id}: "
+                f"expected {expected_output!r}, got {actual_output!r}"
+            )
+        checked += 1
+
+    return {
+        "deterministic_output_checks": checked,
+        "deterministic_output_mismatches": 0,
+        "fallback_candidates_skipped_for_output_check": skipped_fallback_candidates,
+    }
+
+
 def build_dry_run_result(workload: dict[str, Any], workload_path: Path) -> dict[str, Any]:
     summary = summarize_workload(workload)
 
@@ -90,6 +279,7 @@ def build_direct_baseline_result(workload: dict[str, Any], workload_path: Path) 
 
 def build_kora_controlled_result(workload: dict[str, Any], workload_path: Path) -> dict[str, Any]:
     summary = summarize_workload(workload)
+    correctness_summary = validate_expected_outputs(workload)
     direct_baseline_invocations = summary["total_tasks"]
     simulated_model_invocations = summary["requires_model_true"]
     avoided_invocations = direct_baseline_invocations - simulated_model_invocations
@@ -102,6 +292,7 @@ def build_kora_controlled_result(workload: dict[str, Any], workload_path: Path) 
         **summary,
         "deterministic_resolutions": summary["requires_model_false"],
         "fallback_candidates": summary["requires_model_true"],
+        **correctness_summary,
         "simulated_model_invocations": simulated_model_invocations,
         "avoided_model_invocations_vs_direct_baseline": avoided_invocations,
         "avoided_model_invocation_rate": avoided_rate,

--- a/experiments/summarize_benchmark_results.py
+++ b/experiments/summarize_benchmark_results.py
@@ -1,0 +1,142 @@
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+
+CLAIM_BOUNDARY = (
+    "This is reproducible benchmark evidence from simulated benchmark artifacts. "
+    "It is not production cost proof, real API-cost proof, production benchmark proof, "
+    "full runtime-integrated benchmark evidence, broad workload superiority evidence, "
+    "or energy-reduction evidence."
+)
+
+
+def load_result(path: Path) -> dict[str, Any]:
+    with path.open("r", encoding="utf-8") as handle:
+        result = json.load(handle)
+
+    if not isinstance(result, dict):
+        raise ValueError(f"benchmark result must be a JSON object: {path}")
+    return result
+
+
+def _require_number(result: dict[str, Any], key: str, label: str) -> int | float:
+    value = result.get(key)
+    if not isinstance(value, int | float):
+        raise ValueError(f"{label} result must contain numeric {key!r}")
+    return value
+
+
+def _require_mode(result: dict[str, Any], mode: str, label: str) -> None:
+    if result.get("mode") != mode:
+        raise ValueError(f"{label} result must have mode {mode!r}")
+
+
+def _format_rate(value: int | float) -> str:
+    return f"{value * 100:.0f}%" if value == round(value, 2) else f"{value * 100:.2f}%"
+
+
+def build_summary_markdown(direct_result: dict[str, Any], kora_result: dict[str, Any]) -> str:
+    _require_mode(direct_result, "direct-baseline", "direct-baseline")
+    _require_mode(kora_result, "kora-controlled", "kora-controlled")
+
+    benchmark_name = kora_result.get("benchmark_name") or direct_result.get("benchmark_name") or "unknown"
+    workload_path = kora_result.get("workload_path") or direct_result.get("workload_path") or "unknown"
+    total_tasks = _require_number(kora_result, "total_tasks", "kora-controlled")
+    deterministic_tasks = _require_number(kora_result, "requires_model_false", "kora-controlled")
+    fallback_tasks = _require_number(kora_result, "requires_model_true", "kora-controlled")
+    direct_invocations = _require_number(direct_result, "simulated_model_invocations", "direct-baseline")
+    kora_invocations = _require_number(kora_result, "simulated_model_invocations", "kora-controlled")
+    avoided_invocations = _require_number(kora_result, "avoided_model_invocations_vs_direct_baseline", "kora-controlled")
+    avoided_rate = _require_number(kora_result, "avoided_model_invocation_rate", "kora-controlled")
+
+    lines = [
+        f"# KORA Benchmark Result Summary - {benchmark_name}",
+        "",
+        "## Source Artifacts",
+        "",
+        "| Field | Value |",
+        "|---|---|",
+        f"| Benchmark name | `{benchmark_name}` |",
+        f"| Workload | `{workload_path}` |",
+        f"| Direct-baseline result mode | `{direct_result['mode']}` |",
+        f"| KORA-controlled result mode | `{kora_result['mode']}` |",
+        "",
+        "## Result Metrics",
+        "",
+        "| Metric | Value |",
+        "|---|---:|",
+        f"| Total tasks | {total_tasks} |",
+        f"| Deterministic/no-model tasks | {deterministic_tasks} |",
+        f"| Fallback/model-candidate tasks | {fallback_tasks} |",
+        f"| Direct-baseline simulated model invocations | {direct_invocations} |",
+        f"| KORA-controlled simulated model invocations | {kora_invocations} |",
+        f"| Avoided simulated model invocations | {avoided_invocations} |",
+        f"| Avoided invocation rate | {_format_rate(avoided_rate)} |",
+    ]
+
+    correctness_keys = [
+        ("deterministic_output_checks", "Deterministic expected-output checks"),
+        ("deterministic_output_mismatches", "Deterministic expected-output mismatches"),
+        ("fallback_candidates_skipped_for_output_check", "Fallback candidates skipped for output check"),
+    ]
+    correctness_rows = [(key, label) for key, label in correctness_keys if key in kora_result]
+    if correctness_rows:
+        lines.extend(
+            [
+                "",
+                "## Expected-Output Correctness",
+                "",
+                "| Metric | Value |",
+                "|---|---:|",
+            ]
+        )
+        for key, label in correctness_rows:
+            lines.append(f"| {label} | {kora_result[key]} |")
+
+    lines.extend(
+        [
+            "",
+            "## Claim Boundary",
+            "",
+            CLAIM_BOUNDARY,
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def write_summary(markdown: str, output_path: Path) -> None:
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(markdown, encoding="utf-8")
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Generate Markdown summaries from KORA benchmark result JSON.")
+    parser.add_argument("--direct-baseline", required=True, help="Path to direct-baseline result JSON")
+    parser.add_argument("--kora-controlled", required=True, help="Path to KORA-controlled result JSON")
+    parser.add_argument("--output", help="Path for generated Markdown summary. If omitted, prints to stdout.")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    direct_result = load_result(Path(args.direct_baseline))
+    kora_result = load_result(Path(args.kora_controlled))
+    markdown = build_summary_markdown(direct_result, kora_result)
+
+    if args.output:
+        output_path = Path(args.output)
+        write_summary(markdown, output_path)
+        print(str(output_path))
+    else:
+        print(markdown, end="")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_benchmark_runner.py
+++ b/tests/test_benchmark_runner.py
@@ -14,6 +14,7 @@ from experiments.run_benchmark import (
 
 
 WORKLOAD_PATH = Path("experiments/workloads/deterministic_heavy_v0.json")
+V1_100_WORKLOAD_PATH = Path("experiments/workloads/deterministic_heavy_v1_100.json")
 
 
 def test_workload_json_can_be_loaded() -> None:
@@ -154,3 +155,75 @@ def test_expected_output_validation_rejects_mismatched_deterministic_task() -> N
 
     with pytest.raises(DeterministicOutputMismatch, match="arithmetic_mismatch"):
         validate_expected_outputs(workload)
+
+
+def test_expected_output_validation_reports_unsupported_deterministic_category() -> None:
+    workload = {
+        "tasks": [
+            {
+                "id": "unsupported_category_case",
+                "category": "unknown_deterministic_type",
+                "input": {"value": 1},
+                "expected_output": {"value": 1},
+                "requires_model": False,
+            }
+        ]
+    }
+
+    with pytest.raises(ValueError, match="unsupported_category_case category: unknown_deterministic_type"):
+        validate_expected_outputs(workload)
+
+
+def test_expected_output_validation_reports_malformed_deterministic_input_type() -> None:
+    workload = {
+        "tasks": [
+            {
+                "id": "malformed_input_case",
+                "category": "arithmetic",
+                "input": "not-an-object",
+                "expected_output": 3,
+                "requires_model": False,
+            }
+        ]
+    }
+
+    with pytest.raises(ValueError, match="malformed_input_case category arithmetic must contain object input"):
+        validate_expected_outputs(workload)
+
+
+def test_expected_output_validation_skips_fallback_even_with_unsupported_category() -> None:
+    workload = {
+        "tasks": [
+            {
+                "id": "fallback_unsupported_skip",
+                "category": "unknown_deterministic_type",
+                "input": "not-an-object",
+                "expected_output": {"fallback_required": True},
+                "requires_model": True,
+            }
+        ]
+    }
+
+    result = validate_expected_outputs(workload)
+
+    assert result == {
+        "deterministic_output_checks": 0,
+        "deterministic_output_mismatches": 0,
+        "fallback_candidates_skipped_for_output_check": 1,
+    }
+
+
+def test_v1_100_benchmark_evidence_counters_remain_stable(tmp_path: Path) -> None:
+    output_path = tmp_path / "deterministic_heavy_v1_100.kora_controlled.json"
+
+    result = run_kora_controlled(V1_100_WORKLOAD_PATH, output_path)
+
+    assert result["total_tasks"] == 100
+    assert result["requires_model_false"] == 80
+    assert result["requires_model_true"] == 20
+    assert result["simulated_model_invocations"] == 20
+    assert result["avoided_model_invocations_vs_direct_baseline"] == 80
+    assert result["avoided_model_invocation_rate"] == 0.8
+    assert result["deterministic_output_checks"] == 80
+    assert result["deterministic_output_mismatches"] == 0
+    assert result["fallback_candidates_skipped_for_output_check"] == 20

--- a/tests/test_benchmark_runner.py
+++ b/tests/test_benchmark_runner.py
@@ -1,11 +1,15 @@
 import json
 from pathlib import Path
 
+import pytest
+
 from experiments.run_benchmark import (
+    DeterministicOutputMismatch,
     load_workload,
     run_direct_baseline,
     run_dry_run,
     run_kora_controlled,
+    validate_expected_outputs,
 )
 
 
@@ -86,6 +90,9 @@ def test_kora_controlled_result_counts_avoided_model_invocations(tmp_path: Path)
     assert result["total_tasks"] == 20
     assert result["deterministic_resolutions"] == 16
     assert result["fallback_candidates"] == 4
+    assert result["deterministic_output_checks"] == 16
+    assert result["deterministic_output_mismatches"] == 0
+    assert result["fallback_candidates_skipped_for_output_check"] == 4
     assert result["simulated_model_invocations"] == 4
     assert result["avoided_model_invocations_vs_direct_baseline"] == 16
     assert result["avoided_model_invocation_rate"] == 0.8
@@ -101,3 +108,49 @@ def test_kora_controlled_writes_output_json(tmp_path: Path) -> None:
     assert saved["status"] == "ok"
     assert saved["mode"] == "kora-controlled"
     assert saved["simulated_model_invocations"] == 4
+
+
+def test_expected_output_validation_accepts_matching_deterministic_task() -> None:
+    workload = {
+        "tasks": [
+            {
+                "id": "arithmetic_pass",
+                "category": "arithmetic",
+                "input": {"left": 2, "right": 3, "operation": "multiply"},
+                "expected_output": 6,
+                "requires_model": False,
+            },
+            {
+                "id": "fallback_skip",
+                "category": "arithmetic",
+                "input": {"left": 2, "right": 3, "operation": "multiply"},
+                "expected_output": {"fallback_required": True},
+                "requires_model": True,
+            },
+        ]
+    }
+
+    result = validate_expected_outputs(workload)
+
+    assert result == {
+        "deterministic_output_checks": 1,
+        "deterministic_output_mismatches": 0,
+        "fallback_candidates_skipped_for_output_check": 1,
+    }
+
+
+def test_expected_output_validation_rejects_mismatched_deterministic_task() -> None:
+    workload = {
+        "tasks": [
+            {
+                "id": "arithmetic_mismatch",
+                "category": "arithmetic",
+                "input": {"left": 2, "right": 3, "operation": "multiply"},
+                "expected_output": 5,
+                "requires_model": False,
+            }
+        ]
+    }
+
+    with pytest.raises(DeterministicOutputMismatch, match="arithmetic_mismatch"):
+        validate_expected_outputs(workload)

--- a/tests/test_benchmark_summary.py
+++ b/tests/test_benchmark_summary.py
@@ -1,0 +1,56 @@
+from experiments.summarize_benchmark_results import CLAIM_BOUNDARY, build_summary_markdown
+
+
+def minimal_direct_result() -> dict[str, object]:
+    return {
+        "benchmark_name": "deterministic_heavy_v1",
+        "mode": "direct-baseline",
+        "workload_path": "experiments/workloads/deterministic_heavy_v1_100.json",
+        "total_tasks": 100,
+        "requires_model_false": 80,
+        "requires_model_true": 20,
+        "simulated_model_invocations": 100,
+    }
+
+
+def minimal_kora_result() -> dict[str, object]:
+    return {
+        "benchmark_name": "deterministic_heavy_v1",
+        "mode": "kora-controlled",
+        "workload_path": "experiments/workloads/deterministic_heavy_v1_100.json",
+        "total_tasks": 100,
+        "requires_model_false": 80,
+        "requires_model_true": 20,
+        "simulated_model_invocations": 20,
+        "avoided_model_invocations_vs_direct_baseline": 80,
+        "avoided_model_invocation_rate": 0.8,
+        "deterministic_output_checks": 80,
+        "deterministic_output_mismatches": 0,
+        "fallback_candidates_skipped_for_output_check": 20,
+    }
+
+
+def test_build_summary_markdown_from_minimal_result_artifacts() -> None:
+    markdown = build_summary_markdown(minimal_direct_result(), minimal_kora_result())
+
+    assert "# KORA Benchmark Result Summary - deterministic_heavy_v1" in markdown
+    assert "| Workload | `experiments/workloads/deterministic_heavy_v1_100.json` |" in markdown
+    assert "| Total tasks | 100 |" in markdown
+    assert "| Deterministic/no-model tasks | 80 |" in markdown
+    assert "| Fallback/model-candidate tasks | 20 |" in markdown
+    assert "| Direct-baseline simulated model invocations | 100 |" in markdown
+    assert "| KORA-controlled simulated model invocations | 20 |" in markdown
+    assert "| Avoided simulated model invocations | 80 |" in markdown
+    assert "| Avoided invocation rate | 80% |" in markdown
+    assert "| Deterministic expected-output checks | 80 |" in markdown
+    assert "| Deterministic expected-output mismatches | 0 |" in markdown
+    assert "| Fallback candidates skipped for output check | 20 |" in markdown
+
+
+def test_build_summary_markdown_includes_claim_boundary() -> None:
+    markdown = build_summary_markdown(minimal_direct_result(), minimal_kora_result())
+
+    assert CLAIM_BOUNDARY in markdown
+    assert "not production cost proof" in markdown
+    assert "real API-cost proof" in markdown
+    assert "energy-reduction evidence" in markdown


### PR DESCRIPTION
## Summary

This PR prepares the v0.2.0-alpha benchmark evidence expansion for review.

It expands the deterministic-heavy benchmark evidence path while keeping claims limited to reproducible simulated benchmark evidence. It adds deterministic expected-output validation, Markdown summary generation from benchmark result JSON, a raw artifact policy, expanded correctness/error/fallback coverage, and draft release/readiness documentation.

## Included work

- Deterministic expected-output checks for `requires_model: false` benchmark tasks
- Correctness counters for checked deterministic outputs, mismatches, and fallback/model-candidate skips
- Markdown summary generation from direct-baseline and KORA-controlled result JSON artifacts
- Raw benchmark artifact policy covering ephemeral `/tmp` outputs and frozen evidence requirements
- Expanded benchmark tests for success, mismatch, fallback skip, unsupported category, malformed input, and stable `v1_100` counters
- Draft `v0.2.0-alpha` release notes
- `v0.2.0-alpha` readiness-check report

## Benchmark evidence

Current deterministic-heavy benchmark evidence:

| Metric | Value |
|---|---:|
| Workload | `experiments/workloads/deterministic_heavy_v1_100.json` |
| Seed | `42` |
| Total tasks | `100` |
| Deterministic/no-model tasks | `80` |
| Fallback/model-candidate tasks | `20` |
| Direct-baseline simulated model invocations | `100` |
| KORA-controlled simulated model invocations | `20` |
| Avoided simulated model invocations | `80` |
| Avoided invocation rate | `80%` |
| Deterministic outputs checked | `80` |
| Mismatches | `0` |
| Fallback/model-candidate skipped | `20` |

Safe claim:

> In a reproducible 100-task deterministic-heavy benchmark workload, KORA-controlled execution avoided 80 of 100 simulated model invocations versus a naive direct baseline.

## Non-claims

This PR does not claim production cost reduction proof, real API-cost reduction proof, production benchmark proof, full runtime-integrated benchmark evidence, broad workload superiority proof, or energy reduction evidence.

## Validation

- [ ] `python3 -m pytest`
- [ ] `python3 -m kora --help`
- [ ] `python3 -m kora examples list`
- [ ] `python3 -m kora run hello_kora`
- [ ] `python3 -m kora run retry_demo`
- [ ] `python3 -m kora run direct_vs_kora -- --offline`
- [ ] Regenerate `deterministic_heavy_v1_100` under `/tmp` and compare with tracked workload
- [ ] Run dry-run, direct-baseline, and kora-controlled benchmark modes
- [ ] Generate Markdown summary from `/tmp` benchmark artifacts

## Release actions not performed

- No merge to `main`
- No Git tag
- No GitHub Release
- No package version update
- No raw benchmark JSON artifacts committed
