### PR TITLE
Add KORA OSS operating system documentation

### DIFF
--- a/docs/community/2026-05-06-ai-assisted-contribution-guide.md
+++ b/docs/community/2026-05-06-ai-assisted-contribution-guide.md
@@ -1,0 +1,63 @@
+# KORA AI-Assisted Contribution Guide
+
+Date: `2026-05-06`
+
+## Purpose
+
+AI-assisted and vibe-coding contributions are welcome, but they must remain accountable.
+
+The contributor is responsible for the quality, correctness, safety, and maintainability of the submitted work.
+
+## Rules
+
+- Start from an open GitHub issue.
+- Keep PRs small.
+- Explain whether AI tools were used.
+- Run validation commands.
+- Do not modify benchmark claims, release claims, partner claims, or the claim registry unless explicitly assigned.
+- Do not submit large generated code dumps.
+- The contributor is responsible for output quality.
+
+## Recommended Workflow
+
+1. Pick an issue.
+2. Comment with intent.
+3. Fork or create a branch.
+4. Implement a small change.
+5. Run tests/checks.
+6. Open a PR.
+7. Disclose AI assistance.
+8. Respond to review.
+
+## Good First AI-Assisted Work
+
+- docs fixes
+- examples
+- benchmark result templates
+- FAQ
+- small CLI usability improvements
+- tests
+- tutorials
+
+## Work Requiring Special Approval
+
+- core architecture
+- benchmark methodology
+- claim wording
+- release docs
+- investor/EIC/partner language
+- security-sensitive areas
+
+## Reusable AI Prompt
+
+```text
+You are helping me contribute to KORA, an open-source AI Execution Control Layer project.
+
+Work only on the issue scope I provide.
+Keep the change small.
+Do not change benchmark claims, release claims, partner claims, or claim registry wording unless the issue explicitly asks for that.
+Do not invent evidence, partners, grants, investors, publications, or benchmark results.
+Prefer existing repo style.
+After drafting, list files changed and validation commands I should run.
+Mark anything claim-sensitive for Albert review.
+```

