### PR TITLE
Add README migration notice after Krako Labs move

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,18 @@
 
 ---
 
+## Migration Notice
+
+KORA moved into the lab.
+
+KORA started in Albert Kim's personal workshop. It now lives in its official Krako Labs home:
+
+https://github.com/Krako-Labs/KORA
+
+Same code. Same history. Bigger mission.
+
+For issues, discussions, pull requests, benchmarks, and community feedback, please use this repository.
+
 KORA is a standalone open-source execution control layer for AI systems. It structures requests into task graphs, runs deterministic work first, and escalates to model inference only when needed.
 
 KORA v0.1 is terminal-first and developer-oriented.

--- a/docs/ops/2026-05-06-kora-repo-migration-checklist.md
+++ b/docs/ops/2026-05-06-kora-repo-migration-checklist.md
@@ -82,6 +82,7 @@ Expected target URL after transfer:
 Expected redirect behavior caveat:
 
 - GitHub usually redirects old repository URLs after a transfer, but redirects can be affected by future repository creation, rename, or ownership changes. Treat redirects as compatibility support, not as the canonical long-term URL.
+- Do not recreate the previous personal repository as a placeholder repository because GitHub's automatic redirect from the old repository location may be broken if a new repository is created there.
 
 ## 6. Post-Transfer Technical Checklist
 


### PR DESCRIPTION
## Summary

- Add a concise README migration notice for the move into the official Krako Labs repository.
- Add a redirect caveat to the repository migration checklist.

## Validation

- Task 127 validation passed before this PR: git status, git diff --check, old URL scan, and README notice sanity check.

No release, tag, asset upload, raw benchmark artifact upload, settings change, issue creation, project creation, collaborator change, or placeholder repository creation performed.