### PR TITLE
docs: prepare v0.3.0-alpha release validation packet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,52 @@
 # Changelog
 
+## v0.3.0-alpha runtime evidence release-preparation draft
+
+Status: draft/pre-release preparation. No `v0.3.0-alpha` tag has been created, no GitHub Release has been created, no release assets have been uploaded, and no package version change is included in this draft.
+
+Related docs:
+
+- [Runtime-integrated benchmark evidence architecture](docs/design/v0.3.0-runtime-integrated-benchmark-evidence-architecture.md)
+- [Runtime evidence reviewer guide](docs/reports/v0.3.0-alpha-runtime-evidence-reviewer-guide.md)
+- [v0.3.0-alpha release-readiness checklist](docs/reports/v0.3.0-alpha-release-readiness-checklist.md)
+- [v0.3.0-alpha docs claim audit](docs/reports/v0.3.0-alpha-docs-claim-audit.md)
+- [v0.3.0-alpha release validation packet](docs/reports/v0.3.0-alpha-release-validation-packet.md)
+
+### Runtime evidence path
+
+- Added the runtime-integrated benchmark evidence architecture design for the bounded `v0.3.0-alpha` evidence path.
+- Added the initial runtime-path benchmark harness through `python3 -m kora run runtime_integrated_benchmark -- --offline`.
+- Added runtime benchmark JSON output through `--json-out /tmp/kora_runtime_integrated_benchmark.json`.
+- Added a Markdown evidence packet/report generator through `python3 examples/runtime_integrated_benchmark/report.py --input /tmp/kora_runtime_integrated_benchmark.json --md-out /tmp/kora_runtime_integrated_benchmark.md`.
+- Added telemetry-connected runtime benchmark summaries through `python3 -m kora telemetry --input /tmp/kora_runtime_integrated_benchmark.json --json-out /tmp/kora_runtime_integrated_benchmark.telemetry.json --md-out /tmp/kora_runtime_integrated_benchmark.telemetry.md`.
+- Added a reviewer-facing reproduction guide, a `v0.3.0-alpha` release-readiness checklist, and a docs cross-link and public claim-boundary audit.
+
+### Current runtime benchmark counters
+
+- Workload: `experiments/workloads/deterministic_heavy_v1_100.json`
+- Total tasks: `100`
+- Deterministic route count: `80`
+- Fallback/model-candidate route count: `20`
+- Simulated baseline model invocations: `100`
+- KORA-controlled model invocations: `20`
+- Avoided simulated model invocations: `80`
+- Avoided simulated model invocation rate: `0.8`
+- Deterministic outputs checked: `80`
+- Mismatches: `0`
+- Runtime path execution status: `ok`
+- Telemetry event count: `100`
+
+### Artifact policy
+
+- Generated benchmark JSON, Markdown evidence packets, and telemetry summaries remain in `/tmp` or user-provided ignored output paths unless a future release task explicitly selects and reviews a frozen artifact.
+- Raw generated benchmark artifacts are not committed by this draft.
+- No release assets or raw benchmark artifacts should be uploaded without explicit approval.
+
+### Claim boundary
+
+- Safe claim: In a reproducible 100-task deterministic-heavy benchmark workload, KORA-controlled execution avoided 80 of 100 simulated model invocations versus a naive direct baseline.
+- This draft does not claim production cost reduction proof, real API-cost reduction proof, production benchmark proof, full runtime-integrated benchmark evidence, broad workload superiority proof, energy reduction evidence, formal government validation, signed partner validation, guaranteed adoption, or guaranteed funding.
+
 ## v0.2.0-alpha benchmark evidence expansion
 
 Status: published prerelease.