--- a/docs/community/2026-05-06-kora-open-roles.md
+++ b/docs/community/2026-05-06-kora-open-roles.md
@@ -1,0 +1,127 @@
+# KORA Open Roles
+
+Date: `2026-05-06`
+
+## Purpose
+
+KORA is opening early unpaid OSS contributor roles so builders, researchers, writers, and community operators can help shape the project through GitHub.
+
+## Required Disclaimer
+
+These are unpaid early open-source contributor roles, not employment positions. Future paid roles, grants, internships, or contributor programs may be considered if funding becomes available, but they are not guaranteed.
+
+## Open Roles
+
+### Early Builder
+
+- Who it is for: developers who want to try KORA and report usability friction.
+- What they do: run examples, open feedback issues, suggest improvements.
+- Required skills: basic Python and GitHub familiarity.
+- Expected weekly time: 1-3 hours.
+- First recommended task: run the quickstart and report one improvement.
+- GitHub entry point: Discussions or a feedback issue.
+- Review requirement: Albert review for benchmark or claim wording.
+
+### Benchmark Runner
+
+- Who it is for: people comfortable running scripts and reporting results.
+- What they do: run benchmark commands, document reproducibility notes, report failures.
+- Required skills: command line, Python, careful reporting.
+- Expected weekly time: 2-4 hours.
+- First recommended task: reproduce the current deterministic-heavy benchmark flow.
+- GitHub entry point: Benchmark Results discussion or benchmark issue.
+- Review requirement: Albert review before public numeric claims.
+
+### Documentation Contributor
+
+- Who it is for: writers and developers who can make docs clearer.
+- What they do: improve README, guides, FAQs, and onboarding docs.
+- Required skills: Markdown and careful reading.
+- Expected weekly time: 1-3 hours.
+- First recommended task: fix one confusing section or add one small clarification.
+- GitHub entry point: docs issue or docs PR.
+- Review requirement: claim-sensitive docs require Albert review.
+
+### Example Builder
+
+- Who it is for: developers who learn by building small examples.
+- What they do: create focused examples for KORA execution patterns.
+- Required skills: Python and basic testing.
+- Expected weekly time: 2-5 hours.
+- First recommended task: propose one small example in an issue.
+- GitHub entry point: example issue and PR.
+- Review requirement: technical review; claim-sensitive copy requires Albert review.
+
+### AI-Assisted Contributor
+
+- Who it is for: contributors using LLMs or vibe-coding tools responsibly.
+- What they do: make small docs, examples, tests, or usability improvements.
+- Required skills: ability to review generated output and run checks.
+- Expected weekly time: 1-4 hours.
+- First recommended task: pick a small docs or test issue.
+- GitHub entry point: labeled issue and PR.
+- Review requirement: disclose AI assistance and respond to review.
+
+### Community Moderator
+
+- Who it is for: people who can keep discussions welcoming and organized.
+- What they do: route questions, point to docs, collect recurring feedback.
+- Required skills: communication, GitHub Discussions familiarity.
+- Expected weekly time: 1-3 hours.
+- First recommended task: summarize one discussion thread.
+- GitHub entry point: Discussions and community issues.
+- Review requirement: Albert review for claim-sensitive responses.
+
+### Developer Advocate
+
+- Who it is for: builders who can explain KORA to other builders.
+- What they do: draft tutorials, walkthroughs, demo notes, and feedback summaries.
+- Required skills: technical communication and basic KORA usage.
+- Expected weekly time: 2-5 hours.
+- First recommended task: draft one short tutorial outline.
+- GitHub entry point: content review issue.
+- Review requirement: Albert review before publishing externally.
+
+### Research Contributor
+
+- Who it is for: researchers interested in execution control and benchmarks.
+- What they do: review methodology, propose experiments, contribute reproducibility notes.
+- Required skills: research rigor and clear writing.
+- Expected weekly time: 2-6 hours.
+- First recommended task: review the category thesis or benchmark policy.
+- GitHub entry point: research/paper discussion or issue.
+- Review requirement: paper and benchmark claims require Albert review.
+
+### Partner Scout
+
+- Who it is for: ecosystem connectors who can identify potential use cases.
+- What they do: collect leads and use-case signals without overstating status.
+- Required skills: outreach discipline and careful note-taking.
+- Expected weekly time: 1-3 hours.
+- First recommended task: create one partner-lead issue from a real signal.
+- GitHub entry point: partner-lead issue template.
+- Review requirement: Albert review for partner-facing language.
+
+### Translation Contributor
+
+- Who it is for: contributors who can localize docs accurately.
+- What they do: translate approved docs and identify unclear source wording.
+- Required skills: language fluency and Markdown.
+- Expected weekly time: 1-4 hours.
+- First recommended task: propose one translation target.
+- GitHub entry point: translation issue or PR.
+- Review requirement: technical and claim-sensitive wording review.
+
+## How To Express Interest
+
+- Use GitHub Discussions for public interest.
+- Email or a private form may be used for resume/profile sharing if available later.
+- Do not post personal resumes or private data in public GitHub issues.
+- Interested people should share GitHub/LinkedIn, role of interest, and one small contribution they can make in the next 2 weeks.
+
+## Contributor Recognition
+
+- PR authorship.
+- Release notes where appropriate.
+- Acknowledgements where appropriate.
+- Paper authorship only under the paper contribution policy.

