### PR TITLE
Add KORA claim registry and public language guide

### DIFF
--- a/docs/claims/kora-claim-registry.md
+++ b/docs/claims/kora-claim-registry.md
@@ -1,0 +1,157 @@
+# KORA Claim Registry
+
+## Purpose
+
+This document is the source of truth for what KORA can and cannot claim publicly.
+
+It applies to README content, releases, documentation, GitHub Discussions, X/Twitter, LinkedIn, Telegram, investor materials, EIC/grant materials, partner outreach, paper drafts, and LLM-assisted writing.
+
+All public or externally reusable KORA language should be checked against this registry before publication.
+
+## Official Category Language
+
+Category:
+
+- AI Execution Control Layer
+
+Vision phrase:
+
+- Inference OS for AI systems
+
+Approved category one-liner:
+
+> KORA is an AI Execution Control Layer that structures AI requests into verifiable task graphs before escalating to expensive model inference.
+
+Approved technical one-liner:
+
+> KORA routes deterministic work away from unnecessary model invocation through task graphs, validation, fallback, and telemetry.
+
+Approved OSS one-liner:
+
+> KORA is an open-source infrastructure project for building inference-first AI systems.
+
+## Current Approved Benchmark Claim
+
+Use exactly:
+
+> In a reproducible 100-task deterministic-heavy benchmark workload, KORA-controlled execution avoided 80 of 100 simulated model invocations versus a naive direct baseline.
+
+Supporting detail:
+
+- Workload: `experiments/workloads/deterministic_heavy_v1_100.json`
+- Generator: `experiments/generate_workload.py`
+- Seed: `42`
+- Total tasks: `100`
+- Deterministic/no-model tasks: `80`
+- Fallback/model-candidate tasks: `20`
+- Direct-baseline simulated model invocations: `100`
+- KORA-controlled simulated model invocations: `20`
+- Avoided simulated model invocations: `80`
+- Avoided invocation rate: `80%`
+- Deterministic outputs checked: `80`
+- Mismatches: `0`
+- Fallback/model-candidate skipped: `20`
+
+## Claim Status Table
+
+| Claim | Status | Allowed wording | Forbidden wording | Required evidence before escalation | Approved channels |
+|---|---|---|---|---|---|
+| Category claim: KORA as AI Execution Control Layer | Approved | KORA is an AI Execution Control Layer. | KORA has already become the dominant execution-control standard. | Broader adoption evidence before dominance language. | README, docs, discussions, social, investor/EIC intro, partner intro |
+| vLLM analogy claim | Review required | KORA aims to become category-defining for execution control before unnecessary inference is invoked, similar to how vLLM became category-defining for LLM serving. | KORA is already the vLLM of execution control. | Adoption, deployment, and ecosystem evidence before stronger analogy. | Docs, investor/EIC drafts, partner drafts with Albert review |
+| v0.2.0-alpha release claim | Approved | KORA v0.2.0-alpha is a prerelease with bounded deterministic-heavy benchmark evidence. | v0.2.0-alpha proves broad operational impact. | Additional release evidence before expanded impact wording. | Releases, changelog, README, docs |
+| deterministic-heavy benchmark claim | Approved with exact wording | In a reproducible 100-task deterministic-heavy benchmark workload, KORA-controlled execution avoided 80 of 100 simulated model invocations versus a naive direct baseline. | KORA reduced real costs by 80%. | Runtime-integrated and real billing evidence before cost language. | README, docs, release notes, social with exact wording |
+| runtime-integrated benchmark claim | Not approved yet | Runtime-integrated benchmark evidence is planned. | KORA has full runtime-integrated benchmark proof. | Merged runtime-integrated benchmark, result artifacts, validation commands, reviewed report. | Internal roadmap until evidence exists |
+| real application workload replay claim | Not approved yet | Real application workload replay is a future evidence track. | KORA has proven results on real application workloads. | Reproducible real workload replay, source path, validation, report. | Internal roadmap until evidence exists |
+| production cost reduction claim | Prohibited | Not currently supported. | KORA proves production cost reduction. | Production deployment evidence, baseline, billing data, methodology, review. | None until evidence exists |
+| real API cost reduction claim | Prohibited | Not currently supported. | KORA proves real API-cost reduction. | Real API usage data, billing methodology, baseline, review. | None until evidence exists |
+| cloud/data center validation claim | Prohibited unless documented | Exploratory infrastructure conversations may be tracked internally. | KORA is validated by cloud/data center partners. | Signed or documented validation, approved wording, source record. | Partner docs only after approval |
+| energy efficiency claim | Prohibited | Not currently supported. | KORA proves energy reduction. | Energy methodology, measurement, baseline, third-party review if needed. | None until evidence exists |
+| government/institution interest claim | Review required | Exploratory discussion or early interest, if true. | Government validation or government-approved KORA. | Written documentation and Albert approval. | Internal tracking or approved partner/EIC material |
+| partner/LOI claim | Review required | LOI candidate or partner discussion, if true. | Signed partnership unless actually signed. | Signed document or written record, approved wording. | Partner tracker, approved outreach |
+| community adoption claim | Review required | Early community feedback or initial contributors, if documented. | KORA has guaranteed adoption. | Public metrics, issue/discussion activity, contributor evidence. | Community updates with review if numeric |
+| paper/publication claim | Review required | Technical report in preparation. | Peer-reviewed proof or accepted paper unless accepted/published. | Accepted publication, DOI/proceedings link, paper artifact. | Paper roadmap, docs, investor/EIC drafts with review |
+
+## vLLM Analogy Boundaries
+
+Allowed:
+
+> KORA aims to become category-defining for execution control before unnecessary inference is invoked, similar to how vLLM became category-defining for LLM serving.
+
+Forbidden:
+
+- KORA is already the vLLM of execution control.
+- KORA has achieved vLLM-level adoption.
+- KORA is proven at vLLM scale.
+
+## Do-Not-Claim List
+
+Do not claim:
+
+- production cost reduction proof
+- real API-cost reduction proof
+- production benchmark proof
+- full runtime-integrated benchmark evidence
+- broad workload superiority proof
+- energy reduction evidence
+- formal government validation
+- signed cloud/data center/telco partnership unless actually signed
+- guaranteed adoption
+- guaranteed future funding
+- EIC approval or grant success
+- investor commitment unless documented
+
+## Channel Review Levels
+
+Level A: Safe to publish without Albert review.
+
+Examples:
+
+- General KORA category one-liner.
+- GitHub quickstart invitation.
+- Benchmark run invitation.
+- Open-source contribution invitation.
+- "unpaid early contributor role" language.
+
+Level B: Requires Albert review.
+
+Examples:
+
+- Benchmark numeric claim.
+- vLLM analogy.
+- EIC/grant wording.
+- investor-facing wording.
+- partner/cloud/data center/telco wording.
+- government/institution interest wording.
+- paper authorship/contribution wording.
+
+Level C: Prohibited or special approval required.
+
+Examples:
+
+- cost reduction percentage.
+- production proof.
+- energy savings proof.
+- signed partnership claim.
+- formal government validation.
+- "guaranteed" language.
+- unapproved fundraising/investor commitment language.
+
+## LLM-Assisted Writing Rules
+
+- Any LLM-generated KORA content must be checked against this registry.
+- LLMs must not invent evidence, partners, grants, investors, publications, or benchmark results.
+- LLM-generated content mentioning numbers, partners, grants, or papers requires Albert review.
+- If an LLM is uncertain whether a phrase is allowed, it should mark the phrase for Albert review instead of publishing it.
+
+## Update Policy
+
+This registry must be updated when new evidence is merged into `origin/main`.
+
+Claim escalation requires:
+
+- evidence
+- source path
+- validation command
+- review
+
+No claim should be escalated based on aspiration, roadmap, informal interest, or private conversation alone.

