### PR TITLE
feat: add runtime benchmark evidence packet generator

### DIFF
--- a/examples/runtime_integrated_benchmark/report.py
+++ b/examples/runtime_integrated_benchmark/report.py
@@ -1,0 +1,84 @@
+"""Render a Markdown evidence packet from runtime benchmark JSON."""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+
+def _load_runtime_benchmark_module():
+    script_path = Path(__file__).with_name("run.py")
+    repo_root = Path(__file__).resolve().parents[2]
+    if str(repo_root) not in sys.path:
+        sys.path.insert(0, str(repo_root))
+    spec = importlib.util.spec_from_file_location("runtime_integrated_benchmark_run", script_path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError("failed to load runtime_integrated_benchmark module")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def load_runtime_benchmark_json(path: Path) -> dict[str, Any]:
+    obj = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(obj, dict):
+        raise ValueError("runtime benchmark JSON must contain a JSON object")
+    return obj
+
+
+def write_evidence_packet(
+    input_path: Path,
+    md_out: Path,
+    *,
+    runtime_json_command: str | None = None,
+    report_command: str | None = None,
+) -> str:
+    summary = load_runtime_benchmark_json(input_path)
+    runtime_benchmark = _load_runtime_benchmark_module()
+    packet = runtime_benchmark.render_evidence_packet(
+        summary,
+        runtime_json_command=runtime_json_command,
+        report_command=report_command,
+    )
+    md_out.parent.mkdir(parents=True, exist_ok=True)
+    md_out.write_text(packet, encoding="utf-8")
+    return packet
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Render a KORA runtime benchmark Markdown evidence packet from JSON."
+    )
+    parser.add_argument("--input", required=True, help="runtime benchmark JSON input path")
+    parser.add_argument("--md-out", required=True, help="Markdown evidence packet output path")
+    parser.add_argument(
+        "--runtime-json-command",
+        help="command shown in the report for regenerating the runtime benchmark JSON",
+    )
+    parser.add_argument(
+        "--report-command",
+        help="command shown in the report for regenerating this Markdown report",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    input_path = Path(args.input)
+    md_out = Path(args.md_out)
+    write_evidence_packet(
+        input_path,
+        md_out,
+        runtime_json_command=args.runtime_json_command,
+        report_command=args.report_command,
+    )
+    print(f"Saved runtime benchmark evidence packet: {md_out}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/runtime_integrated_benchmark/run.py
+++ b/examples/runtime_integrated_benchmark/run.py
@@ -4,12 +4,14 @@ from __future__ import annotations
 
 import argparse
 import json
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
 from experiments.run_benchmark import load_workload
 from kora.executor import run_graph
 from kora.task_ir import TaskGraph, normalize_graph, validate_graph
+from kora.telemetry import summarize_run
 
 DEFAULT_WORKLOAD = Path("experiments/workloads/deterministic_heavy_v1_100.json")
 SAFE_CLAIM = (
@@ -200,6 +202,147 @@ def build_runtime_integrated_summary(
     return summary
 
 
+def _format_percent(value: Any) -> str:
+    if isinstance(value, int | float):
+        return f"{float(value) * 100:.0f}%"
+    return "n/a"
+
+
+def render_evidence_packet(
+    summary: dict[str, Any],
+    *,
+    generated_at: str | None = None,
+    runtime_json_command: str | None = None,
+    report_command: str | None = None,
+) -> str:
+    generated_at = generated_at or datetime.now(UTC).replace(microsecond=0).isoformat()
+    runtime_json_command = runtime_json_command or (
+        "python3 -m kora run runtime_integrated_benchmark -- "
+        "--offline --json-out /tmp/kora_runtime_integrated_benchmark.json"
+    )
+    report_command = report_command or (
+        "python3 examples/runtime_integrated_benchmark/report.py "
+        "--input /tmp/kora_runtime_integrated_benchmark.json "
+        "--md-out /tmp/kora_runtime_integrated_benchmark_report.md"
+    )
+    telemetry_summary = summarize_run(summary)
+    stage_counts = telemetry_summary.get("stage_counts", {})
+    if not isinstance(stage_counts, dict):
+        stage_counts = {}
+    stage_rows = [
+        f"| `{stage}` | `{int(count)}` |"
+        for stage, count in sorted(stage_counts.items())
+    ]
+    if not stage_rows:
+        stage_rows = ["| `(none)` | `0` |"]
+
+    lines = [
+        "# KORA v0.3.0-alpha initial runtime-path benchmark evidence packet",
+        "",
+        "Status: initial runtime-path benchmark harness output",
+        f"Generated at: `{generated_at}`",
+        "",
+        "## Source",
+        "",
+        "| Field | Value |",
+        "|---|---|",
+        f"| Benchmark | `{summary.get('benchmark_name', '')}` |",
+        f"| Mode | `{summary.get('mode', '')}` |",
+        f"| Workload | `{summary.get('workload_path', '')}` |",
+        f"| Offline/mock mode | `{summary.get('offline', False)}` |",
+        "",
+        "## Reproduction Commands",
+        "",
+        "```bash",
+        runtime_json_command,
+        report_command,
+        "```",
+        "",
+        "## Runtime Benchmark Counters",
+        "",
+        "| Metric | Value |",
+        "|---|---:|",
+        f"| Total tasks | `{summary.get('total_tasks')}` |",
+        f"| Deterministic route count | `{summary.get('deterministic_route_count')}` |",
+        (
+            "| Fallback/model-candidate route count | "
+            f"`{summary.get('fallback_or_model_candidate_route_count')}` |"
+        ),
+        (
+            "| Simulated baseline model invocations | "
+            f"`{summary.get('simulated_baseline_model_invocations')}` |"
+        ),
+        (
+            "| KORA-controlled model invocations | "
+            f"`{summary.get('kora_controlled_model_invocations')}` |"
+        ),
+        (
+            "| Avoided simulated model invocations | "
+            f"`{summary.get('avoided_simulated_model_invocations')}` |"
+        ),
+        (
+            "| Avoided simulated model invocation rate | "
+            f"`{_format_percent(summary.get('avoided_simulated_model_invocation_rate'))}` |"
+        ),
+        f"| Deterministic outputs checked | `{summary.get('deterministic_outputs_checked')}` |",
+        f"| Mismatch count | `{summary.get('mismatch_count')}` |",
+        f"| Runtime path execution status | `{summary.get('runtime_path_execution_status')}` |",
+        f"| Telemetry event count | `{summary.get('telemetry_event_count')}` |",
+        "",
+        "## Telemetry Summary",
+        "",
+        "| Metric | Value |",
+        "|---|---:|",
+        f"| Total LLM calls | `{telemetry_summary.get('total_llm_calls')}` |",
+        f"| Events OK | `{telemetry_summary.get('events_ok')}` |",
+        f"| Events failed | `{telemetry_summary.get('events_fail')}` |",
+        f"| Events skipped | `{telemetry_summary.get('events_skipped')}` |",
+        f"| Tokens in | `{telemetry_summary.get('tokens_in')}` |",
+        f"| Tokens out | `{telemetry_summary.get('tokens_out')}` |",
+        "",
+        "### Stage Counts",
+        "",
+        "| Stage | Count |",
+        "|---|---:|",
+        *stage_rows,
+        "",
+        "## Safe Current Claim",
+        "",
+        f"> {summary.get('safe_current_claim', SAFE_CLAIM)}",
+        "",
+        "## Claim Boundary",
+        "",
+        str(summary.get("claim_boundary", CLAIM_BOUNDARY)),
+        "",
+        "This packet does not claim production cost reduction proof, real API-cost reduction proof, "
+        "production benchmark proof, full runtime-integrated benchmark evidence, broad workload "
+        "superiority proof, or energy reduction evidence.",
+        "",
+        "Explicit non-claims:",
+        "",
+        "- This is not production benchmark evidence.",
+        "- This does not prove real API-cost reduction.",
+        "- This does not prove production cost reduction.",
+        "- This does not prove broad workload superiority.",
+        "- This does not prove energy reduction.",
+        "- This is not full runtime-integrated benchmark evidence.",
+        "",
+        "## Reproducibility Notes",
+        "",
+        "- The runtime benchmark runs in offline mode.",
+        "- The workload is the deterministic-heavy v1 100-task workload.",
+        "- No external API, network access, or API key is required.",
+        "- Generated outputs should be regenerated locally when reviewing evidence.",
+        "",
+        "## Artifact Policy",
+        "",
+        "Generated JSON and Markdown outputs are reproducible local outputs. Keep them in `/tmp` "
+        "or another ignored path unless a later review explicitly selects a frozen artifact.",
+        "",
+    ]
+    return "\n".join(lines)
+
+
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(
         description="Run the initial KORA runtime-integrated benchmark harness."
@@ -211,6 +354,7 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     )
     parser.add_argument("--offline", action="store_true", help="Run with offline/mock behavior.")
     parser.add_argument("--json-out", help="Optional path for generated raw JSON output.")
+    parser.add_argument("--md-out", help="Optional path for generated Markdown evidence packet.")
     return parser.parse_args(argv)
 
 
@@ -220,11 +364,16 @@ def main(argv: list[str] | None = None) -> int:
         raise SystemExit("This harness currently requires --offline.")
 
     workload_path = Path(args.workload)
-    if not workload_path.is_absolute():
+    if not workload_path.exists() and not workload_path.is_absolute():
         workload_path = _repo_root() / workload_path
 
     json_out = Path(args.json_out) if args.json_out else None
     summary = build_runtime_integrated_summary(workload_path, offline=True, json_out=json_out)
+    if args.md_out:
+        md_out = Path(args.md_out)
+        md_out.parent.mkdir(parents=True, exist_ok=True)
+        md_out.write_text(render_evidence_packet(summary), encoding="utf-8")
+        summary["evidence_packet_path"] = str(md_out)
     printable = {key: value for key, value in summary.items() if key != "events"}
     print(json.dumps(printable, indent=2, sort_keys=True))
     return 0 if summary["ok"] else 1

--- a/experiments/README.md
+++ b/experiments/README.md
@@ -105,7 +105,17 @@ python3 -m kora run runtime_integrated_benchmark -- \
   --json-out /tmp/kora_runtime_integrated_benchmark_v0_3_0.json
 ```
 
-This harness is an initial runtime-integrated benchmark scaffold. It is not production benchmark evidence, does not call external APIs in offline mode, and does not change the current public claim boundary. Raw generated JSON should stay in `/tmp` or another ignored path unless a later release process explicitly selects frozen evidence.
+To generate a local Markdown evidence packet from the saved runtime benchmark JSON, use the report generator:
+
+```bash
+python3 examples/runtime_integrated_benchmark/report.py \
+  --input /tmp/kora_runtime_integrated_benchmark_v0_3_0.json \
+  --md-out /tmp/kora_runtime_integrated_benchmark_v0_3_0.md
+```
+
+The harness can also write the Markdown packet during the runtime run with `--md-out`, but the separate report command is the reproducible evidence-packet path for reviewing an existing JSON run.
+
+This harness is an initial runtime-integrated benchmark scaffold. It is not production benchmark evidence, does not call external APIs in offline mode, and does not change the current public claim boundary. Raw generated JSON and generated Markdown evidence packets should stay in `/tmp` or another ignored path unless a later release process explicitly selects frozen evidence.
 
 ## Artifact Policy
 

--- a/tests/test_runtime_integrated_benchmark.py
+++ b/tests/test_runtime_integrated_benchmark.py
@@ -13,6 +13,16 @@ def _load_runtime_benchmark_module():
     return module
 
 
+def _load_runtime_report_module():
+    script_path = Path("examples/runtime_integrated_benchmark/report.py")
+    spec = importlib.util.spec_from_file_location("runtime_integrated_benchmark_report", script_path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError("failed to load runtime_integrated_benchmark report module")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
 def test_runtime_integrated_benchmark_counts_v1_100() -> None:
     module = _load_runtime_benchmark_module()
 
@@ -45,3 +55,72 @@ def test_runtime_integrated_benchmark_writes_json(tmp_path: Path) -> None:
     assert saved["kora_controlled_model_invocations"] == 20
     assert len(saved["events"]) == 100
     assert "production cost reduction proof" in saved["claim_boundary"]
+
+
+def test_runtime_integrated_benchmark_renders_evidence_packet() -> None:
+    module = _load_runtime_benchmark_module()
+    result = module.build_runtime_integrated_summary(offline=True)
+
+    packet = module.render_evidence_packet(result)
+
+    assert "# KORA v0.3.0-alpha initial runtime-path benchmark evidence packet" in packet
+    assert "| Total tasks | `100` |" in packet
+    assert "| KORA-controlled model invocations | `20` |" in packet
+    assert "| Avoided simulated model invocations | `80` |" in packet
+    assert "| Avoided simulated model invocation rate | `80%` |" in packet
+    assert "| `ADAPTER` | `20` |" in packet
+    assert "| `DETERMINISTIC` | `80` |" in packet
+    assert "No external API, network access, or API key is required." in packet
+    assert "Generated JSON and Markdown outputs are reproducible local outputs." in packet
+    assert "full runtime-integrated benchmark evidence" in packet
+    assert (
+        "python3 -m kora run runtime_integrated_benchmark -- "
+        "--offline --json-out /tmp/kora_runtime_integrated_benchmark.json"
+    ) in packet
+
+
+def test_runtime_integrated_benchmark_report_from_json(tmp_path: Path) -> None:
+    benchmark_module = _load_runtime_benchmark_module()
+    report_module = _load_runtime_report_module()
+    json_path = tmp_path / "runtime_integrated_benchmark.json"
+    md_path = tmp_path / "runtime_integrated_benchmark_report.md"
+
+    benchmark_module.build_runtime_integrated_summary(offline=True, json_out=json_path)
+    packet = report_module.write_evidence_packet(
+        json_path,
+        md_path,
+        runtime_json_command=(
+            "python3 -m kora run runtime_integrated_benchmark -- "
+            "--offline --json-out /tmp/kora_runtime_integrated_benchmark_task167.json"
+        ),
+        report_command=(
+            "python3 examples/runtime_integrated_benchmark/report.py "
+            "--input /tmp/kora_runtime_integrated_benchmark_task167.json "
+            "--md-out /tmp/kora_runtime_integrated_benchmark_task167.md"
+        ),
+    )
+
+    assert md_path.exists()
+    saved = md_path.read_text(encoding="utf-8")
+    assert saved == packet
+    assert "KORA-controlled execution avoided 80 of 100 simulated model invocations" in saved
+    assert "| Total tasks | `100` |" in saved
+    assert "| Deterministic route count | `80` |" in saved
+    assert "| Fallback/model-candidate route count | `20` |" in saved
+    assert "| Simulated baseline model invocations | `100` |" in saved
+    assert "| KORA-controlled model invocations | `20` |" in saved
+    assert "| Avoided simulated model invocations | `80` |" in saved
+    assert "| Avoided simulated model invocation rate | `80%` |" in saved
+    assert "| Deterministic outputs checked | `80` |" in saved
+    assert "| Mismatch count | `0` |" in saved
+    assert "| Runtime path execution status | `ok` |" in saved
+    assert "| Telemetry event count | `100` |" in saved
+    assert "| Total LLM calls | `20` |" in saved
+    assert "| Events OK | `100` |" in saved
+    assert "This packet does not claim production cost reduction proof" in saved
+    assert "This is not production benchmark evidence." in saved
+    assert "This does not prove real API-cost reduction." in saved
+    assert "This does not prove production cost reduction." in saved
+    assert "This does not prove broad workload superiority." in saved
+    assert "This does not prove energy reduction." in saved
+    assert "This is not full runtime-integrated benchmark evidence." in saved


### PR DESCRIPTION
## Summary

- Adds a JSON-to-Markdown evidence packet generator for the initial runtime-path benchmark harness.
- Documents the reproducible review flow: runtime benchmark JSON in `/tmp`, then Markdown evidence packet in `/tmp`.
- Preserves the existing artifact policy by not committing generated benchmark outputs.

## Commands

```bash
python3 -m kora run runtime_integrated_benchmark -- --offline
python3 -m kora run runtime_integrated_benchmark -- --offline --json-out /tmp/kora_runtime_integrated_benchmark_task168.json
python3 examples/runtime_integrated_benchmark/report.py --input /tmp/kora_runtime_integrated_benchmark_task168.json --md-out /tmp/kora_runtime_integrated_benchmark_task168.md
python3 -m kora telemetry --input /tmp/kora_runtime_integrated_benchmark_task168.json --json-out /tmp/kora_runtime_integrated_benchmark_task168.telemetry.json --md-out /tmp/kora_runtime_integrated_benchmark_task168.telemetry.md
```

## Benchmark Counters

- total_tasks: 100
- deterministic_route_count: 80
- fallback_or_model_candidate_route_count: 20
- simulated_baseline_model_invocations: 100
- kora_controlled_model_invocations: 20
- avoided_simulated_model_invocations: 80
- avoided_simulated_model_invocation_rate: 0.8
- deterministic_outputs_checked: 80
- mismatch_count: 0
- runtime_path_execution_status: ok
- telemetry_event_count: 100

## Telemetry Counters

- total_llm_calls: 20
- events_ok: 100
- events_fail: 0
- events_skipped: 0
- stage_counts: ADAPTER 20 / DETERMINISTIC 80

## Files Changed

- `examples/runtime_integrated_benchmark/report.py`
- `examples/runtime_integrated_benchmark/run.py`
- `experiments/README.md`
- `tests/test_runtime_integrated_benchmark.py`

## Validation Results

- `python3 -m pytest tests/test_runtime_integrated_benchmark.py`: 4 passed
- `python3 -m pytest`: 54 passed
- `python3 -m kora run direct_vs_kora -- --offline`: passed
- `python3 -m kora run runtime_integrated_benchmark -- --offline`: passed
- `python3 -m kora run runtime_integrated_benchmark -- --offline --json-out /tmp/kora_runtime_integrated_benchmark_task168.json`: passed
- `python3 examples/runtime_integrated_benchmark/report.py --input /tmp/kora_runtime_integrated_benchmark_task168.json --md-out /tmp/kora_runtime_integrated_benchmark_task168.md`: passed
- `python3 -m kora telemetry --input /tmp/kora_runtime_integrated_benchmark_task168.json --json-out /tmp/kora_runtime_integrated_benchmark_task168.telemetry.json --md-out /tmp/kora_runtime_integrated_benchmark_task168.telemetry.md`: passed

## Claim Boundary

This is a reproducibility/evidence packet for an initial runtime-path benchmark harness.

Safe current claim:

> In a reproducible 100-task deterministic-heavy benchmark workload, KORA-controlled execution avoided 80 of 100 simulated model invocations versus a naive direct baseline.

Explicit non-claims:

- This is not production benchmark evidence.
- This does not prove real API-cost reduction.
- This does not prove production cost reduction.
- This does not prove broad workload superiority.
- This does not prove energy reduction.
- This is not full runtime-integrated benchmark evidence.

## Artifact Policy

- Generated JSON and Markdown outputs remain in `/tmp` or user-provided output paths.
- No generated raw benchmark artifacts are committed.

## Recommended Next Task

Check PR status and merge if safe, then refresh local ChatGPT context after merge.
