### PR TITLE
Add KORA EOD handoff for 2026-05-06

### DIFF
--- a/docs/context/KORA_CURRENT_STATE.md
+++ b/docs/context/KORA_CURRENT_STATE.md
@@ -12,7 +12,7 @@ Public truth:
 
 Current `origin/main` HEAD:
 
-- `f40da300b2518c76538e5669feaa4f66f065f63d`
+- `83bd8d5e013701c0d3aca6703e2a14a5d5189021`
 
 Published release:
 
@@ -37,6 +37,12 @@ Release URL:
 - Task 125/125B URL and remote migration updates merged.
 - Task 126/126B Albert-Sumanta GitHub sync setup merged.
 - Task 127/128/128B README migration notice compacted and merged.
+- Task 129/129B category thesis and context foundation merged.
+- Task 130/130B claim registry and public language guide merged.
+- Task 131/131B OSS operating system documentation merged.
+- Task 132/132B GitHub full-platform setup plan merged.
+- Task 133/133B repository hygiene audit merged.
+- Task 134/134B docs index and navigation map merged.
 
 Note:
 
@@ -51,10 +57,11 @@ Note:
 
 ## Current Recommended Next Tasks
 
-- Create Claim Registry.
-- Create KORA OSS Operating System.
-- Create Sumanta Community OS + LLM Promptbook.
-- Create GitHub full-platform setup plan.
+- Task 136: safe docs cross-link cleanup using `docs/README.md` and the docs navigation map.
+- Task 137: repo-managed PR template and CODEOWNERS draft.
+- Task 138: Sumanta Community OS + LLM Promptbook.
+- Task 139: GitHub manual setup execution log.
+- Task 140: v0.2.1-alpha OSS polish roadmap.
 
 ## Current Safe Benchmark Claim
 

--- a/docs/context/KORA_NEXT_CHATGPT_SOD_PROMPT.md
+++ b/docs/context/KORA_NEXT_CHATGPT_SOD_PROMPT.md
@@ -1,0 +1,68 @@
+# KORA Next ChatGPT SOD Prompt
+
+Copy and paste this prompt into ChatGPT for the next KORA work session.
+
+```text
+You are helping Albert continue KORA after the 2026-05-06 EOD handoff.
+
+Official repo:
+- https://github.com/Krako-Labs/KORA
+
+Public truth:
+- origin/main on Krako-Labs/KORA
+
+Current origin/main HEAD:
+- 83bd8d5e013701c0d3aca6703e2a14a5d5189021
+
+Published release:
+- v0.2.0-alpha
+
+Release URL:
+- https://github.com/Krako-Labs/KORA/releases/tag/v0.2.0-alpha
+
+Today completed:
+- Task 124/124B: repository migration checklist created and merged.
+- Task 125/125B: migrated official repo URL and local remote references to Krako-Labs/KORA.
+- Task 126/126B: Albert-Sumanta GitHub sync setup created and merged.
+- Task 127/128/128B: README migration notice added, then compacted and merged.
+- Task 129/129B: category thesis and context foundation created and merged.
+- Task 130/130B: claim registry and public language guide created and merged.
+- Task 131/131B: OSS operating system, open roles, AI-assisted contribution guide, Korean ops coordinator handbook, and paper contribution policy created and merged.
+- Task 132/132B: GitHub full-platform setup plan, label taxonomy, discussions/wiki plan, Actions roadmap, and manual setup checklist created and merged.
+- Task 133/133B: repository hygiene audit created and merged.
+- Task 134/134B: docs index and navigation map created and merged.
+
+Current strategic position:
+- KORA is a category-building open-source infrastructure project.
+- Official category: AI Execution Control Layer.
+- Vision phrase: Inference OS for AI systems.
+- Official repo: Krako-Labs/KORA.
+- GitHub is the OSS operating HQ for development, community, paper, EIC/grant, investor, partner, and operator readiness.
+
+Current safe benchmark claim:
+“In a reproducible 100-task deterministic-heavy benchmark workload, KORA-controlled execution avoided 80 of 100 simulated model invocations versus a naive direct baseline.”
+
+Do not claim:
+- production cost reduction proof
+- real API-cost reduction proof
+- production benchmark proof
+- full runtime-integrated benchmark evidence
+- broad workload superiority proof
+- energy reduction evidence
+- formal government validation
+- signed cloud/data center/telco partnership unless actually signed
+- guaranteed adoption or funding
+
+Next priorities:
+- Task 136: safe docs cross-link cleanup using docs/README.md and docs/ops/2026-05-06-kora-docs-navigation-map.md.
+- Task 137: repo-managed PR template and CODEOWNERS draft.
+- Task 138: Sumanta Community OS + LLM Promptbook.
+- Task 139: GitHub manual setup execution log.
+- Task 140: v0.2.1-alpha OSS polish roadmap.
+
+Start by summarizing the current state, then propose the next single Codex task prompt.
+
+When responding to Albert, use Korean honorific style.
+When writing Codex task prompts, write them in English.
+Keep claims evidence-safe and distinguish public-facing claims from internal strategy.
+```

