### PR TITLE
Add KORA GitHub platform setup plan

### DIFF
--- a/docs/ops/2026-05-06-kora-discussions-and-wiki-plan.md
+++ b/docs/ops/2026-05-06-kora-discussions-and-wiki-plan.md
@@ -1,0 +1,201 @@
+# KORA Discussions And Wiki Plan
+
+Date: `2026-05-06`
+
+## Purpose
+
+Discussions and Wiki should help turn external interest into structured community participation.
+
+Discussions are for conversation and early signal collection. Wiki is for beginner-friendly onboarding. Official evidence and claim language remain in versioned repository docs.
+
+## GitHub Discussions Categories
+
+### Announcements
+
+Purpose:
+
+- share official project updates and links to releases, docs, and roadmap items
+
+Example posts:
+
+- release note link
+- new contributor guide link
+- benchmark evidence update link
+
+Moderation rule:
+
+- official claims must follow `docs/claims/`
+
+Convert to issue when:
+
+- a reply identifies actionable work or a docs gap
+
+### Q&A
+
+Purpose:
+
+- answer user and contributor questions
+
+Example posts:
+
+- install questions
+- first-run issues
+- architecture questions
+
+Moderation rule:
+
+- answer with links when possible; mark uncertain claims for review
+
+Convert to issue when:
+
+- a question reveals a bug, missing docs, or reproducible failure
+
+### Benchmark Results
+
+Purpose:
+
+- collect reproducibility reports and benchmark questions
+
+Example posts:
+
+- benchmark command output
+- environment report
+- result discrepancy
+
+Moderation rule:
+
+- benchmark results should include environment and command details
+
+Convert to issue when:
+
+- a result suggests a bug, docs issue, or methodology change
+
+### Use Cases
+
+Purpose:
+
+- collect real-world scenarios and possible workload examples
+
+Example posts:
+
+- AI app routing scenario
+- deterministic preprocessing idea
+- validation-heavy workflow
+
+Moderation rule:
+
+- do not present use-case interest as validation
+
+Convert to issue when:
+
+- a use case can become an example, workload, or benchmark task
+
+### Ideas
+
+Purpose:
+
+- collect proposals before they become scoped work
+
+Example posts:
+
+- CLI improvement idea
+- docs improvement idea
+- workflow extension idea
+
+Moderation rule:
+
+- ask for concrete expected behavior
+
+Convert to issue when:
+
+- scope, owner, and done criteria are clear
+
+### Contributors
+
+Purpose:
+
+- help new contributors find roles and first tasks
+
+Example posts:
+
+- introduction
+- role interest
+- first contribution question
+
+Moderation rule:
+
+- no personal resumes in public issues/discussions
+
+Convert to issue when:
+
+- a contributor is ready to take a concrete task
+
+### Research & Paper
+
+Purpose:
+
+- discuss methodology, reproducibility, and paper roadmap questions
+
+Example posts:
+
+- benchmark methodology question
+- related work suggestion
+- reproducibility concern
+
+Moderation rule:
+
+- paper/publication claims require review
+
+Convert to issue when:
+
+- a research question becomes a tracked paper or benchmark task
+
+### AI-assisted Contributions
+
+Purpose:
+
+- guide contributors using LLMs or vibe-coding tools
+
+Example posts:
+
+- safe workflow question
+- prompt improvement
+- generated PR review question
+
+Moderation rule:
+
+- contributors remain accountable for AI-generated output
+
+Convert to issue when:
+
+- a proposed AI-assisted contribution has a narrow scope
+
+## Wiki Plan
+
+Recommended pages:
+
+- Start Here
+- What is KORA?
+- How to Join
+- Community Roles
+- How to Run the Benchmark
+- How to Open an Issue
+- How to Submit a Pull Request
+- AI-assisted Contribution Rules
+- Weekly Community Rhythm
+- Claim Boundaries
+- FAQ
+
+## Repo Docs Versus Wiki Boundary
+
+- Official evidence and claims stay in repo docs.
+- Beginner-friendly handbook content can live in Wiki.
+- Important Wiki content should eventually link back to versioned docs.
+- The Wiki should not become the only source for release, claim, or benchmark evidence.
+
+## Moderation Principles
+
+- no unsupported claims
+- no personal resumes in public issues/discussions
+- no partner/government validation language without approval
+- benchmark results should include environment and command details

