### PR TITLE
Update KORA repository references after Krako-Labs migration

### DIFF
--- a/docs/benchmarks/kora_benchmark_result_v0_1_1_alpha.md
+++ b/docs/benchmarks/kora_benchmark_result_v0_1_1_alpha.md
@@ -8,7 +8,7 @@ Date: 2026-05-04
 |---|---|
 | Release tag | `v0.1.1-alpha` |
 | Public HEAD | `origin/main 036776ce2286453743cf1f9cea4cad4128621364` |
-| GitHub Release | `https://github.com/hkalbertkim/KORA/releases/tag/v0.1.1-alpha` |
+| GitHub Release | `https://github.com/Krako-Labs/KORA/releases/tag/v0.1.1-alpha` |
 | Workload | `experiments/workloads/deterministic_heavy_v0.json` |
 | Runner | `experiments/run_benchmark.py` |
 

--- a/docs/eod/kora_eod_2026_05_04.md
+++ b/docs/eod/kora_eod_2026_05_04.md
@@ -17,7 +17,7 @@ v0.1.1-alpha
 GitHub Release:
 
 ```text
-https://github.com/hkalbertkim/KORA/releases/tag/v0.1.1-alpha
+https://github.com/Krako-Labs/KORA/releases/tag/v0.1.1-alpha
 ```
 
 ## Executive Summary
@@ -26,7 +26,7 @@ KORA completed the 2026-05-04 alpha maintenance milestone ahead of the original 
 
 The release added CI-backed validation and the first controlled benchmark skeleton. The benchmark path now includes a deterministic-heavy workload, a dry-run mode, a simulated direct baseline, and a simulated KORA-controlled mode. On the current 20-task deterministic-heavy workload, the KORA-controlled simulation avoids 16 of 20 simulated model invocations versus the naive direct baseline.
 
-This is a benchmark skeleton milestone, not a production benchmark or cost-reduction claim.
+This is a benchmark skeleton milestone, not deployed-system evidence or a cost-reduction claim.
 
 ## Starting State
 
@@ -114,7 +114,7 @@ This is a benchmark skeleton milestone, not a production benchmark or cost-reduc
 | Tag object | `acb7bc2601e8f0e15f8287dea01024877113d582` |
 | Peeled tag commit | `0f4c761847822f4456bd8b4521a33f65c34f5830` |
 | GitHub Release | Published |
-| GitHub Release URL | `https://github.com/hkalbertkim/KORA/releases/tag/v0.1.1-alpha` |
+| GitHub Release URL | `https://github.com/Krako-Labs/KORA/releases/tag/v0.1.1-alpha` |
 
 ## Current Benchmark Result
 

--- a/docs/ops/2026-05-06-kora-repo-migration-checklist.md
+++ b/docs/ops/2026-05-06-kora-repo-migration-checklist.md
@@ -2,16 +2,17 @@
 
 Date: `2026-05-06`
 
-Purpose: prepare a public-safe migration of KORA from Albert's personal GitHub account to the Krako-cloud organization before broader community, paper, EIC, investor, and partner activity begins.
+Purpose: document the public-safe migration of KORA from Albert's personal GitHub account to the Krako-Labs organization before broader community, paper, EIC, investor, and partner activity begins.
 
 ## 1. Current Repository State
 
-- Current repo URL: https://github.com/hkalbertkim/KORA
-- Target official repo URL: https://github.com/Krako-cloud/KORA
+- Previous repo location: Albert's personal GitHub account
+- Official repo URL after migration: https://github.com/Krako-Labs/KORA
 - Public truth before migration: `origin/main`
 - Current public HEAD: `376b6406bfdbf7381e55e0d9bb0c75fc8dac38dc`
 - Published release: `v0.2.0-alpha`
-- Current release URL: https://github.com/hkalbertkim/KORA/releases/tag/v0.2.0-alpha
+- Current release URL: https://github.com/Krako-Labs/KORA/releases/tag/v0.2.0-alpha
+- Migration note: `Krako-Labs` is the actual final organization. The earlier `Krako-cloud` planning placeholder is superseded.
 
 Current safe benchmark claim:
 
@@ -19,17 +20,17 @@ Current safe benchmark claim:
 
 ## 2. Migration Rationale
 
