### PR TITLE
Add Albert-Sumanta GitHub sync setup

### DIFF
--- a/.github/ISSUE_TEMPLATE/community-task.md
+++ b/.github/ISSUE_TEMPLATE/community-task.md
@@ -1,0 +1,45 @@
+---
+name: Community task
+about: Track KORA community, outreach, or ecosystem coordination work
+title: "[Community Task] "
+labels: community
+assignees: ""
+---
+
+## Objective
+
+Describe the community or ecosystem task and the intended outcome.
+
+## Channel Checklist
+
+- [ ] GitHub
+- [ ] Telegram
+- [ ] X/Twitter
+- [ ] LinkedIn
+- [ ] Direct outreach
+- [ ] Partner lead
+
+## Draft / Output
+
+Add draft copy, link, screenshot, notes, or expected output here.
+
+## Claim Check
+
+- [ ] Uses approved KORA one-liner
+- [ ] Does not claim production cost reduction
+- [ ] Does not claim real API-cost reduction
+- [ ] Does not claim production benchmark proof
+- [ ] Does not claim energy reduction evidence
+- [ ] Does not claim formal partnership
+- [ ] Does not claim government validation
+
+## Review
+
+- [ ] Needs Albert review
+
+## Done Criteria
+
+- [ ] Output is posted, sent, or otherwise completed
+- [ ] Links or screenshots are attached where useful
+- [ ] Follow-up owner is clear
+- [ ] Any sensitive claims were reviewed before publishing

--- a/.github/ISSUE_TEMPLATE/content-review.md
+++ b/.github/ISSUE_TEMPLATE/content-review.md
@@ -1,0 +1,46 @@
+---
+name: Content review
+about: Review KORA public copy before posting or publication
+title: "[Content Review] "
+labels: content,needs-albert-review
+assignees: ""
+---
+
+## Channel Checklist
+
+- [ ] X/Twitter
+- [ ] LinkedIn
+- [ ] Telegram
+- [ ] GitHub Announcement
+- [ ] GitHub Discussion
+
+## Draft Copy
+
+Paste the draft copy here.
+
+## Intended Audience
+
+- [ ] Developers
+- [ ] AI startup founders
+- [ ] Students
+- [ ] Investors
+- [ ] Cloud/data center/telco partners
+- [ ] Government or innovation institutions
+
+## Claim Sensitivity
+
+- [ ] Low
+- [ ] Medium
+- [ ] High
+
+## Review Request
+
+- [ ] Albert review requested
+
+## Approval Status
+
+- [ ] Draft
+- [ ] Needs Albert review
+- [ ] Approved
+- [ ] Published
+- [ ] Rejected / revise

--- a/.github/ISSUE_TEMPLATE/partner-lead.md
+++ b/.github/ISSUE_TEMPLATE/partner-lead.md
@@ -1,0 +1,54 @@
+---
+name: Partner lead
+about: Track KORA ecosystem, partner, investor, or institutional leads
+title: "[Partner Lead] "
+labels: partner-lead,claim-sensitive
+assignees: ""
+---
+
+## Lead Name / Organisation
+
+Add name and organisation.
+
+## Type
+
+- [ ] AI startup
+- [ ] Student/community group
+- [ ] University/lab
+- [ ] Government/innovation institution
+- [ ] Cloud/data center/telco
+- [ ] Investor/accelerator
+
+## Source
+
+How did this lead come in?
+
+## Interest
+
+What did they ask about or respond to?
+
+## Current Status
+
+- [ ] Cold
+- [ ] Warm
+- [ ] Intro call requested
+- [ ] Intro call done
+- [ ] Use case identified
+- [ ] LOI candidate
+- [ ] Partner discussion
+
+## Notes
+
+Add context, constraints, links, and relevant history.
+
+## Next Action
+
+What should happen next?
+
+## Owner
+
+Who owns the next action?
+
+## Claim Boundary Reminder
+
+Do not describe interest as validation unless formally signed or documented.

