### PR TITLE
Add v0.2.0-alpha EOD report

### DIFF
--- a/docs/reports/kora_eod_2026-05-05_v0.2.0-alpha.md
+++ b/docs/reports/kora_eod_2026-05-05_v0.2.0-alpha.md
@@ -1,0 +1,209 @@
+# KORA EOD Report - 2026-05-05 - v0.2.0-alpha
+
+Date: `2026-05-05`
+
+Final public HEAD: `0082f35c80625740ea0f05c3a41fc1ecf49a0ba1`
+
+Published release: `v0.2.0-alpha`
+
+Release URL: https://github.com/hkalbertkim/KORA/releases/tag/v0.2.0-alpha
+
+Release status:
+
+- Git tag created and pushed.
+- GitHub Release created.
+- Prerelease: true.
+- Latest: false.
+- No release assets uploaded.
+- No raw benchmark JSON artifacts uploaded.
+- Remaining blockers: none for `v0.2.0-alpha`.
+
+## Summary
+
+Today completed the `v0.2.0-alpha` benchmark evidence expansion cycle from implementation through release publication.
+
+The release adds deterministic expected-output correctness checks, benchmark Markdown summary generation, raw benchmark artifact policy documentation, expanded correctness/error/fallback benchmark coverage, reviewed release/readiness documentation, changelog wording, a raw artifact freeze decision, and final release validation.
+
+## Completed Tasks
+
+| Task | Result |
+|---|---|
+| Task 101 | Added deterministic expected-output correctness checks. |
+| Task 102 | Added benchmark summary generation. |
+| Task 103 | Added raw benchmark artifact policy. |
+| Task 104 | Expanded correctness/error/fallback benchmark coverage. |
+| Task 105 | Drafted `v0.2.0-alpha` release notes. |
+| Task 106 | Added readiness check. |
+| Task 107 | Added merge-readiness PR packet. |
+| Task 108 | Added pre-merge self-review. |
+| Task 109 | Added merge candidate validation. |
+| Task 110 | Opened PR #17. |
+| Task 111 | Added PR #17 review packet. |
+| Task 112 | Merged PR #17 and validated public HEAD. |
+| Task 113 | Prepared changelog update branch. |
+| Task 114 | Opened PR #18. |
+| Task 115 | Merged PR #18 and validated public HEAD. |
+| Task 116 | Documented raw artifact freeze decision. |
+| Task 117 | Opened and merged PR #19, then validated public HEAD. |
+| Task 118 | Cleaned stale remote `origin/task*` branches. |
+| Task 119 | Ran final release preflight. |
+| Task 120 | Created and pushed the annotated `v0.2.0-alpha` Git tag. |
+| Task 121 | Created the GitHub Release for `v0.2.0-alpha`. |
+
+## PR Summary
+
+| PR | Summary | Status |
+|---|---|---|
+| #17 | Benchmark evidence expansion: expected-output checks, summary generation, artifact policy, expanded tests, readiness docs. | Merged |
+| #18 | `CHANGELOG.md` update for `v0.2.0-alpha`. | Merged |
+| #19 | Raw artifact freeze decision: no raw benchmark JSON artifacts frozen or committed for this alpha release. | Merged |
+
+## Final Validation Summary
+
+Final validation passed from public `origin/main` before release publication:
+
+- `python3 -m pytest`: `50 passed`
+- CLI smoke tests passed:
+  - `python3 -m kora --help`
+  - `python3 -m kora examples list`
+  - `python3 -m kora run hello_kora`
+  - `python3 -m kora run retry_demo`
+  - `python3 -m kora run direct_vs_kora -- --offline`
+- Benchmark validation passed:
+  - regenerated `deterministic_heavy_v1_100` under `/tmp` and compared with the tracked workload
+  - dry-run benchmark passed
+  - direct-baseline benchmark passed
+  - KORA-controlled benchmark passed
+  - Markdown summary generation from `/tmp` benchmark artifacts passed
+
+## Benchmark Evidence
+
+| Metric | Value |
+|---|---:|
+| Workload | `experiments/workloads/deterministic_heavy_v1_100.json` |
+| Generator | `experiments/generate_workload.py` |
+| Seed | `42` |
+| Total tasks | `100` |
+| Deterministic/no-model tasks | `80` |
+| Fallback/model-candidate tasks | `20` |
+| Direct-baseline simulated model invocations | `100` |
+| KORA-controlled simulated model invocations | `20` |
+| Avoided simulated model invocations | `80` |
+| Avoided invocation rate | `80%` |
+| Deterministic outputs checked | `80` |
+| Mismatches | `0` |
+| Fallback/model-candidate skipped | `20` |
+
+## Safe Release Claim
+
+> In a reproducible 100-task deterministic-heavy benchmark workload, KORA-controlled execution avoided 80 of 100 simulated model invocations versus a naive direct baseline.
+
+## Explicit Non-Claims
+
+This release does not claim:
+
+- production cost reduction proof
+- real API-cost reduction proof
+- production benchmark proof
+- full runtime-integrated benchmark evidence
+- broad workload superiority proof
+- energy reduction evidence
+
+## Artifact Policy Summary
+
+- Raw benchmark JSON artifacts were not frozen or committed for `v0.2.0-alpha`.
+- Raw benchmark JSON artifacts were not uploaded to the GitHub Release.
+- Release evidence remains reproducible through tracked workload definitions, scripts, docs, changelog, tests, and regeneration commands.
+- Routine raw benchmark outputs should continue to use `/tmp` or ignored result paths.
+
+## Remaining Blockers
+
+None for `v0.2.0-alpha`.
+
+## Next Development Recommendation
+
+- `v0.2.1-alpha`: release polish, repo hygiene, public onboarding, documentation cleanup, and user-facing first-run improvements.
+- `v0.3.0-alpha`: runtime-integrated benchmark evidence design, including clear correctness gates and stronger evidence boundaries before any production-adjacent claims.
+
+## Next ChatGPT Start Prompt
+
+```text
+We are continuing KORA development.
+
+Repository:
+/Users/albertkim/02_PROJECTS/05_KORA
+
+Current public truth:
+origin/main
+
+Current public HEAD:
+0082f35c80625740ea0f05c3a41fc1ecf49a0ba1
+
+Published release:
+v0.2.0-alpha
+
+Release URL:
+https://github.com/hkalbertkim/KORA/releases/tag/v0.2.0-alpha
+
+Today completed the v0.2.0-alpha release cycle:
+- benchmark evidence expansion merged through PR #17
+- changelog update merged through PR #18
+- raw artifact freeze decision merged through PR #19
+- stale remote task branches cleaned
+- final release preflight passed
+- annotated Git tag v0.2.0-alpha created
+- GitHub Release v0.2.0-alpha published as a prerelease
+- no release assets or raw benchmark JSON artifacts uploaded
+
+Safe release claim:
+In a reproducible 100-task deterministic-heavy benchmark workload, KORA-controlled execution avoided 80 of 100 simulated model invocations versus a naive direct baseline.
+
+Important non-claims:
+- no production cost reduction proof
+- no real API-cost reduction proof
+- no production benchmark proof
+- no full runtime-integrated benchmark evidence
+- no broad workload superiority proof
+- no energy reduction evidence
+
+Start the next cycle from fresh branches based on origin/main. Do not touch dirty local main. Please propose Task 123.
+```
+
+## Next Codex Start Prompt
+
+```text
+Task 123
+
+You are working on KORA.
+
+Repository:
+/Users/albertkim/02_PROJECTS/05_KORA
+
+Public truth:
+origin/main
+
+Current public HEAD:
+0082f35c80625740ea0f05c3a41fc1ecf49a0ba1
+
+Published release:
+v0.2.0-alpha
+
+Release URL:
+https://github.com/hkalbertkim/KORA/releases/tag/v0.2.0-alpha
+
+Important constraints:
+- Do not touch the dirty local main.
+- Use a fresh clean worktree and branch based on origin/main.
+- Do not push directly to main.
+- Do not create a Git tag unless explicitly instructed.
+- Do not create a GitHub Release unless explicitly instructed.
+- Do not update package version unless explicitly instructed.
+- Do not make production cost, real API-cost, production benchmark, full runtime-integrated benchmark, broad workload superiority, or energy-reduction claims.
+- Completion output must start with the exact label: Implemented Task 123
+
+Recommended next task options:
+- v0.2.1-alpha release polish / repo hygiene / public onboarding
+- v0.3.0-alpha runtime-integrated benchmark design
+
+Start by inspecting origin/main in a fresh worktree. Then implement the selected Task 123 scope, run validation, commit and push a PR branch, and report results.
+```


### PR DESCRIPTION
## Summary

Adds the final EOD report for the `v0.2.0-alpha` release day.

The report documents the completed release, validation status, benchmark evidence counters, safe claim boundary, explicit non-claims, artifact policy summary, and next-session ChatGPT/Codex restart prompts.

## Hygiene

- No source changes.
- No release assets.
- No package version changes.
- No tags.
- No raw benchmark JSON artifacts.
- No production/API-cost/energy claims.
