### PR TITLE
docs: clarify post-release SOD HEAD references

### DIFF
--- a/docs/context/KORA_NEXT_CHATGPT_SOD_PROMPT.md
+++ b/docs/context/KORA_NEXT_CHATGPT_SOD_PROMPT.md
@@ -11,7 +11,10 @@ Official repo:
 Public truth:
 - origin/main on Krako-Labs/KORA
 
-Current public HEAD:
+Current public HEAD after post-release docs:
+- f41d7a41acb1de4a466c8a478cd03477851aa6d1
+
+v0.3.0-alpha release/tag target HEAD:
 - 078de0777178f8b233877f126a4ed844247da7d7
 
 Released tag:
@@ -36,12 +39,13 @@ Workspace paths:
 
 Repository rules:
 - Use /Users/albertkim/02_PROJECTS/05_KORA_Project/repo/KORA as the active clean repo.
-- Create fresh worktrees under /Users/albertkim/02_PROJECTS/05_KORA_Project/worktrees/ for public repo changes.
+- Create fresh worktrees under /Users/albertkim/02_PROJECTS/05_KORA_Project/worktrees/ from latest origin/main / current public HEAD for public repo changes.
 - Do not use or modify /Users/albertkim/02_PROJECTS/05_KORA.
 - Do not create additional tags or GitHub Releases without explicit approval.
 - Do not upload release assets or raw benchmark artifacts without explicit approval.
 - Do not change package version without explicit approval.
 - Do not delete task branches or worktrees unless explicitly approved.
+- Do not base new work on the v0.3.0-alpha release tag unless explicitly requested; release evidence remains tied to the tag target HEAD above.
 
 Current v0.3.0-alpha state:
 - Runtime evidence architecture design exists.

--- a/docs/context/KORA_NEXT_CODEX_SOD_PROMPT.md
+++ b/docs/context/KORA_NEXT_CODEX_SOD_PROMPT.md
@@ -10,7 +10,8 @@ Continue KORA after the v0.3.0-alpha prerelease.
 Repository and workspace rules:
 - Official repo: https://github.com/Krako-Labs/KORA
 - Public truth: origin/main on Krako-Labs/KORA
-- Current public HEAD: 078de0777178f8b233877f126a4ed844247da7d7
+- Current public HEAD after post-release docs: f41d7a41acb1de4a466c8a478cd03477851aa6d1
+- v0.3.0-alpha release/tag target HEAD: 078de0777178f8b233877f126a4ed844247da7d7
 - Released tag: v0.3.0-alpha
 - GitHub Release URL: https://github.com/Krako-Labs/KORA/releases/tag/v0.3.0-alpha
 - Active clean repo path: /Users/albertkim/02_PROJECTS/05_KORA_Project/repo/KORA
@@ -18,7 +19,8 @@ Repository and workspace rules:
 - Local ChatGPT context path: /Users/albertkim/02_PROJECTS/05_KORA_Project/local/chatgpt_context/
 - Legacy/dirty old repo: /Users/albertkim/02_PROJECTS/05_KORA
 - Do not use or modify the legacy/dirty old repo.
-- Create fresh worktrees under /Users/albertkim/02_PROJECTS/05_KORA_Project/worktrees/ for public repo changes.
+- Create fresh worktrees under /Users/albertkim/02_PROJECTS/05_KORA_Project/worktrees/ from latest origin/main / current public HEAD for public repo changes.
+- Do not base new work on the v0.3.0-alpha release tag unless explicitly requested; release evidence remains tied to the tag target HEAD above.
 - Do not create additional tags or GitHub Releases without explicit approval.
 - Do not upload release assets or raw benchmark artifacts without explicit approval.
 - Do not create GitHub issues, project boards, repo setting changes, package version changes, collaborator changes, or raw benchmark artifacts unless explicitly approved.