--- a/docs/ops/2026-05-06-kora-github-actions-roadmap.md
+++ b/docs/ops/2026-05-06-kora-github-actions-roadmap.md
@@ -1,0 +1,59 @@
+# KORA GitHub Actions Roadmap
+
+Date: `2026-05-06`
+
+## Purpose
+
+Actions should gradually protect quality and claim safety as KORA grows.
+
+Automation should start lightweight and advisory, then become stricter when the project has enough contributor volume and stable workflows.
+
+## Phase 1 Actions
+
+- Python smoke test
+- markdown diff/check
+- basic docs link check
+- no old repo URL check
+
+## Phase 2 Actions
+
+- claim-scan workflow
+- benchmark command smoke workflow
+- examples list smoke workflow
+- PR title/checklist validation
+
+## Phase 3 Actions
+
+- release checklist validation
+- paper artifact validation
+- benchmark result schema validation
+- contributor docs validation
+
+## Claim-Scan Candidates
+
+Candidate terms:
+
+- production cost
+- real API
+- energy reduction
+- production benchmark
+- broad workload superiority
+- government validation
+- formal partnership
+- guaranteed
+- proven cost reduction
+
+The workflow should flag these terms for review rather than automatically assuming the surrounding text is unsafe.
+
+## Caution
+
+Actions should not block productive early contribution too aggressively.
+
+Start advisory, then make required checks later.
+
+Early goals:
+
+- catch obvious broken docs
+- catch old repository URLs
+- remind reviewers about claim-sensitive language
+- preserve velocity for small contributor PRs