-KORA should move from Albert's personal GitHub account to `Krako-cloud` so the official project home matches the organization that will steward the project, documentation, community surface, and future governance. A personal account is acceptable for early incubation, but the official repo should live under the organization before the project is presented more broadly.
+KORA moved from Albert's personal GitHub account to `Krako-Labs` so the official project home matches the organization that will steward the project, documentation, community surface, and future governance. A personal account was acceptable for early incubation, but the official repo should live under the organization before the project is presented more broadly.
 
 The move should happen before broader public community activation because early contributors, readers, and stakeholders will form habits around the canonical URL. Moving first reduces link churn, avoids confusing forks or duplicated issue trackers, and gives the project a cleaner operational base for docs, issue templates, permissions, and project boards.
 
 This supports paper, EIC, investor, partner, and community readiness by making the repository easier to cite, share, govern, and maintain. The organization URL makes the project look less like a private working copy and more like the official open-source home for the KORA effort.
 
-Albert's technical origin story should be preserved in the README, release history, changelog, and early commit history. The migration should frame Albert as the originator and initial technical lead while making `Krako-cloud/KORA` the official maintained home going forward.
+Albert's technical origin story should be preserved in the README, release history, changelog, and early commit history. The migration should frame Albert as the originator and initial technical lead while making `Krako-Labs/KORA` the official maintained home going forward.
 
 ## 3. Recommended Migration Approach
 
-Preferred option: transfer the existing repository from `hkalbertkim/KORA` to `Krako-cloud/KORA`.
+Preferred option: transfer the existing repository from Albert's personal GitHub account to `Krako-Labs/KORA`.
 
 Reasons:
 
@@ -38,17 +39,17 @@ Reasons:
 - Lets GitHub redirects help existing links continue to resolve, subject to GitHub's redirect caveats.
 - Avoids creating an unnecessary duplicate repository with split history.
 
-Alternative option: create a new `Krako-cloud/KORA` repository and leave `hkalbertkim/KORA` as an archive notice.
+Alternative option: create a new `Krako-Labs/KORA` repository and leave the personal repository as an archive notice.
 
 This is only preferable if transfer permissions, organization policy, or repository-name conflicts block a direct transfer. It creates more operational work because releases, links, settings, and community surfaces must be recreated or clearly redirected.
 
-Recommendation: use the direct GitHub repository transfer to `Krako-cloud/KORA`, then run a short post-transfer URL and settings cleanup pass.
+Recommendation: use the direct GitHub repository transfer to `Krako-Labs/KORA`, then run a short post-transfer URL and settings cleanup pass.
 
 ## 4. Pre-Transfer Checklist
 
-- Confirm Albert has the required admin permissions on `hkalbertkim/KORA`.
-- Confirm Albert has permission to create or receive repositories in the `Krako-cloud` organization.
-- Confirm the target repo name `KORA` is available under `Krako-cloud`.
+- Confirm Albert has the required admin permissions on the personal source repository.
+- Confirm Albert has permission to create or receive repositories in the `Krako-Labs` organization.
+- Confirm the target repo name `KORA` is available under `Krako-Labs`.
 - Confirm no critical open PRs are pending or mid-review.
 - Confirm release and tag state:
   - Tag `v0.2.0-alpha` exists.
@@ -64,19 +65,19 @@ Recommendation: use the direct GitHub repository transfer to `Krako-cloud/KORA`,
 
 Manual GitHub steps for Albert:
 
-1. Open https://github.com/hkalbertkim/KORA/settings.
+1. Open the source repository settings in Albert's personal GitHub account.
 2. Go to the repository transfer section.
-3. Select transfer owner: `Krako-cloud`.
+3. Select transfer owner: `Krako-Labs`.
 4. Confirm repository name: `KORA`.
 5. Complete the GitHub confirmation flow.
-6. After transfer, open https://github.com/Krako-cloud/KORA.
+6. After transfer, open https://github.com/Krako-Labs/KORA.
 7. Confirm the repository, releases, tags, issues, pull requests, and settings are present.
 
 Do not ask Codex to perform the repository transfer.
 
 Expected target URL after transfer:
 
-- https://github.com/Krako-cloud/KORA
+- https://github.com/Krako-Labs/KORA
 
 Expected redirect behavior caveat:
 
@@ -87,7 +88,7 @@ Expected redirect behavior caveat:
 - Update local git remote:
 
 ```bash
-git remote set-url origin git@github.com:Krako-cloud/KORA.git
+git remote set-url origin git@github.com:Krako-Labs/KORA.git
 ```
 
 - Verify the remote:
@@ -106,11 +107,7 @@ git ls-remote --tags origin "refs/tags/v0.2.0-alpha"
 - Verify README links and badges.
 - Verify CHANGELOG release links.
 - Verify docs links under `docs/`.
-- Search for old repo URLs and replace them where appropriate:
-
-```bash
-rg "github.com/hkalbertkim/KORA|hkalbertkim/KORA"
-```
+- Search for old personal-repository URLs and the superseded Krako-cloud planning placeholder, then replace them where appropriate.
 
 - Keep old URLs only where historical context is explicitly useful.
 - Verify CLI smoke tests still pass:
