### PR TITLE
docs: add v0.3.0-alpha release approval checkpoint

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -45,6 +45,8 @@ Final `v0.3.0-alpha` docs and claim audit: [`docs/reports/v0.3.0-alpha-docs-clai
 
 Draft `v0.3.0-alpha` release validation packet: [`docs/reports/v0.3.0-alpha-release-validation-packet.md`](reports/v0.3.0-alpha-release-validation-packet.md)
 
+`v0.3.0-alpha` release approval checkpoint: [`docs/reports/v0.3.0-alpha-release-approval-checkpoint.md`](reports/v0.3.0-alpha-release-approval-checkpoint.md)
+
 Initial runtime-path harness command:
 
 ```bash

--- a/docs/reports/v0.3.0-alpha-release-approval-checkpoint.md
+++ b/docs/reports/v0.3.0-alpha-release-approval-checkpoint.md
@@ -1,0 +1,115 @@
+# v0.3.0-alpha Release Approval Checkpoint
+
+Approval checkpoint date: 2026-05-07
+
+Current public HEAD reviewed: `7826cd12b0319679ad8d54bcd6c002e275788ce2`
+
+Release candidate label: `v0.3.0-alpha`
+
+Status: release approval checkpoint for a future `v0.3.0-alpha` release decision. This document does not approve or create a tag, GitHub Release, package version change, release asset upload, raw benchmark artifact upload, or claim expansion.
+
+## Current Release-Preparation State
+
+- Draft/pre-release changelog entry exists in `CHANGELOG.md`.
+- Release validation packet exists: `docs/reports/v0.3.0-alpha-release-validation-packet.md`.
+- Reviewer-facing runtime evidence guide exists: `docs/reports/v0.3.0-alpha-runtime-evidence-reviewer-guide.md`.
+- Release-readiness checklist exists: `docs/reports/v0.3.0-alpha-release-readiness-checklist.md`.
+- Docs cross-link and public claim-boundary audit exists: `docs/reports/v0.3.0-alpha-docs-claim-audit.md`.
+- Runtime evidence architecture design exists: `docs/design/v0.3.0-runtime-integrated-benchmark-evidence-architecture.md`.
+- Initial runtime-path benchmark harness exists.
+- Runtime benchmark JSON output path exists.
+- Markdown evidence packet/report generator exists.
+- Telemetry-connected runtime benchmark summary path exists.
+
+## Validation Commands Required Before Release
+
+- `python3 -m pytest`
+- `python3 -m kora run direct_vs_kora -- --offline`
+- `python3 -m kora run runtime_integrated_benchmark -- --offline`
+- `python3 -m kora run runtime_integrated_benchmark -- --offline --json-out /tmp/kora_runtime_integrated_benchmark_task183.json`
+- `python3 examples/runtime_integrated_benchmark/report.py --input /tmp/kora_runtime_integrated_benchmark_task183.json --md-out /tmp/kora_runtime_integrated_benchmark_task183.md`
+- `python3 -m kora telemetry --input /tmp/kora_runtime_integrated_benchmark_task183.json --json-out /tmp/kora_runtime_integrated_benchmark_task183.telemetry.json --md-out /tmp/kora_runtime_integrated_benchmark_task183.telemetry.md`
+
+## Expected Runtime Benchmark Counters
+
+| Counter | Expected value |
+|---|---:|
+| `total_tasks` | `100` |
+| `deterministic_route_count` | `80` |
+| `fallback_or_model_candidate_route_count` | `20` |
+| `simulated_baseline_model_invocations` | `100` |
+| `kora_controlled_model_invocations` | `20` |
+| `avoided_simulated_model_invocations` | `80` |
+| `avoided_simulated_model_invocation_rate` | `0.8` |
+| `deterministic_outputs_checked` | `80` |
+| `mismatch_count` | `0` |
+| `runtime_path_execution_status` | `ok` |
+| `telemetry_event_count` | `100` |
+
+## Expected Telemetry Counters
+
+| Counter | Expected value |
+|---|---:|
+| `total_llm_calls` | `20` |
+| `events_ok` | `100` |
+| `events_fail` | `0` |
+| `events_skipped` | `0` |
+| `stage_counts.ADAPTER` | `20` |
+| `stage_counts.DETERMINISTIC` | `80` |
+
+## Safe Current Claim
+
+> In a reproducible 100-task deterministic-heavy benchmark workload, KORA-controlled execution avoided 80 of 100 simulated model invocations versus a naive direct baseline.
+
+## Explicit Non-Claims
+
+KORA does not currently claim:
+
+- production cost reduction proof
+- real API-cost reduction proof
+- production benchmark proof
+- full runtime-integrated benchmark evidence yet
+- broad workload superiority proof
+- energy reduction evidence
+- formal government validation
+- signed partner validation unless actually signed and documented
+- guaranteed adoption or funding
+
+## Release Actions Requiring Explicit Approval
+
+The following actions require explicit human approval before execution:
+
+- creating tag `v0.3.0-alpha`
+- creating GitHub Release `v0.3.0-alpha`
+- marking the release as prerelease or latest
+- uploading any release asset
+- uploading any raw benchmark artifact
+- changing package version
+
+## Recommended Approval Wording
+
+Use explicit approval wording in a future task. Examples:
+
+- "Approved: create tag v0.3.0-alpha only."
+- "Approved: create GitHub Release v0.3.0-alpha as prerelease only."
+- "Approved: no release assets."
+- "Approved: do not upload raw benchmark artifacts."
+
+## Release Blocker Checklist
+
+Do not proceed with release execution if any of these are true:
+
+- tests are failing
+- runtime benchmark counters mismatch
+- telemetry counters mismatch
+- unsafe claim wording is present
+- generated benchmark JSON, Markdown evidence packet, or telemetry outputs are staged or committed
+- package version change is present without explicit approval
+- release asset upload is not explicitly approved
+- raw benchmark artifact upload is not explicitly approved
+
+## Final Recommendation
+
+Prepare release execution only after explicit human approval. If approved, the next task should create tag only, or create tag plus GitHub Release, depending on the exact approval wording.
+
+Do not proceed automatically.

--- a/docs/reports/v0.3.0-alpha-release-validation-packet.md
+++ b/docs/reports/v0.3.0-alpha-release-validation-packet.md
@@ -115,4 +115,4 @@ KORA does not currently claim:
 
 This packet prepares for release review only. Any release action requires explicit approval in a later task.
 
-Recommended next step after this packet is reviewed: open a PR for this release-preparation branch, merge if safe, refresh local ChatGPT context, and then request explicit approval before any tag or GitHub Release task.
+Recommended next step after this packet is reviewed: review the [`v0.3.0-alpha release approval checkpoint`](v0.3.0-alpha-release-approval-checkpoint.md), open a PR for that release-approval checkpoint branch, merge if safe, refresh local ChatGPT context, and then request explicit approval before any tag or GitHub Release task.


### PR DESCRIPTION
## Summary

- Adds a v0.3.0-alpha release approval checkpoint document.
- Captures the current public HEAD, release candidate label, release-preparation state, required validation commands, expected counters, safe claim, explicit non-claims, approval wording, release blockers, and final recommendation.
- Adds minimal cross-links from docs index and release validation packet.
- Clearly states this is not release execution and does not approve automatic release action.

## Files changed

- `docs/reports/v0.3.0-alpha-release-approval-checkpoint.md`
- `docs/README.md`
- `docs/reports/v0.3.0-alpha-release-validation-packet.md`

## Commands validated

- `python3 -m pytest`
- `python3 -m kora run direct_vs_kora -- --offline`
- `python3 -m kora run runtime_integrated_benchmark -- --offline`
- `python3 -m kora run runtime_integrated_benchmark -- --offline --json-out /tmp/kora_runtime_integrated_benchmark_task184.json`
- `python3 examples/runtime_integrated_benchmark/report.py --input /tmp/kora_runtime_integrated_benchmark_task184.json --md-out /tmp/kora_runtime_integrated_benchmark_task184.md`
- `python3 -m kora telemetry --input /tmp/kora_runtime_integrated_benchmark_task184.json --json-out /tmp/kora_runtime_integrated_benchmark_task184.telemetry.json --md-out /tmp/kora_runtime_integrated_benchmark_task184.telemetry.md`

## Runtime benchmark counters

- `total_tasks`: 100
- `deterministic_route_count`: 80
- `fallback_or_model_candidate_route_count`: 20
- `simulated_baseline_model_invocations`: 100
- `kora_controlled_model_invocations`: 20
- `avoided_simulated_model_invocations`: 80
- `avoided_simulated_model_invocation_rate`: 0.8
- `deterministic_outputs_checked`: 80
- `mismatch_count`: 0
- `runtime_path_execution_status`: ok
- `telemetry_event_count`: 100

## Telemetry counters

- `total_llm_calls`: 20
- `events_ok`: 100
- `events_fail`: 0
- `events_skipped`: 0
- `stage_counts`: ADAPTER 20 / DETERMINISTIC 80

## Claim boundary

- This is a release approval checkpoint for a bounded v0.3.0-alpha evidence path.
- It is not production benchmark evidence.
- It does not prove real API-cost reduction.
- It does not prove production cost reduction.
- It does not prove broad workload superiority.
- It does not prove energy reduction.
- It is not full runtime-integrated benchmark evidence.

## Release restrictions

- No v0.3.0-alpha tag or GitHub Release should be created without explicit approval.
- No release assets or raw benchmark artifacts should be uploaded without explicit approval.
- This PR prepares approval review only; it does not perform release action.

## Recommended next task

- Check PR status and merge if safe.
- Then refresh local ChatGPT context after merge.
- Only after explicit approval, execute the specific approved release action.
