### PR TITLE
docs: add v0.3.0-alpha cleanup plan

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -49,6 +49,8 @@ Final `v0.3.0-alpha` docs and claim audit: [`docs/reports/v0.3.0-alpha-docs-clai
 
 Post-release EOD report: [`docs/eod/kora_eod_2026_05_07_v0.3.0-alpha_release.md`](eod/kora_eod_2026_05_07_v0.3.0-alpha_release.md)
 
+Post-release cleanup plan: [`docs/reports/v0.3.0-alpha-post-release-cleanup-plan.md`](reports/v0.3.0-alpha-post-release-cleanup-plan.md)
+
 Initial runtime-path harness command:
 
 ```bash

--- a/docs/reports/v0.3.0-alpha-post-release-cleanup-plan.md
+++ b/docs/reports/v0.3.0-alpha-post-release-cleanup-plan.md
@@ -1,0 +1,178 @@
+# v0.3.0-alpha Post-Release Cleanup Plan
+
+Date: 2026-05-07
+
+Current public HEAD reviewed: `f07ac97e1e369e8c9f413b8d8c848024003faf85`
+
+Release: `v0.3.0-alpha`
+
+Release/tag target HEAD: `078de0777178f8b233877f126a4ed844247da7d7`
+
+Release URL: https://github.com/Krako-Labs/KORA/releases/tag/v0.3.0-alpha
+
+Purpose: inventory and planning only. No cleanup was performed.
+
+## Active Repo Status
+
+- Active clean repo: `/Users/albertkim/02_PROJECTS/05_KORA_Project/repo/KORA`
+- Public truth: `origin/main`
+- HEAD: `f07ac97e1e369e8c9f413b8d8c848024003faf85`
+- `origin/main`: `f07ac97e1e369e8c9f413b8d8c848024003faf85`
+- `v0.3.0-alpha` tag exists.
+- GitHub Release exists and is marked prerelease.
+- Release assets: none.
+- Raw benchmark artifacts uploaded: none.
+- Package version remains `0.1.0a0`.
+
+## Cleanup Rules
+
+This plan is approval-gated. It does not authorize deletion.
+
+- Do not delete any worktree without explicit approval.
+- Do not delete any local branch without explicit approval.
+- Do not delete any remote branch without explicit approval.
+- Do not prune worktrees without explicit approval.
+- Do not delete tags, releases, release assets, raw artifacts, or package versions.
+
+## Worktree Inventory
+
+| Worktree path | Branch | HEAD | Clean | Pushed to origin | Related PR | Category | Reason |
+|---|---|---:|---|---|---|---|---|
+| `/Users/albertkim/02_PROJECTS/05_KORA_Project/worktrees/task159_runtime_integrated_benchmark_architecture` | `task159_runtime_integrated_benchmark_architecture` | `6ae0cdf` | yes | yes | PR #38 merged | safe-to-remove-after-approval | Clean task worktree; branch pushed; runtime architecture PR merged into `origin/main`. |
+| `/Users/albertkim/02_PROJECTS/05_KORA_Project/worktrees/task163_runtime_integrated_benchmark_harness` | `task163_runtime_integrated_benchmark_harness` | `5fe9383` | yes | yes | PR #39 merged | safe-to-remove-after-approval | Clean task worktree; branch pushed; runtime harness PR merged into `origin/main`. |
+| `/Users/albertkim/02_PROJECTS/05_KORA_Project/worktrees/task167_runtime_benchmark_evidence_packet` | `task167_runtime_benchmark_evidence_packet` | `26c12f2` | yes | yes | PR #40 merged | safe-to-remove-after-approval | Clean task worktree; branch pushed; evidence packet PR merged into `origin/main`. |
+| `/Users/albertkim/02_PROJECTS/05_KORA_Project/worktrees/task171_runtime_evidence_reviewer_guide` | `task171_runtime_evidence_reviewer_guide` | `e39faaf` | yes | yes | PR #41 merged | safe-to-remove-after-approval | Clean task worktree; branch pushed; reviewer guide PR merged into `origin/main`. |
+| `/Users/albertkim/02_PROJECTS/05_KORA_Project/worktrees/task175_v030_docs_claim_audit` | `task175_v030_docs_claim_audit` | `1c5ce3e` | yes | yes | PR #42 merged | safe-to-remove-after-approval | Clean task worktree; branch pushed; docs claim audit PR merged into `origin/main`. |
+| `/Users/albertkim/02_PROJECTS/05_KORA_Project/worktrees/task179_v030_changelog_release_validation_packet` | `task179_v030_changelog_release_validation_packet` | `1435d3c` | yes | yes | PR #43 merged | safe-to-remove-after-approval | Clean task worktree; branch pushed; release validation packet PR merged into `origin/main`. |
+| `/Users/albertkim/02_PROJECTS/05_KORA_Project/worktrees/task183_v030_release_approval_checkpoint` | `task183_v030_release_approval_checkpoint` | `5770417` | yes | yes | PR #44 merged | safe-to-remove-after-approval | Clean task worktree; branch pushed; release approval checkpoint PR merged into `origin/main`. |
+| `/Users/albertkim/02_PROJECTS/05_KORA_Project/worktrees/task189_v030_post_release_eod_sod` | `task189_v030_post_release_eod_sod` | `c812d6d` | yes | yes | PR #45 merged | safe-to-remove-after-approval | Clean task worktree; branch pushed; post-release EOD/SOD PR merged into `origin/main`. |
+| `/Users/albertkim/02_PROJECTS/05_KORA_Project/worktrees/task193_fix_sod_head_wording` | `task193_fix_sod_head_wording` | `56079bc` | yes | yes | PR #46 merged | safe-to-remove-after-approval | Clean task worktree; branch pushed; SOD HEAD wording PR merged into `origin/main`. |
+| `/Users/albertkim/02_PROJECTS/05_KORA_Project/worktrees/task197_post_release_cleanup_plan` | `task197_post_release_cleanup_plan` | `f07ac97` | yes at inventory time | not yet at inventory time | this task | keep | Current planning worktree; do not remove until this branch is reviewed, merged, and explicitly approved for cleanup. |
+
+## Branch Inventory
+
+### v0.3.0-alpha Workstream Remote Branches
+
+These remote branches were present during inventory and appear merged into `origin/main`:
+
+| Remote branch | Related PR | Merge state | Suggested category |
+|---|---|---|---|
+| `origin/task159_runtime_integrated_benchmark_architecture` | PR #38 | merged | safe-to-remove-after-approval |
+| `origin/task163_runtime_integrated_benchmark_harness` | PR #39 | merged | safe-to-remove-after-approval |
+| `origin/task167_runtime_benchmark_evidence_packet` | PR #40 | merged | safe-to-remove-after-approval |
+| `origin/task171_runtime_evidence_reviewer_guide` | PR #41 | merged | safe-to-remove-after-approval |
+| `origin/task175_v030_docs_claim_audit` | PR #42 | merged | safe-to-remove-after-approval |
+| `origin/task179_v030_changelog_release_validation_packet` | PR #43 | merged | safe-to-remove-after-approval |
+| `origin/task183_v030_release_approval_checkpoint` | PR #44 | merged | safe-to-remove-after-approval |
+| `origin/task189_v030_post_release_eod_sod` | PR #45 | merged | safe-to-remove-after-approval |
+| `origin/task193_fix_sod_head_wording` | PR #46 | merged | safe-to-remove-after-approval |
+
+No v0.3.0-alpha task remote branches were reported as unmerged by `git branch -r --no-merged origin/main`.
+
+### Local Branches
+
+Local task branches reported as merged into `origin/main` include:
+
+- `task131_v021_polish_onboarding_audit`
+- `task132_readme_current_release_quickstart`
+- `task133_docs_index_benchmark_path`
+- `task134_experiments_benchmark_regeneration_guide`
+- `task135_release_evidence_crosslinks`
+- `task136_contributor_path_audit`
+- `task137_contributing_current_status`
+- `task138_security_reporting_guidance`
+- `task139_template_verification_claim_hygiene`
+- `task140_seed_good_first_issues`
+- `task141_governance_duplication_resolution`
+- `task142_first_run_expected_outputs`
+- `task143_telemetry_counter_definitions`
+- `task144_v021_polish_merge_packet`
+- `task145_open_v021_polish_pr`
+- `task149_issue_33_36_triage`
+- `task159_runtime_integrated_benchmark_architecture`
+- `task163_runtime_integrated_benchmark_harness`
+- `task167_runtime_benchmark_evidence_packet`
+- `task171_runtime_evidence_reviewer_guide`
+- `task175_v030_docs_claim_audit`
+- `task179_v030_changelog_release_validation_packet`
+- `task183_v030_release_approval_checkpoint`
+- `task189_v030_post_release_eod_sod`
+- `task193_fix_sod_head_wording`
+- `task197_post_release_cleanup_plan`
+
+Local task branches reported as not merged into `origin/main`:
+
+- `task146_pr37_checks_review`
+- `task147_pr37_post_merge_validation`
+
+Suggested category:
+
+- Merged local task branches: `safe-to-remove-after-approval`, after confirming no unique unpushed commits and no active worktree depends on them.
+- Unmerged local task branches: `review-before-removal`, because they may preserve validation or follow-up work not present on `origin/main`.
+- Current branch `task197_post_release_cleanup_plan`: `keep` until this cleanup plan is reviewed and merged.
+
+## Recommended Cleanup Categories
+
+- `keep`: active branch/worktree or branch with unresolved review value.
+- `safe-to-remove-after-approval`: clean worktree or merged branch with no unique unpushed commits, after explicit user approval.
+- `review-before-removal`: branch or worktree with uncertain merge status, unmerged commits, or unclear historical value.
+- `do-not-remove`: protected repo state, release tag, published release, active clean repo, or anything explicitly retained by the user.
+
+## Approval-Gated Cleanup Procedure
+
+Future cleanup should be split into small approval-scoped steps.
+
+1. Confirm current `origin/main` and active repo status.
+2. Re-run `git worktree list` and `git status --short --branch` in every candidate worktree.
+3. For each candidate worktree, confirm:
+   - working tree is clean
+   - related PR is merged or task is obsolete by explicit decision
+   - no uncommitted changes exist
+   - user explicitly approves that specific worktree removal
+4. For each candidate local branch, confirm:
+   - branch is merged or explicitly obsolete
+   - branch has no unique unpushed commits
+   - branch is not checked out by any worktree
+   - user explicitly approves that specific local branch deletion
+5. For each candidate remote branch, confirm:
+   - PR is merged
+   - branch is no longer needed
+   - user explicitly approves remote deletion
+6. Perform cleanup only in the later approved task.
+7. Re-run status checks and report exactly what was removed.
+
+## Explicit Non-Actions
+
+- No worktree deletion was performed.
+- No local branch deletion was performed.
+- No remote branch deletion was performed.
+- No worktree pruning was performed.
+- No additional tag was created.
+- No additional GitHub Release was created.
+- No release assets were uploaded.
+- No raw benchmark artifacts were uploaded.
+- No package version change was made.
+
+## Suggested Future Cleanup Task Prompt Outline
+
+Use this only after explicit human approval:
+
+```text
+Approved cleanup scope:
+- Remove only these clean merged task worktrees:
+  - <list exact paths>
+- Delete only these merged local branches:
+  - <list exact branch names>
+- Delete only these merged remote branches:
+  - <list exact remote branch names>
+
+Do not prune unrelated worktrees.
+Do not delete unlisted branches.
+Do not delete tags, releases, release assets, raw benchmark artifacts, or package versions.
+Before deleting, re-confirm each candidate is clean, merged or explicitly obsolete, and has no unique unpushed commits.
+After deleting, report the exact removals and final repo status.
+```
+
+## Final Recommendation
+
+The v0.3.0-alpha task worktrees from PR #38 through PR #46 appear clean, pushed, and related to merged PRs. They are reasonable candidates for later cleanup after explicit approval. The unmerged local branches `task146_pr37_checks_review` and `task147_pr37_post_merge_validation` should be reviewed before any removal decision.


### PR DESCRIPTION
## Summary

Describe the change in one or two sentences.

## Type of change

- [ ] Docs only
- [ ] CLI / example
- [ ] Benchmark / evidence
- [ ] Code / tests
- [ ] Security-sensitive

## Verification

- [ ] Validation commands were run or marked not applicable.
- [ ] Claim hygiene checked.
- [ ] No unsupported production, API-cost, benchmark, broad workload, or energy claims added.
- [ ] No raw benchmark JSON artifacts committed.
- [ ] No local absolute paths introduced.
- [ ] No release, tag, package-version, or release-asset changes unless explicitly approved.

List commands run and results:

```text

```

Useful references: [CONTRIBUTING.md](../CONTRIBUTING.md), [SECURITY.md](../SECURITY.md), [experiments/README.md](../experiments/README.md), and [docs/README.md](../docs/README.md).

## Scope check

- [ ] No unrelated refactors
- [ ] No public surface expansion without discussion
- [ ] Deterministic-first behavior preserved
- [ ] No hidden model calls introduced
- [ ] README, docs, examples, and templates remain factual and alpha-scoped

## Notes for reviewer

Call out risk, follow-up work, or anything intentionally left out of scope.