--- a/docs/community/2026-05-06-albert-sumanta-github-sync.md
+++ b/docs/community/2026-05-06-albert-sumanta-github-sync.md
@@ -1,0 +1,182 @@
+# Albert-Sumanta GitHub Sync Setup
+
+Date: `2026-05-06`
+
+## Purpose
+
+This document defines the initial GitHub-based operating system for Albert and Sumanta to coordinate KORA community, content, outreach, benchmark feedback, and partner-interest tracking.
+
+## Why GitHub Is The Source Of Truth
+
+GitHub should be the source of truth because KORA is an open-source project and the repository is where public work, documentation, issues, discussions, and evidence boundaries can be reviewed together. Telegram and other channels can move quickly, but decisions, follow-ups, public claims, and reusable process should resolve back into GitHub.
+
+Using GitHub as the operating base gives KORA:
+
+- a durable public record of community and evidence work
+- clear ownership for follow-ups
+- reviewable content and claim boundaries
+- a way to turn feedback into issues, docs, and benchmark tasks
+- a shared workflow for Albert, Sumanta, and future contributors
+
+## Role Split
+
+Albert:
+
+- technical authority
+- final claim approval
+- investor, EIC, and partner narrative owner
+- final reviewer for claim-sensitive content
+- final reviewer for benchmark and evidence wording
+
+Sumanta:
+
+- community and ecosystem activation
+- outreach coordination
+- feedback collection
+- early builder engagement
+- first-pass issue triage for community and content work
+- weekly community feedback summary preparation
+
+## What Lives In GitHub Issues
+
+- community tasks
+- content drafts needing review
+- outreach follow-ups
+- benchmark feedback from users
+- partner-interest tracking
+- questions that need a concrete owner or decision
+- recurring weekly sync issues
+
+## What Lives In GitHub Discussions
+
+- open-ended community questions
+- onboarding threads
+- public feedback from builders
+- early use-case discussion
+- announcement follow-ups
+- non-urgent ecosystem conversation
+
+## What Lives In GitHub Projects
+
+- status tracking for community and evidence operations
+- weekly priorities
+- blocked work
+- Albert review queue
+- published or completed community items
+- partner-lead follow-up status
+
+Recommended GitHub Project board:
+
+- `KORA Community & Evidence Ops`
+
+Recommended columns:
+
+- Backlog
+- Ready
+- In Progress
+- Needs Albert Review
+- Approved
+- Published / Done
+- Blocked
+
+## What Lives In docs/community
+
+- operating manuals
+- weekly summary templates
+- approved language references
+- community workflows
+- onboarding guides for contributors and community coordinators
+- durable summaries of recurring process decisions
+
+## What Stays In Telegram
+
+- lightweight daily coordination
+- quick community responses
+- informal reminders
+- real-time handoff notes
+- pointers back to GitHub issues, discussions, or docs
+
+Telegram should not be the only place where important decisions, claim approvals, partner status, or benchmark feedback live.
+
+## Recommended Labels
+
+- `community`
+- `content`
+- `outreach`
+- `benchmark`
+- `partner-lead`
+- `github-discussion`
+- `telegram`
+- `linkedin`
+- `twitter`
+- `needs-albert-review`
+- `approved`
+- `blocked`
+- `claim-sensitive`
+
+## Sumanta Permission Model
+
+Sumanta can:
+
+- create issues
+- comment in discussions
+- update project status
+- open PRs for `docs/community` changes
+
+Sumanta should not:
+
+- push directly to `main`
+- change repository settings
+- publish claim-sensitive content without review
+- describe partner or institutional interest as validation unless signed or documented
+
+## Content Approval Levels
+
+Level A: free to publish using approved language.
+
+Examples:
+
+- community reminders
+- links to existing docs
+- neutral announcements about open issues
+- invitations to try examples or share feedback
+
+Level B: needs Albert review.
+
+Examples:
+
+- benchmark summaries
+- investor-facing copy
+- EIC-facing copy
+- partner-facing copy
+- posts mentioning results, impact, adoption, or institutional interest
+
+Level C: prohibited or special approval required.
+
+Examples:
+
+- claims outside the approved benchmark boundary
+- statements implying signed partners without documentation
+- statements implying institutional validation without documentation
+- release announcements not tied to an actual release
+- technical claims that have not been reviewed by Albert
+
+## Weekly Rhythm
+
+- Daily lightweight GitHub/project updates.
+- Two content review windows per week.
+- One weekly sync issue.
+- One weekly community feedback summary.
+
+## First 10 Suggested GitHub Issues To Create Manually
+
+1. Create the `KORA Community & Evidence Ops` project board.
+2. Add recommended community and claim-boundary labels.
+3. Enable or configure GitHub Discussions for KORA community questions.
+4. Draft the first approved KORA community one-liner and short description.
+5. Prepare a pinned GitHub Discussion for early builder feedback.
+6. Create the first weekly community sync issue.
+7. Collect first-run feedback from developers using the CLI examples.
+8. Collect benchmark evidence questions from early readers.
+9. Draft Sumanta's first LinkedIn/X/Twitter content batch for Albert review.
+10. Create the first partner-interest tracking issue using the partner lead template.

--- a/docs/community/2026-05-06-community-sync-issue-template.md
+++ b/docs/community/2026-05-06-community-sync-issue-template.md
@@ -1,0 +1,73 @@
+# Community Sync Issue Template
+
+Use this Markdown body when creating the weekly KORA community sync issue.
+
+Weekly sync issue title format:
+
+```text
+[Community Sync] Week of YYYY-MM-DD
+```
+
+## This Week's Focus
+
+- 
+
+## Community Activity
+
+Telegram:
+
+- 
+
+GitHub:
+
+- 
+
+X/Twitter:
+
+- 
+
+LinkedIn:
+
+- 
+
+Direct outreach:
+
+- 
+
+## Metrics
+
+| Metric | Count / Status |
+|---|---:|
+| GitHub stars |  |
+| GitHub issues/discussions |  |
+| Telegram members |  |
+| Benchmark runs reported |  |
+| Outreach messages sent |  |
+| Replies received |  |
+| Pilot/LOI candidates |  |
+
+## Questions From Community
+
+- 
+
+## Potential Leads
+
+| Name/Org | Type | Source | Interest | Next action | Owner |
+|---|---|---|---|---|---|
+|  |  |  |  |  |  |
+
+## Content Drafts Needing Albert Review
+
+- 
+
+## Blockers
+
+- 
+
+## Albert Decisions Needed
+
+- 
+
+## Next Week's Actions
+
+- 


### PR DESCRIPTION
## Summary

- Add GitHub issue templates for community tasks, content review, and partner leads.
- Add community docs for Albert-Sumanta GitHub sync operations and weekly community sync issues.

## Validation

- Task 126 validation passed before this PR: git status, git log, git diff --check, and unsafe-claim scan.

No release, tag, asset upload, raw benchmark artifact upload, settings change, issue creation, project creation, or collaborator change performed.