--- a/docs/claims/kora-public-language-guide.md
+++ b/docs/claims/kora-public-language-guide.md
@@ -1,0 +1,140 @@
+# KORA Public Language Guide
+
+## Purpose
+
+This is a practical copywriting guide for public KORA communication.
+
+Use it with `docs/claims/kora-claim-registry.md` when drafting README copy, GitHub Discussions, social posts, Telegram updates, investor/EIC language, partner outreach, and paper-related text.
+
+## Approved Short Descriptions
+
+README:
+
+> KORA is an open-source AI Execution Control Layer that structures AI requests into verifiable task graphs before escalating to expensive model inference.
+
+GitHub Discussions:
+
+> KORA helps developers explore deterministic-first execution, validation, fallback, and telemetry before model calls become the default path.
+
+X/Twitter:
+
+> KORA is building an AI Execution Control Layer: task graphs, deterministic routing, validation, fallback, and telemetry before unnecessary inference.
+
+LinkedIn:
+
+> KORA is an open-source infrastructure project for AI execution control. It structures requests into verifiable task graphs and escalates to model inference only when needed.
+
+Telegram:
+
+> KORA is the open-source AI Execution Control Layer project. Use this repo for issues, discussions, PRs, benchmark feedback, and community coordination: https://github.com/Krako-Labs/KORA
+
+Investor intro:
+
+> KORA is building the AI Execution Control Layer: infrastructure that structures AI requests into task graphs, routes deterministic work away from unnecessary model invocation, and preserves validation and telemetry before inference escalation.
+
+EIC/grant intro:
+
+> KORA is an open-source AI infrastructure project focused on execution control before inference escalation, with a bounded public benchmark evidence path and a roadmap toward runtime-integrated evaluation.
+
+Partner intro:
+
+> KORA explores how AI systems can control execution before inference escalation through task graphs, deterministic routing, validation, fallback, and telemetry.
+
+Paper intro:
+
+> KORA studies execution control for AI systems by converting requests into task graphs, routing deterministic work before model invocation, and preserving validation and telemetry for reproducible evaluation.
+
+## Approved Migration Note
+
+> KORA has moved into its official Krako Labs home at https://github.com/Krako-Labs/KORA.
+
+> Same code, same history, bigger mission.
+
+## Approved Benchmark Wording
+
+Short version:
+
+> In a reproducible 100-task deterministic-heavy benchmark workload, KORA-controlled execution avoided 80 of 100 simulated model invocations versus a naive direct baseline.
+
+Technical version:
+
+> On `experiments/workloads/deterministic_heavy_v1_100.json`, generated from seed `42`, the direct-baseline mode counted 100 simulated model invocations while KORA-controlled mode counted 20. Deterministic outputs checked: 80. Mismatches: 0. Fallback/model-candidate skipped: 20.
+
+Social media version:
+
+> In KORA's reproducible 100-task deterministic-heavy benchmark, KORA-controlled execution avoided 80 of 100 simulated model invocations versus a naive direct baseline. This is simulated benchmark evidence, not a production claim.
+
+Paper-safe version:
+
+> In the current deterministic-heavy benchmark workload, KORA-controlled execution avoids 80 of 100 simulated model invocations relative to a naive direct baseline, with 80 deterministic outputs checked and 0 mismatches.
+
+Investor/EIC-safe version:
+
+> KORA's current public evidence is a reproducible simulated benchmark: in a 100-task deterministic-heavy workload, KORA-controlled execution avoided 80 of 100 simulated model invocations versus a naive direct baseline. The next evidence track is runtime-integrated evaluation.
+
+## Prohibited Rewrites
+
+Do not rewrite:
+
+- "80 of 100 simulated model invocations avoided" as "80% cost reduction."
+- "simulated model invocation" as "real API call."
+- "benchmark workload" as "production workload."
+- "interest" as "partnership."
+- "planned validation" as "validated."
+
+## Public Contributor Role Boundary Language
+
+Approved language:
+
+> These are unpaid early open-source contributor roles, not employment positions.
+
+> Future paid roles, grants, internships, or contributor programs may be considered if funding becomes available, but they are not guaranteed.
+
+## Partner / Government / Institution Language
+
+Allowed:
+
+- early interest
+- exploratory discussion
+- potential pilot candidate
+- LOI candidate
+
+Forbidden unless documented and approved:
+
+- validated by
+- partnered with
+- officially backed by
+- government-approved
+
+## Paper / Publication Language
+
+Allowed:
+
+- technical report in preparation
+- paper roadmap
+- community benchmark contribution program planned
+
+Forbidden unless actually accepted or published:
+
+- published paper
+- accepted conference paper
+- peer-reviewed proof
+
+## Example LLM Prompt For Safe KORA Writing
+
+```text
+You are writing public KORA content.
+
+Use these approved one-liners:
+- KORA is an AI Execution Control Layer that structures AI requests into verifiable task graphs before escalating to expensive model inference.
+- KORA routes deterministic work away from unnecessary model invocation through task graphs, validation, fallback, and telemetry.
+
+Preserve this benchmark wording exactly unless asked to omit the benchmark:
+"In a reproducible 100-task deterministic-heavy benchmark workload, KORA-controlled execution avoided 80 of 100 simulated model invocations versus a naive direct baseline."
+
+Do not rewrite simulated benchmark evidence as production evidence, cost reduction, real API-cost reduction, energy reduction, partner validation, government validation, investor commitment, or publication proof.
+
+If a draft mentions numbers, partners, grants, investors, institutions, papers, or adoption, mark it for Albert review.
+
+If evidence is missing, write "needs review" instead of inventing support.
+```


### PR DESCRIPTION
## Summary

- Add the KORA Claim Registry as the source of truth for approved and prohibited claims.
- Add the KORA Public Language Guide with safe channel-specific wording and LLM-assisted writing rules.

## Validation

- Task 130 validation passed before this PR: git status, git log, git diff --check, and unsafe-claim scan.

No release, tag, asset upload, raw benchmark artifact upload, settings change, issue creation, project creation, collaborator change, or file edit performed during this PR-open step.