--- a/docs/eod/kora_eod_2026_05_07_v0.3.0-alpha_release.md
+++ b/docs/eod/kora_eod_2026_05_07_v0.3.0-alpha_release.md
@@ -4,7 +4,9 @@ Date: 2026-05-07
 
 Release: `v0.3.0-alpha`
 
-Public HEAD: `078de0777178f8b233877f126a4ed844247da7d7`
+Release/tag target HEAD: `078de0777178f8b233877f126a4ed844247da7d7`
+
+Current public HEAD after post-release docs: `f41d7a41acb1de4a466c8a478cd03477851aa6d1`
 
 GitHub Release URL: https://github.com/Krako-Labs/KORA/releases/tag/v0.3.0-alpha
 


### PR DESCRIPTION
## Summary

- Clarifies current public HEAD after post-release docs.
- Clarifies v0.3.0-alpha release/tag target HEAD.
- Updates next ChatGPT and Codex SOD prompts to tell future work to start from latest origin/main, not the release tag, unless explicitly requested.
- Adds a small EOD clarification distinguishing release/tag target HEAD from current post-release docs HEAD.

## Files changed

- `docs/context/KORA_NEXT_CHATGPT_SOD_PROMPT.md`
- `docs/context/KORA_NEXT_CODEX_SOD_PROMPT.md`
- `docs/eod/kora_eod_2026_05_07_v0.3.0-alpha_release.md`

## Release state

- v0.3.0-alpha published as GitHub prerelease
- Release URL: https://github.com/Krako-Labs/KORA/releases/tag/v0.3.0-alpha
- release/tag target HEAD: `078de0777178f8b233877f126a4ed844247da7d7`
- current public HEAD after post-release docs: `f41d7a41acb1de4a466c8a478cd03477851aa6d1`
- no release assets
- no raw benchmark artifacts
- package version unchanged `0.1.0a0`

## Commands validated

- `python3 -m pytest`
- `python3 -m kora run direct_vs_kora -- --offline`
- `python3 -m kora run runtime_integrated_benchmark -- --offline`
- `python3 -m kora run runtime_integrated_benchmark -- --offline --json-out /tmp/kora_runtime_integrated_benchmark_task194.json`
- `python3 examples/runtime_integrated_benchmark/report.py --input /tmp/kora_runtime_integrated_benchmark_task194.json --md-out /tmp/kora_runtime_integrated_benchmark_task194.md`
- `python3 -m kora telemetry --input /tmp/kora_runtime_integrated_benchmark_task194.json --json-out /tmp/kora_runtime_integrated_benchmark_task194.telemetry.json --md-out /tmp/kora_runtime_integrated_benchmark_task194.telemetry.md`

## Runtime benchmark counters

- `total_tasks`: 100
- `deterministic_route_count`: 80
- `fallback_or_model_candidate_route_count`: 20
- `simulated_baseline_model_invocations`: 100
- `kora_controlled_model_invocations`: 20
- `avoided_simulated_model_invocations`: 80
- `avoided_simulated_model_invocation_rate`: 0.8
- `deterministic_outputs_checked`: 80
- `mismatch_count`: 0
- `runtime_path_execution_status`: ok
- `telemetry_event_count`: 100

## Telemetry counters

- `total_llm_calls`: 20
- `events_ok`: 100
- `events_fail`: 0
- `events_skipped`: 0
- `stage_counts`: ADAPTER 20 / DETERMINISTIC 80

## Claim boundary

- This is a docs-only clarification.
- It does not add production benchmark evidence.
- It does not prove real API-cost reduction.
- It does not prove production cost reduction.
- It does not prove broad workload superiority.
- It does not prove energy reduction.
- It is not full runtime-integrated benchmark evidence.

## Artifact policy

- Generated JSON and Markdown outputs remain in `/tmp` or user-provided output paths.
- No generated raw benchmark artifacts are committed.
- No additional release assets or raw benchmark artifacts are uploaded.

## Recommended next task

- Check PR status and merge if safe.
- Then refresh local ChatGPT context after merge.