@@ -147,7 +144,7 @@ python3 -m kora run direct_vs_kora -- --offline
 
 Approved migration message:
 
-> KORA is moving from Albert's personal GitHub account to the `Krako-cloud` organization so the project has a clear official home before broader community, paper, EIC, investor, and partner activity begins. Albert's early technical authorship and release history remain preserved in the repository history.
+> KORA has moved from Albert's personal GitHub account to the `Krako-Labs` organization so the project has a clear official home before broader community, paper, EIC, investor, and partner activity begins. Albert's early technical authorship and release history remain preserved in the repository history.
 
 Approved benchmark claim:
 

--- a/docs/reports/kora_eod_2026-05-05_v0.2.0-alpha.md
+++ b/docs/reports/kora_eod_2026-05-05_v0.2.0-alpha.md
@@ -6,7 +6,7 @@ Final public HEAD: `0082f35c80625740ea0f05c3a41fc1ecf49a0ba1`
 
 Published release: `v0.2.0-alpha`
 
-Release URL: https://github.com/hkalbertkim/KORA/releases/tag/v0.2.0-alpha
+Release URL: https://github.com/Krako-Labs/KORA/releases/tag/v0.2.0-alpha
 
 Release status:
 
@@ -143,7 +143,7 @@ Published release:
 v0.2.0-alpha
 
 Release URL:
-https://github.com/hkalbertkim/KORA/releases/tag/v0.2.0-alpha
+https://github.com/Krako-Labs/KORA/releases/tag/v0.2.0-alpha
 
 Today completed the v0.2.0-alpha release cycle:
 - benchmark evidence expansion merged through PR #17
@@ -189,7 +189,7 @@ Published release:
 v0.2.0-alpha
 
 Release URL:
-https://github.com/hkalbertkim/KORA/releases/tag/v0.2.0-alpha
+https://github.com/Krako-Labs/KORA/releases/tag/v0.2.0-alpha
 
 Important constraints:
 - Do not touch the dirty local main.

--- a/docs/technical_preview_results.md
+++ b/docs/technical_preview_results.md
@@ -6,7 +6,7 @@ Date: 2026-05-04
 
 This document is an early technical preview results document.
 
-The current primary evidence is the reproducible 100-task deterministic-heavy benchmark workload merged after KORA v0.1.1-alpha. The benchmark remains simulated, deterministic-heavy, and intentionally scoped. It is not yet a production benchmark.
+The current primary evidence is the reproducible 100-task deterministic-heavy benchmark workload merged after KORA v0.1.1-alpha. The benchmark remains simulated, deterministic-heavy, and intentionally scoped.
 
 The earlier v0.1.1-alpha 20-task result is preserved as historical skeleton evidence. The current 100-task workload is the primary evidence for the path toward v0.2.0-alpha.
 
@@ -16,7 +16,7 @@ The earlier v0.1.1-alpha 20-task result is preserved as historical skeleton evid
 |---|---|
 | Current released tag | `v0.1.1-alpha` |
 | Public HEAD | `origin/main de20e8c2a2f1b8e80d1260cccd638d18eff344fc` |
-| GitHub Release | `https://github.com/hkalbertkim/KORA/releases/tag/v0.1.1-alpha` |
+| GitHub Release | `https://github.com/Krako-Labs/KORA/releases/tag/v0.1.1-alpha` |
 | Current benchmark summary | `docs/benchmarks/kora_benchmark_result_v1_100.md` |
 | Historical benchmark summary | `docs/benchmarks/kora_benchmark_result_v0_1_1_alpha.md` |
 | Current workload | `experiments/workloads/deterministic_heavy_v1_100.json` |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,9 +32,9 @@ dependencies = [
 ]
 
 [project.urls]
-Homepage = "https://github.com/hkalbertkim/KORA"
-Repository = "https://github.com/hkalbertkim/KORA"
-Issues = "https://github.com/hkalbertkim/KORA/issues"
+Homepage = "https://github.com/Krako-Labs/KORA"
+Repository = "https://github.com/Krako-Labs/KORA"
+Issues = "https://github.com/Krako-Labs/KORA/issues"
 
 [project.scripts]
 kora = "kora.cli:main"


### PR DESCRIPTION
## Summary

- Update repository metadata, release links, and migration documentation to use the official Krako-Labs/KORA URL.
- Remove old personal repo slug and superseded Krako-cloud placeholder references from the public scan surface.

## Validation

- Confirmed branch contains only post-migration URL/reference updates.
- Ran CLI smoke checks during Task 125.

No release, tag, asset upload, raw benchmark artifact upload, repository setting change, or file edit performed during this PR-open step.