--- a/docs/ops/2026-05-06-kora-ops-coordinator-handbook-ko.md
+++ b/docs/ops/2026-05-06-kora-ops-coordinator-handbook-ko.md
@@ -1,0 +1,102 @@
+# KORA 운영 코디네이터 핸드북
+
+작성일: `2026-05-06`
+
+## 1. 목적
+
+이 문서는 한국 운영 담당자가 개발자가 아니어도 GitHub 중심으로 KORA 운영을 도울 수 있게 하기 위한 안내서입니다.
+
+KORA 운영 담당자는 코드를 직접 작성하는 사람이 아니라, GitHub 이슈, 보드, 주간 리포트, 관심자 정리, 문서 정리를 통해 프로젝트 흐름을 안정적으로 만드는 역할입니다.
+
+## 2. 역할 정의
+
+역할 이름:
+
+- KORA Operations Coordinator
+
+역할 성격:
+
+- 개발 담당이 아니라 운영/정리/프로젝트 관리 담당입니다.
+- 영어가 약해도 GitHub board, issue, weekly report, lead tracking, 문서 정리를 담당할 수 있습니다.
+- 중요한 claim, 외부 공개 문구, 투자자/EIC/파트너 관련 표현은 Albert review로 넘깁니다.
+
+## 3. 주요 업무
+
+- GitHub Project board 정리
+- issue 상태 업데이트
+- weekly community sync 정리
+- Sumanta와 Albert 사이 follow-up 정리
+- 지원자/관심자 목록 정리
+- EOD/SOD 자료 정리
+- 한국어 내부 운영 문서 관리
+- claim-sensitive 내용은 Albert review로 넘김
+
+## 4. 하면 안 되는 일
+
+- `main` branch에 직접 push
+- release/tag 생성
+- claim 임의 확장
+- partnership/government validation 표현
+- 투자자/EIC 문구 임의 작성
+- 개인정보를 public issue에 올리기
+
+## 5. 주간 루틴
+
+월요일:
+
+- board 정리
+- 지난주 미완료 issue 확인
+- blocked 상태 확인
+
+수요일:
+
+- review queue 정리
+- Albert review가 필요한 항목 모으기
+- Sumanta follow-up 확인
+
+금요일:
+
+- weekly summary 작성
+- 다음 주 action 정리
+- EOD/SOD 문서 확인
+
+## 6. GitHub 초보 운영 가이드
+
+Issues:
+
+- 해야 할 일을 하나씩 정리하는 공간입니다.
+- 각 issue에는 목표, 담당자, 완료 기준이 있어야 합니다.
+
+Pull Requests:
+
+- 코드나 문서 변경을 main에 합치기 전에 검토하는 공간입니다.
+- 운영 담당자는 PR 상태를 확인하고 review가 필요한 사람에게 알려줄 수 있습니다.
+
+Projects:
+
+- 여러 issue와 PR의 진행 상태를 한눈에 보는 보드입니다.
+- Backlog, In Progress, Needs Review, Done 같은 칸으로 관리합니다.
+
+Discussions:
+
+- 질문, 아이디어, 커뮤니티 대화를 위한 공간입니다.
+- 바로 작업할 일이 되면 issue로 옮깁니다.
+
+Wiki:
+
+- 초보자용 안내서나 handbook을 두기 좋은 공간입니다.
+- 공식 claim/evidence 문서는 repo의 `docs/`에 둡니다.
+
+Labels:
+
+- issue나 PR의 종류를 표시하는 태그입니다.
+- 예: `community`, `benchmark`, `needs-albert-review`, `claim-sensitive`
+
+## 7. Albert에게 Review 요청해야 하는 경우
+
+- 숫자/benchmark claim
+- partner/government/investor/EIC 표현
+- 외부 공개 문구
+- 논문 저자/기여자 관련 내용
+- release note 또는 public announcement
+- claim registry와 충돌할 수 있는 표현