--- a/docs/context/KORA_NEXT_CODEX_SOD_PROMPT.md
+++ b/docs/context/KORA_NEXT_CODEX_SOD_PROMPT.md
@@ -1,0 +1,61 @@
+# KORA Next Codex SOD Prompt
+
+Copy and paste this prompt into Codex for the next KORA work session.
+
+```text
+Task ###
+
+Continue KORA from the 2026-05-06 EOD handoff.
+
+Repository:
+- Official repo: https://github.com/Krako-Labs/KORA
+- Local path: /Users/albertkim/02_PROJECTS/05_KORA
+- Public truth: origin/main on Krako-Labs/KORA
+- Current origin/main HEAD: 83bd8d5e013701c0d3aca6703e2a14a5d5189021
+- Published release: v0.2.0-alpha
+- Release URL: https://github.com/Krako-Labs/KORA/releases/tag/v0.2.0-alpha
+
+Operating rules:
+- Do not modify dirty local main.
+- Use a fresh clean worktree and branch from origin/main.
+- Work one task at a time.
+- Do not create a release unless explicitly requested.
+- Do not create a tag unless explicitly requested.
+- Do not upload release assets unless explicitly requested.
+- Do not upload raw benchmark artifacts unless explicitly requested.
+- Do not change repository settings unless explicitly requested.
+- Do not create actual GitHub issues or project boards unless explicitly requested.
+- Do not add collaborators unless explicitly requested.
+- Completion output must start with the exact label: Implemented Task ###
+
+Current strategic position:
+- KORA is a category-building open-source infrastructure project.
+- Official category: AI Execution Control Layer.
+- Vision phrase: Inference OS for AI systems.
+- Official repo: Krako-Labs/KORA.
+- GitHub is the OSS operating HQ.
+
+Current safe benchmark claim:
+“In a reproducible 100-task deterministic-heavy benchmark workload, KORA-controlled execution avoided 80 of 100 simulated model invocations versus a naive direct baseline.”
+
+Claim boundaries:
+- Do not claim production cost reduction proof.
+- Do not claim real API-cost reduction proof.
+- Do not claim production benchmark proof.
+- Do not claim full runtime-integrated benchmark evidence.
+- Do not claim broad workload superiority proof.
+- Do not claim energy reduction evidence.
+- Do not claim formal government validation.
+- Do not claim signed cloud/data center/telco partnership unless actually signed.
+- Do not claim guaranteed adoption or funding.
+
+Recommended first task:
+- Verify whether Task 126 branch is merged; if not, open/merge it.
+- If Task 126 is already merged, start safe docs cross-link cleanup using docs/README.md and docs/ops/2026-05-06-kora-docs-navigation-map.md.
+
+Expected validation baseline:
+- git status -sb
+- git log --oneline -5
+- git diff --check
+- relevant ripgrep scans for old repository URLs and unsafe claim language when documentation changes.
+```