--- a/docs/ops/2026-05-06-kora-github-platform-setup-plan.md
+++ b/docs/ops/2026-05-06-kora-github-platform-setup-plan.md
@@ -1,0 +1,148 @@
+# KORA GitHub Full-Platform Setup Plan
+
+Date: `2026-05-06`
+
+## Purpose
+
+GitHub is KORA's OSS operating HQ.
+
+This plan defines what should be configured manually on GitHub versus what should live in the repository.
+
+The plan supports development, community, research, EIC/grant readiness, investor readiness, and partner readiness from one shared evidence base.
+
+## Setup Phases
+
+Phase 1: Essential OSS operating foundation.
+
+- Issues, labels, basic project boards, PR workflow, and core docs links.
+
+Phase 2: Community and research activation.
+
+- Discussions, Wiki onboarding, community roles, benchmark feedback intake, and paper/research contribution routing.
+
+Phase 3: Automation and quality gates.
+
+- GitHub Actions for smoke checks, docs checks, claim scanning, and benchmark command checks.
+
+Phase 4: Governance and scale.
+
+- CODEOWNERS, branch protections, maintainer roles, security process, release governance, and contributor programs.
+
+## GitHub Feature Map
+
+| Feature | Purpose | Owner | Public/private boundary | Setup method |
+|---|---|---|---|---|
+| README | Public front door and quickstart. | Albert / maintainers | Public | Repo file |
+| Issues | Track actionable work and feedback. | Track owners | Public unless sensitive | GitHub UI + templates |
+| Labels | Route issues and PRs. | Ops coordinator / maintainers | Public | GitHub UI; documented in repo |
+| Projects | Coordinate work status. | Track owners | Public or private by board | GitHub UI |
+| Discussions | Community Q&A, ideas, and feedback. | Community lead | Public | GitHub UI |
+| Wiki | Beginner handbook and onboarding. | Community/ops | Public if enabled | GitHub UI |
+| Pull Requests | Review code and docs before merge. | Maintainers | Public | GitHub native |
+| PR template | Standardize validation and review. | Maintainers | Public | Repo file |
+| CODEOWNERS | Route required reviews later. | Maintainers | Public | Repo file |
+| Milestones | Group release and evidence cycles. | Maintainers | Public | GitHub UI |
+| Releases | Publish versioned release notes. | Albert / release owner | Public | GitHub UI / gh |
+| Actions | Automate quality checks. | Technical owner | Public check results | Repo files |
+| Security | Receive and track sensitive reports. | Security owner | Private where needed | GitHub UI |
+| Insights | Observe project activity. | Maintainers | Repo-visible metrics | GitHub native |
+
+## Recommended Project Boards
+
+### KORA Core Development
+
+Purpose:
+
+- Track core code, tests, examples, benchmarks, releases, and technical docs.
+
+Columns:
+
+- Backlog
+- Ready
+- In Progress
+- Needs Review
+- Blocked
+- Done
+
+Issue types:
+
+- bugs
+- features
+- tests
+- examples
+- benchmark work
+- release docs
+
+Owners:
+
+- Albert and future technical maintainers.
+
+Review cadence:
+
+- weekly technical review
+- release-cycle review before tags or releases
+
+### KORA Community & Evidence Ops
+
+Purpose:
+
+- Track community, content, outreach, evidence intake, partner-interest routing, and claim-sensitive review.
+
+Columns:
+
+- Backlog
+- Ready
+- In Progress
+- Needs Albert Review
+- Approved
+- Published / Done
+- Blocked
+
+Issue types:
+
+- community tasks
+- content review
+- benchmark feedback
+- partner leads
+- discussion summaries
+- weekly sync issues
+
+Owners:
+
+- Sumanta, ops coordinator, Albert for review-sensitive items.
+
+Review cadence:
+
+- weekly community sync
+- weekly Albert review queue
+
+## Manual Versus Repo-Managed Setup
+
+| Setup type | Items |
+|---|---|
+| Manually configured in GitHub UI | enable Issues, enable Discussions, decide Wiki, create labels, create Projects, create milestones, review branch protection, review collaborator permissions |
+| Tracked as repo files | README, issue templates, future PR template, future CODEOWNERS, Actions workflows |
+| Tracked as docs only | label taxonomy, Discussions/Wiki plan, project board model, manual setup checklist |
+| Future automation candidate | label sync, milestone creation, issue forms, project automation, claim-scan checks |
+
+## Recommended Setup Order
+
+1. Confirm Issues enabled.
+2. Confirm Discussions enabled.
+3. Confirm Wiki enabled if desired.
+4. Create labels.
+5. Create Project board.
+6. Configure Discussions categories.
+7. Add PR template.
+8. Add CODEOWNERS later.
+9. Add basic GitHub Actions later.
+10. Create milestones.
+11. Publish open roles / contributor docs links.
+
+## Governance Notes
+
+- Direct pushes to `main` should be avoided.
+- Claim-sensitive files require Albert review.
+- Partner/government/investor language requires Albert review.
+- Releases and tags should be Albert-controlled until maintainers are added.
+- Manual setup changes should be logged in a future GitHub setup log.