--- a/docs/ops/2026-05-06-kora-oss-operating-system.md
+++ b/docs/ops/2026-05-06-kora-oss-operating-system.md
@@ -1,0 +1,197 @@
+# KORA OSS Operating System v0.1
+
+Date: `2026-05-06`
+
+## Purpose
+
+KORA's goal is to grow into a category-building OSS infrastructure project.
+
+GitHub is the operating HQ, not just code storage.
+
+KORA should support development, community, paper, EIC, investor, partner, and grant readiness from one evidence base.
+
+## OSS Ambition
+
+KORA aims to define the AI Execution Control Layer category.
+
+KORA uses the vision phrase "Inference OS for AI systems."
+
+vLLM may be used as an analogy for category ambition, but KORA must not claim it has achieved vLLM-level adoption.
+
+## GitHub Feature Map
+
+| Feature | KORA use |
+|---|---|
+| README | Public front door, quickstart, category framing, and current official repo note. |
+| Issues | Concrete tasks, bug reports, docs work, benchmark feedback, community follow-up, and claim-sensitive review requests. |
+| Labels | Routing layer for area, role, difficulty, review status, claim sensitivity, and evidence type. |
+| Projects | Shared operating boards for core development and community/evidence operations. |
+| Discussions | Community Q&A, announcements, ideas, use cases, contributor onboarding, and benchmark result discussion. |
+| Wiki | Beginner-friendly onboarding and handbook material. |
+| Pull Requests | Reviewable implementation and documentation changes. |
+| Releases | Versioned public release notes and bounded evidence summaries. |
+| Milestones | Release and evidence-cycle grouping. |
+| Actions | Automated tests, checks, and future benchmark validation workflows. |
+| Security | Responsible handling of security reports and sensitive areas. |
+| CODEOWNERS | Future ownership routing for review responsibility. |
+| Issue templates | Structured intake for community tasks, content review, partner leads, bugs, and docs. |
+| PR templates | Future standard checklist for validation, claim safety, and review ownership. |
+
+## Operating Tracks
+
+| Track | Owner type | Primary artifacts | GitHub tools used | Review requirements |
+|---|---|---|---|---|
+| CORE | Technical owner | Code, tests, examples, architecture docs | Issues, PRs, Actions, Projects, Milestones | Technical review; claim-sensitive docs require Albert review |
+| PAPER | Research owner | Technical reports, benchmark reports, authorship policy | Issues, Discussions, PRs, docs/paper | Albert review for claims, authorship, and evidence wording |
+| EIC | Narrative owner | Grant-ready summaries, evidence packets, roadmap docs | Issues, Projects, docs/context, docs/claims | Albert review required |
+| INVESTOR | Narrative owner | Intro language, evidence summaries, category thesis | docs/claims, docs/context, Issues | Albert review required |
+| PARTNER | Ecosystem owner | Lead notes, use cases, pilot candidates, LOI candidates | Issues, Discussions, Projects | Albert review for external wording |
+| COMMUNITY | Community owner | Discussions, open roles, weekly sync issues, feedback summaries | Issues, Discussions, Projects, docs/community | Claim-sensitive content requires Albert review |
+| OPS | Operations owner | Weekly reports, board hygiene, EOD/SOD artifacts | Projects, Issues, docs/ops, docs/context | Keep internal/private boundaries clear |
+
+## GitHub Projects Model
+
+Recommended project board: `KORA Core Development`
+
+Recommended columns:
+
+- Backlog
+- Ready
+- In Progress
+- Needs Review
+- Blocked
+- Done
+
+Recommended project board: `KORA Community & Evidence Ops`
+
+Recommended columns:
+
+- Backlog
+- Ready
+- In Progress
+- Needs Albert Review
+- Approved
+- Published / Done
+- Blocked
+
+## Labels Model
+
+Area:
+
+- `area:core`
+- `area:docs`
+- `area:benchmark`
+- `area:examples`
+- `area:community`
+- `area:paper`
+- `area:ops`
+
+Role:
+
+- `role:early-builder`
+- `role:benchmark-runner`
+- `role:docs-contributor`
+- `role:example-builder`
+- `role:ai-assisted`
+- `role:moderator`
+- `role:research`
+
+Difficulty:
+
+- `good first issue`
+- `difficulty:easy`
+- `difficulty:medium`
+- `difficulty:advanced`
+
+Review:
+
+- `needs-review`
+- `needs-albert-review`
+- `approved`
+
+Status:
+
+- `blocked`
+- `ready`
+- `in-progress`
+- `done`
+
+Claim sensitivity:
+
+- `claim-sensitive`
+- `claim-safe`
+
+Evidence type:
+
+- `evidence:benchmark`
+- `evidence:runtime`
+- `evidence:feedback`
+- `evidence:case-study`
+- `evidence:partner-interest`
+
+## Issue Triage Workflow
+
+1. Intake the issue or external signal.
+2. Apply area, role, difficulty, status, and claim-sensitivity labels.
+3. Assign an owner or mark owner needed.
+4. Clarify done criteria.
+5. Link to `docs/claims/` if claim-sensitive.
+6. Move through the relevant project board.
+7. Close with evidence, merged PR, linked discussion, or follow-up issue.
+
+## PR Workflow
+
+- Use branch names like `task###_short_scope`.
+- Keep PRs small and reviewable.
+- Run validation commands appropriate to scope.
+- Name the review owner.
+- Do not push directly to `main`.
+- Claim-sensitive docs require Albert review.
+- PRs should explain files changed, validation run, and claim-safety status.
+
+## Discussions Workflow
+
+Recommended categories:
+
+- Announcements
+- Q&A
+- Benchmark Results
+- Use Cases
+- Ideas
+- Contributors
+- Research & Paper
+
+Discussions are for open-ended conversation. Issues are for owned work with done criteria.
+
+## Wiki Workflow
+
+The Wiki is for beginner-friendly onboarding and handbook material.
+
+Official claim, evidence, release, and operating docs live in the repository under `docs/` so they can be reviewed through PRs.
+
+## Evidence Intake Workflow
+
+Benchmark results, user feedback, use cases, and partner interest should not remain only in Telegram, social media, email, or direct conversations.
+
+Route evidence into GitHub:
+
+- Benchmark result -> Discussion or Issue, then reviewed docs if useful.
+- User feedback -> Discussion or Issue.
+- Use case -> Discussion, Issue, or docs/community summary.
+- Partner interest -> partner-lead issue template or private tracker if sensitive.
+- Claim-sensitive evidence -> link to `docs/claims/` and request Albert review.
+
+## Weekly Cadence
+
+- Weekly community sync issue.
+- Weekly metrics snapshot.
+- Weekly Albert review queue.
+- Monthly OSS report.
+- EOD/SOD internal context flow.
+
+## Public / Private Boundary
+
+- Public repo docs are public-facing unless clearly marked internal.
+- Personal data and resumes should not be posted in public issues.
+- Partner or government interest should not be overstated.
+- Internal EOD/SOD prompts are internal operating artifacts.