--- a/docs/eod/kora_eod_2026_05_06.md
+++ b/docs/eod/kora_eod_2026_05_06.md
@@ -1,0 +1,97 @@
+# KORA EOD Report - 2026-05-06
+
+## 1. Date And Purpose
+
+Date: `2026-05-06`
+
+Purpose: preserve the end-of-day public state for KORA after the post-release migration, OSS operating, claim-safety, repository hygiene, and documentation navigation work completed on May 6, 2026.
+
+This report is an operating handoff for Albert, ChatGPT, Codex, and future KORA operators.
+
+## 2. Official Repo And Public Truth
+
+Official repo:
+
+- https://github.com/Krako-Labs/KORA
+
+Public truth:
+
+- `origin/main` on `Krako-Labs/KORA`
+
+Current `origin/main` HEAD:
+
+- `83bd8d5e013701c0d3aca6703e2a14a5d5189021`
+
+Published release:
+
+- `v0.2.0-alpha`
+
+Release URL:
+
+- https://github.com/Krako-Labs/KORA/releases/tag/v0.2.0-alpha
+
+## 3. Completed Work Today
+
+- Task 124/124B: repository migration checklist created and merged.
+- Task 125/125B: migrated official repo URL and local remote references to `Krako-Labs/KORA`.
+- Task 126/126B: Albert-Sumanta GitHub sync setup created and merged.
+- Task 127/128/128B: README migration notice added, then compacted and merged.
+- Task 129/129B: category thesis and context foundation created and merged.
+- Task 130/130B: claim registry and public language guide created and merged.
+- Task 131/131B: OSS operating system, open roles, AI-assisted contribution guide, Korean ops coordinator handbook, and paper contribution policy created and merged.
+- Task 132/132B: GitHub full-platform setup plan, label taxonomy, discussions/wiki plan, Actions roadmap, and manual setup checklist created and merged.
+- Task 133/133B: repository hygiene audit created and merged.
+- Task 134/134B: docs index and navigation map created and merged.
+
+## 4. Strategic Outcome
+
+- KORA is now positioned as a category-building OSS project.
+- Official category: AI Execution Control Layer.
+- Vision phrase: Inference OS for AI systems.
+- Official repo: `Krako-Labs/KORA`.
+- GitHub is now treated as the OSS operating HQ.
+
+## 5. Current Safe Benchmark Claim
+
+Approved claim:
+
+> In a reproducible 100-task deterministic-heavy benchmark workload, KORA-controlled execution avoided 80 of 100 simulated model invocations versus a naive direct baseline.
+
+## 6. Do-Not-Claim List
+
+Do not claim:
+
+- production cost reduction proof
+- real API-cost reduction proof
+- production benchmark proof
+- full runtime-integrated benchmark evidence
+- broad workload superiority proof
+- energy reduction evidence
+- formal government validation
+- signed cloud/data center/telco partnership unless actually signed
+- guaranteed adoption or funding
+
+## 7. Important Current Notes
+
+- `hkalbertkim/KORA` should not be recreated as a placeholder repo because it may break GitHub automatic redirect from the old repository location.
+- Old repo URL and incorrect `Krako-cloud` placeholder references have been removed from the official public reference surface, except where migration-history or redirect caveat context is intentional.
+- Task 126/126B is already merged. It was merged through PR #23 and is included in current public truth.
+
+## 8. Recommended Next Priorities
+
+- Task 136: safe docs cross-link cleanup using `docs/README.md` and the docs navigation map.
+- Task 137: repo-managed PR template and CODEOWNERS draft.
+- Task 138: Sumanta Community OS + LLM Promptbook.
+- Task 139: GitHub manual setup execution log.
+- Task 140: v0.2.1-alpha OSS polish roadmap.
+
+## 9. Blockers
+
+None known.
+
+## 10. Next-Day Operating Principle
+
+- Continue one Codex task at a time.
+- Preserve dirty local `main`.
+- Use fresh worktrees from `origin/main`.
+- Keep claim boundaries strict.


### PR DESCRIPTION
## Summary
- Add the 2026-05-06 KORA EOD report
- Add next-day ChatGPT and Codex SOD prompt handoff files
- Update KORA current state to the Task 134B public HEAD

## Validation
- git status -sb
- git log --oneline -5
- git diff --check
- old repo URL scan
- unsafe-claim scan