--- a/docs/ops/2026-05-06-kora-label-taxonomy.md
+++ b/docs/ops/2026-05-06-kora-label-taxonomy.md
@@ -1,0 +1,110 @@
+# KORA Label Taxonomy
+
+Date: `2026-05-06`
+
+## Purpose
+
+Labels make KORA issues and PRs navigable for contributors, operators, Sumanta, the Korean ops coordinator, and future maintainers.
+
+Labels should help route work quickly without turning triage into a heavy process.
+
+## Label Groups
+
+Area:
+
+- `area:core`
+- `area:docs`
+- `area:benchmark`
+- `area:community`
+- `area:paper`
+- `area:eic`
+- `area:investor`
+- `area:partner`
+- `area:ops`
+- `area:github`
+
+Type:
+
+- `type:bug`
+- `type:feature`
+- `type:docs`
+- `type:question`
+- `type:discussion`
+- `type:benchmark-result`
+- `type:use-case`
+- `type:outreach`
+- `type:partner-lead`
+- `type:paper-contribution`
+
+Difficulty:
+
+- `good first issue`
+- `help wanted`
+- `difficulty:easy`
+- `difficulty:medium`
+- `difficulty:hard`
+
+Review:
+
+- `needs-albert-review`
+- `needs-technical-review`
+- `needs-community-review`
+- `needs-claim-review`
+
+Status:
+
+- `status:backlog`
+- `status:ready`
+- `status:in-progress`
+- `status:blocked`
+- `status:done`
+- `status:deferred`
+
+Claim sensitivity:
+
+- `claim-safe`
+- `claim-sensitive`
+- `do-not-publish`
+
+Evidence:
+
+- `evidence:benchmark`
+- `evidence:runtime`
+- `evidence:real-workload`
+- `evidence:community`
+- `evidence:partner`
+- `evidence:paper`
+
+## Label Usage Rules
+
+- Apply labels during issue intake or PR review.
+- Any maintainer or trusted operator can apply routine labels.
+- `needs-albert-review`, `needs-claim-review`, `claim-sensitive`, and `do-not-publish` trigger Albert review before external publication.
+- Status labels should map to Project board columns where practical.
+- Area labels should be used to route work to the right operating track.
+- Evidence labels should be used when an issue contains benchmark results, runtime notes, user feedback, use cases, partner-interest signals, or paper evidence.
+
+## Initial Recommended Labels To Create First
+
+Create this smaller first batch before the full taxonomy:
+
+- `area:core`
+- `area:docs`
+- `area:benchmark`
+- `area:community`
+- `area:ops`
+- `type:bug`
+- `type:docs`
+- `type:question`
+- `type:benchmark-result`
+- `type:partner-lead`
+- `good first issue`
+- `help wanted`
+- `needs-albert-review`
+- `needs-technical-review`
+- `needs-claim-review`
+- `status:blocked`
+- `claim-sensitive`
+- `claim-safe`
+- `evidence:benchmark`
+- `evidence:community`

--- a/docs/ops/2026-05-06-kora-manual-github-setup-checklist.md
+++ b/docs/ops/2026-05-06-kora-manual-github-setup-checklist.md
@@ -1,0 +1,43 @@
+# KORA Manual GitHub Setup Checklist
+
+Date: `2026-05-06`
+
+## Manual Setup Checklist
+
+- [ ] Enable Issues.
+- [ ] Enable Discussions.
+- [ ] Decide whether to enable Wiki.
+- [ ] Create first label batch.
+- [ ] Create Project board.
+- [ ] Create Discussion categories.
+- [ ] Create milestones.
+- [ ] Review branch protection.
+- [ ] Review collaborator permissions.
+- [ ] Add Sumanta permission later.
+- [ ] Add Korean ops coordinator permission later if applicable.
+
+## Recommended First Milestones
+
+- `v0.2.1-alpha OSS polish`
+- `v0.3.0-alpha runtime-integrated benchmark`
+- `paper-preprint-ready`
+- `eic-short-proposal-ready`
+- `community-alpha`
+
+## Recommended First Project Board Columns
+
+- Backlog
+- Ready
+- In Progress
+- Needs Albert Review
+- Approved
+- Published / Done
+- Blocked
+
+## Manual Setup Notes
+
+- Record what was changed manually in a GitHub setup log later.
+- Do not over-configure before contributors arrive.
+- Keep setup lightweight but intentional.
+- Prefer reversible setup choices during early community activation.
+- Avoid making checks mandatory until the workflow is stable enough for contributors.


### PR DESCRIPTION
## Summary

- Add the KORA GitHub full-platform setup plan.
- Add label taxonomy, Discussions/Wiki plan, GitHub Actions roadmap, and manual setup checklist.

## Validation

- Task 132 validation passed before this PR: git status, git log, git diff --check, and unsafe-claim scan.

No release, tag, asset upload, raw benchmark artifact upload, repository settings change, issue creation, project board creation, collaborator change, or file edit performed during this PR-open step.