--- a/docs/paper/2026-05-06-kora-authorship-and-contribution-policy.md
+++ b/docs/paper/2026-05-06-kora-authorship-and-contribution-policy.md
@@ -1,0 +1,98 @@
+# KORA Authorship And Contribution Policy
+
+Date: `2026-05-06`
+
+## Purpose
+
+This policy defines fair authorship and contribution rules for KORA papers, technical reports, benchmark reports, and community evidence.
+
+It is intended to make contribution expectations clear before paper, technical report, benchmark appendix, or community evidence work begins.
+
+## Contribution Types
+
+- core architecture contribution
+- substantial code contribution
+- benchmark methodology contribution
+- reproducibility validation
+- real workload case study contribution
+- writing/review contribution
+- minor docs fixes
+- GitHub issue/comment feedback
+
+## Authorship Levels
+
+Core author:
+
+- leads the intellectual, technical, empirical, or writing direction of the work
+- participates in drafting, review, and final approval
+
+Co-author candidate:
+
+- makes a substantial intellectual, technical, or empirical contribution
+- may become a co-author after review and approval by the lead author
+
+Acknowledged contributor:
+
+- contributes useful implementation, review, feedback, data, reproducibility work, or documentation support
+- does not meet co-author criteria
+
+Community benchmark contributor:
+
+- contributes reproducible benchmark runs, workload cases, or validation notes that may be cited or summarized
+
+General community participant:
+
+- participates in discussions, stars the repo, asks questions, or shares general feedback
+
+## Co-Author Criteria
+
+Co-authorship requires substantial intellectual, technical, or empirical contribution and review/approval by the lead author.
+
+Examples may include:
+
+- designing core architecture or methodology
+- contributing substantial implementation used in the paper
+- creating benchmark methodology or reproducibility protocol
+- providing a real workload case study with usable data and documentation
+- writing or substantially revising technical sections
+
+## Acknowledgement Criteria
+
+Acknowledgement may be appropriate for:
+
+- useful code review
+- reproducibility validation
+- issue reports that materially improve the work
+- documentation or editorial support
+- community benchmark contributions
+- feedback that shapes examples or evaluation framing
+
+## What Does Not Qualify By Itself
+
+- GitHub star
+- minor typo fix
+- generic comment
+- Telegram chat message
+- simple benchmark run without usable data
+
+## Tracking Mechanism
+
+Contributions should be tracked through:
+
+- GitHub issues
+- Pull Requests
+- GitHub Discussions
+- documented benchmark reports
+
+Paper-related contributions should reference issue, PR, discussion, or report links.
+
+## Paper Roadmap Connection
+
+Potential paper and report stages:
+
+- technical report
+- arXiv preprint
+- conference/journal submission
+- community benchmark appendix
+
+Authorship and acknowledgement decisions should be revisited at each stage.


### PR DESCRIPTION
## Summary

- Add KORA OSS Operating System documentation for GitHub-as-HQ operations.
- Add open unpaid contributor roles, AI-assisted contribution rules, Korean ops coordinator handbook, and paper authorship policy.

## Validation

- Task 131 validation passed before this PR: git status, git log, git diff --check, and unsafe-claim scan.

No release, tag, asset upload, raw benchmark artifact upload, settings change, issue creation, project creation, collaborator change, or file edit performed during this PR-open step.