--- a/docs/README.md
+++ b/docs/README.md
@@ -43,6 +43,8 @@ Future `v0.3.0-alpha` release-readiness checklist: [`docs/reports/v0.3.0-alpha-r
 
 Final `v0.3.0-alpha` docs and claim audit: [`docs/reports/v0.3.0-alpha-docs-claim-audit.md`](reports/v0.3.0-alpha-docs-claim-audit.md)
 
+Draft `v0.3.0-alpha` release validation packet: [`docs/reports/v0.3.0-alpha-release-validation-packet.md`](reports/v0.3.0-alpha-release-validation-packet.md)
+
 Initial runtime-path harness command:
 
 ```bash

--- a/docs/reports/v0.3.0-alpha-release-readiness-checklist.md
+++ b/docs/reports/v0.3.0-alpha-release-readiness-checklist.md
@@ -46,6 +46,7 @@ python3 -m kora telemetry \
 - [ ] Claim boundary review is complete.
 - [ ] README and docs index review is complete.
 - [ ] `CHANGELOG.md` review is complete if a release is planned.
+- [ ] Release validation packet is reviewed: [`docs/reports/v0.3.0-alpha-release-validation-packet.md`](v0.3.0-alpha-release-validation-packet.md).
 - [ ] Release notes draft uses only approved bounded language.
 
 ## Expected Runtime Benchmark Counters
@@ -109,4 +110,5 @@ python3 -m kora telemetry \
 - [Benchmark artifact policy](benchmark_artifact_policy.md)
 - [KORA claim registry](../claims/kora-claim-registry.md)
 - [KORA public language guide](../claims/kora-public-language-guide.md)
+- [v0.3.0-alpha release validation packet](v0.3.0-alpha-release-validation-packet.md)
 - [Documentation index](../README.md)

--- a/docs/reports/v0.3.0-alpha-release-validation-packet.md
+++ b/docs/reports/v0.3.0-alpha-release-validation-packet.md
@@ -1,0 +1,118 @@
+# v0.3.0-alpha Release Validation Packet
+
+Validation date: 2026-05-07
+
+Public HEAD reviewed: `0e777b56eb384e3b4675df42a5966ca162309670`
+
+Status: release-preparation validation packet for a future `v0.3.0-alpha` release decision. This packet prepares for release review only. It does not approve or create a tag, GitHub Release, package version change, release asset upload, raw benchmark artifact upload, or claim expansion.
+
+## Release-Preparation Status
+
+- Validation packet prepared.
+- No tag created.
+- No GitHub Release created.
+- No release assets uploaded.
+- No raw benchmark artifacts uploaded.
+- No package version change included.
+
+## Files Reviewed
+
+- `README.md`
+- `CHANGELOG.md`
+- `docs/README.md`
+- `experiments/README.md`
+- `docs/design/v0.3.0-runtime-integrated-benchmark-evidence-architecture.md`
+- `docs/reports/benchmark_artifact_policy.md`
+- `docs/reports/v0.3.0-alpha-runtime-evidence-reviewer-guide.md`
+- `docs/reports/v0.3.0-alpha-release-readiness-checklist.md`
+- `docs/reports/v0.3.0-alpha-docs-claim-audit.md`
+- `examples/runtime_integrated_benchmark/run.py`
+- `examples/runtime_integrated_benchmark/report.py`
+- `tests/test_runtime_integrated_benchmark.py`
+- `docs/telemetry-and-observability.md`
+
+## Validation Commands
+
+- `python3 -m pytest`
+- `python3 -m kora run direct_vs_kora -- --offline`
+- `python3 -m kora run runtime_integrated_benchmark -- --offline`
+- `python3 -m kora run runtime_integrated_benchmark -- --offline --json-out /tmp/kora_runtime_integrated_benchmark_task179.json`
+- `python3 examples/runtime_integrated_benchmark/report.py --input /tmp/kora_runtime_integrated_benchmark_task179.json --md-out /tmp/kora_runtime_integrated_benchmark_task179.md`
+- `python3 -m kora telemetry --input /tmp/kora_runtime_integrated_benchmark_task179.json --json-out /tmp/kora_runtime_integrated_benchmark_task179.telemetry.json --md-out /tmp/kora_runtime_integrated_benchmark_task179.telemetry.md`
+
+Validation result: passed on 2026-05-07.
+
+- `python3 -m pytest`: 54 passed.
+- `python3 -m kora run direct_vs_kora -- --offline`: passed.
+- `python3 -m kora run runtime_integrated_benchmark -- --offline`: passed.
+- Runtime JSON generation to `/tmp/kora_runtime_integrated_benchmark_task179.json`: passed.
+- Markdown evidence packet generation to `/tmp/kora_runtime_integrated_benchmark_task179.md`: passed.
+- Telemetry JSON and Markdown generation to `/tmp/kora_runtime_integrated_benchmark_task179.telemetry.json` and `/tmp/kora_runtime_integrated_benchmark_task179.telemetry.md`: passed.
+
+## Expected Runtime Benchmark Counters
+
+| Counter | Expected value |
+|---|---:|
+| `total_tasks` | `100` |
+| `deterministic_route_count` | `80` |
+| `fallback_or_model_candidate_route_count` | `20` |
+| `simulated_baseline_model_invocations` | `100` |
+| `kora_controlled_model_invocations` | `20` |
+| `avoided_simulated_model_invocations` | `80` |
+| `avoided_simulated_model_invocation_rate` | `0.8` |
+| `deterministic_outputs_checked` | `80` |
+| `mismatch_count` | `0` |
+| `runtime_path_execution_status` | `ok` |
+| `telemetry_event_count` | `100` |
+
+## Expected Telemetry Counters
+
+| Counter | Expected value |
+|---|---:|
+| `total_llm_calls` | `20` |
+| `events_ok` | `100` |
+| `events_fail` | `0` |
+| `events_skipped` | `0` |
+| `stage_counts.ADAPTER` | `20` |
+| `stage_counts.DETERMINISTIC` | `80` |
+
+## Safe Current Claim
+
+> In a reproducible 100-task deterministic-heavy benchmark workload, KORA-controlled execution avoided 80 of 100 simulated model invocations versus a naive direct baseline.
+
+## Explicit Non-Claims
+
+KORA does not currently claim:
+
+- production cost reduction proof
+- real API-cost reduction proof
+- production benchmark proof
+- full runtime-integrated benchmark evidence yet
+- broad workload superiority proof
+- energy reduction evidence
+- formal government validation
+- signed partner validation unless actually signed and documented
+- guaranteed adoption or funding
+
+## Artifact Policy
+
+- Generated benchmark JSON outputs stay in `/tmp` or user-provided ignored output paths.
+- Generated Markdown evidence packets stay in `/tmp` or user-provided ignored output paths unless a future release task explicitly selects a reviewed public report.
+- Generated telemetry JSON and Markdown summaries stay in `/tmp` or user-provided ignored output paths.
+- Generated raw benchmark artifacts are not committed.
+- No release assets are uploaded without explicit approval.
+
+## Release Restrictions
+
+- No `v0.3.0-alpha` tag without explicit approval.
+- No GitHub Release without explicit approval.
+- No release assets without explicit approval.
+- No raw benchmark artifact upload without explicit approval.
+- No package version change without explicit approval.
+- No production/API-cost/energy, broad workload superiority, formal validation, partner validation, adoption, or funding claim expansion without reviewed evidence and explicit approval.
+
+## Release Decision Checkpoint
+
+This packet prepares for release review only. Any release action requires explicit approval in a later task.
+
+Recommended next step after this packet is reviewed: open a PR for this release-preparation branch, merge if safe, refresh local ChatGPT context, and then request explicit approval before any tag or GitHub Release task.


### PR DESCRIPTION
## Summary

- Adds a draft/pre-release v0.3.0-alpha changelog section.
- Adds a v0.3.0-alpha release validation packet.
- Adds minimal cross-links from docs index and release-readiness checklist.
- Preserves artifact policy, claim boundaries, and release restrictions.
- Does not create any tag, GitHub Release, release asset, package version change, or raw benchmark artifact upload.

## Files changed

- `CHANGELOG.md`
- `docs/README.md`
- `docs/reports/v0.3.0-alpha-release-readiness-checklist.md`
- `docs/reports/v0.3.0-alpha-release-validation-packet.md`

## Commands validated

- `python3 -m pytest`
- `python3 -m kora run direct_vs_kora -- --offline`
- `python3 -m kora run runtime_integrated_benchmark -- --offline`
- `python3 -m kora run runtime_integrated_benchmark -- --offline --json-out /tmp/kora_runtime_integrated_benchmark_task180.json`
- `python3 examples/runtime_integrated_benchmark/report.py --input /tmp/kora_runtime_integrated_benchmark_task180.json --md-out /tmp/kora_runtime_integrated_benchmark_task180.md`
- `python3 -m kora telemetry --input /tmp/kora_runtime_integrated_benchmark_task180.json --json-out /tmp/kora_runtime_integrated_benchmark_task180.telemetry.json --md-out /tmp/kora_runtime_integrated_benchmark_task180.telemetry.md`

## Runtime benchmark counters

- `total_tasks`: 100
- `deterministic_route_count`: 80
- `fallback_or_model_candidate_route_count`: 20
- `simulated_baseline_model_invocations`: 100
- `kora_controlled_model_invocations`: 20
- `avoided_simulated_model_invocations`: 80
- `avoided_simulated_model_invocation_rate`: 0.8
- `deterministic_outputs_checked`: 80
- `mismatch_count`: 0
- `runtime_path_execution_status`: ok
- `telemetry_event_count`: 100

## Telemetry counters

- `total_llm_calls`: 20
- `events_ok`: 100
- `events_fail`: 0
- `events_skipped`: 0
- `stage_counts`: ADAPTER 20 / DETERMINISTIC 80

## Claim boundary

This is release-preparation documentation for a bounded v0.3.0-alpha evidence path.

- It is not production benchmark evidence.
- It does not prove real API-cost reduction.
- It does not prove production cost reduction.
- It does not prove broad workload superiority.
- It does not prove energy reduction.
- It is not full runtime-integrated benchmark evidence.

## Artifact policy

- Generated JSON and Markdown outputs remain in `/tmp` or user-provided output paths.
- No generated raw benchmark artifacts are committed.

## Release restrictions

- No v0.3.0-alpha tag or GitHub Release should be created without explicit approval.
- No release assets or raw benchmark artifacts should be uploaded without explicit approval.
- This PR prepares release review only; it does not perform release action.

## Recommended next task

Check PR status and merge if safe. Then refresh local ChatGPT context after merge. Only after explicit approval, prepare a release approval checkpoint.
