### PR TITLE
Refactor KORA launch messaging and validation docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,57 +1,127 @@
-<p align="center">
-  <img src="assets/KORA_Img_Text_logo.png" alt="KORA Logo" width="330" />
-</p>
+# KORA
 
-<br>
+Open-source execution control for AI workloads.
 
-<h1 align="center">KORA</h1>
+Most AI apps call the model too soon.
 
-<p align="center"><strong>Open-source execution control for AI systems</strong></p>
-<p align="center">Structure first. Inference second.</p>
+Every request becomes a prompt.
+Every prompt becomes tokens.
+Every token becomes latency, cost, and infrastructure pressure.
 
-<p align="center">
-  <img alt="Deterministic-first" src="https://img.shields.io/badge/Deterministic--first-0f766e?style=flat-square" />
-  <img alt="Task graphs" src="https://img.shields.io/badge/Task-graphs-1d4ed8?style=flat-square" />
-  <img alt="Execution control" src="https://img.shields.io/badge/Execution-control-111827?style=flat-square" />
-  <img alt="Schema validation" src="https://img.shields.io/badge/Schema-validation-7c3aed?style=flat-square" />
-  <img alt="Telemetry" src="https://img.shields.io/badge/Telemetry-observability-475569?style=flat-square" />
-  <img alt="Terminal first" src="https://img.shields.io/badge/Terminal-first-374151?style=flat-square" />
-</p>
+KORA turns AI requests into structured execution paths before inference: task graphs, deterministic-first execution, validation, telemetry, and model escalation only when needed.
 
----
+![KORA execution control overview](docs/assets/kora-execution-control-overview.svg)
 
-KORA is a standalone open-source execution control layer for AI systems. It structures requests into task graphs, runs deterministic work first, and escalates to model inference only when needed.
+Before:
 
-> Repository note: KORA has moved into its official Krako Labs home at https://github.com/Krako-Labs/KORA. Same code, same history, bigger mission.
+```text
+request -> prompt -> model -> output
+```
 
-## Current Release
+After:
 
-Current published release: [`v0.2.0-alpha`](https://github.com/Krako-Labs/KORA/releases/tag/v0.2.0-alpha).
+```text
+request -> task graph -> deterministic path -> validation -> model escalation -> telemetry
+```
 
-KORA is still alpha / prerelease software. The `v0.2.0-alpha` release focuses on bounded deterministic-heavy benchmark evidence for the terminal-first developer surface. No release assets were uploaded, and no raw benchmark JSON artifacts were uploaded.
+Structure first. Inference second.
 
-Want to contribute? Start with [CONTRIBUTING.md](CONTRIBUTING.md), browse [good first issue candidates](docs/good_first_issues.md), and review [SECURITY.md](SECURITY.md), [GOVERNANCE.md](GOVERNANCE.md), and [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md). Community moderators can use the [KORA community manager guide](docs/community/KORA_COMMUNITY_MANAGER_GUIDE.md).
+## 3-Minute Local Run
+
+For local development in this repository:
+
+```bash
+python3 -m venv .venv
+source .venv/bin/activate
+python3 -m pip install -e ".[dev]"
+```
+
+Run the CLI and first offline demo:
+
+```bash
+python3 -m kora --help
+python3 -m kora examples list
+python3 -m kora run direct_vs_kora -- --offline
+```
+
+Inspect the output to see how KORA changes a direct model-first path into a controlled execution path.
+
+## What KORA Does
+
+KORA sits between an AI request and a model call.
+
+It helps developers:
+
+- turn requests into explicit task graphs
+- run deterministic work before inference
+- validate outputs before escalation
+- make model calls conditional instead of default
+- record telemetry around each execution path
+- compare direct model-first execution against controlled execution
+
+KORA does not try to make models smarter. It controls when, why, and how they are used.
+
+## Current Alpha Evidence
+
+KORA reduced model invocations by 80% in a reproducible deterministic-heavy benchmark workload.
+
+![KORA benchmark evidence card](docs/assets/kora-benchmark-evidence-card.svg)
+
+This result is based on the current deterministic-heavy alpha benchmark and should not be interpreted as a universal production cost-reduction claim.
+
+For methodology, counters, artifact policy, and reproduction commands, see:
+
+- [Runtime evidence reviewer guide](docs/reports/v0.3.0-alpha-runtime-evidence-reviewer-guide.md)
+- [Benchmark artifact policy](docs/reports/benchmark_artifact_policy.md)
+- [Benchmark result summary](docs/benchmarks/kora_benchmark_result_v1_100.md)
+- [Claim registry](docs/claims/kora-claim-registry.md)
+- [Validation roadmap](docs/benchmarks/validation-roadmap.md)
+
+## What We Are Testing Next
+
+1. Runtime-integrated benchmark paths with real model calls
+2. Customer-support triage workloads
+3. RAG answer-routing workloads
+4. Agent budget-guard workloads
+
+We are looking for early developers and AI app teams who want to test KORA against real workloads.
+
+See the [KORA validation roadmap](docs/benchmarks/validation-roadmap.md) for the measurement plan.
+
+## Help Test KORA
+
+Good candidate workloads:
+
+- customer-support triage
+- repetitive RAG workflows
+- agent workflows with budget or escalation rules
+- deterministic-heavy backend workflows
+- LLM apps with high repeated request patterns
+
+To participate, open a GitHub Discussion or contact the project maintainers.
+
+TODO: Add the canonical GitHub Discussions URL and maintainer contact route once they are finalized.
+
+See [Help Test KORA](docs/community/help-test-kora.md) for the workload submission template.
 
 ## Documentation
 
-Start with the [KORA Documentation Index](docs/README.md) to find technical docs, benchmark evidence, claim guidance, community workflows, and operating docs.
+Start with the [KORA Documentation Index](docs/README.md) for the developer path:
 
-For current benchmark evidence and claim boundaries, see the [changelog](CHANGELOG.md), [experiments regeneration guide](experiments/README.md), [benchmark artifact policy](docs/reports/benchmark_artifact_policy.md), [raw artifact freeze decision](docs/reports/v0.2.0-alpha-raw-artifact-freeze-decision.md), [100-task benchmark summary](docs/benchmarks/kora_benchmark_result_v1_100.md), and [claim registry](docs/claims/kora-claim-registry.md).
+- Start
+- Understand
+- Run
+- Inspect evidence
+- Help test
+- Contribute
 
-## What KORA Is
+Useful entry points:
 
-KORA sits between a request and a model call.
-
-Instead of treating every request as an immediate prompt-to-model operation, KORA turns execution into a structured path:
-
-- decompose work into task graphs
-- run deterministic tasks first
-- enforce budgets and stage boundaries
-- validate outputs against explicit structure
-- escalate to model inference only when deterministic execution is insufficient
-- record telemetry for inspection and replay
-
-KORA provides execution control before model invocation.
+- [Examples directory](examples/)
+- [Telemetry and observability counters](docs/telemetry-and-observability.md)
+- [Public language guide](docs/claims/kora-public-language-guide.md)
+- [Community manager guide](docs/community/KORA_COMMUNITY_MANAGER_GUIDE.md)
+- [Contributing guide](CONTRIBUTING.md)
 
 ## Install
 
@@ -67,144 +137,41 @@ Homebrew install path:
 brew install kora
 ```
 
-For local development in this repository:
+For the current repository alpha, use the editable local install in the [3-Minute Local Run](#3-minute-local-run).
 
-```bash
-python3 -m venv .venv
-source .venv/bin/activate
-python3 -m pip install -e ".[dev]"
-```
-
-## Quickstart
-
-For local development in this repository, after installing with `python3 -m pip install -e ".[dev]"`, use:
-
-```bash
-python3 -m kora --help
-python3 -m kora examples list
-python3 -m kora run hello_kora
-python3 -m kora run retry_demo
-python3 -m kora run direct_vs_kora -- --offline
-```
-
-Use `--offline` for the reproducible first-run demo path without OpenAI credentials.
-
-Expected first-run shape:
-
-- `hello_kora` completes with JSON containing `status: "ok"` and `message: "hello from kora"`. It shows the basic deterministic graph path.
-- `retry_demo` completes with `final_output.status: "ok"`, `message: "recovered"`, and an `event_count` greater than one. It shows retry/recovery behavior without changing the public CLI.
-- `direct_vs_kora -- --offline` prints `Running direct_vs_kora in offline mock mode`, then a local direct-vs-KORA comparison with simulated call counters such as `llm_calls_direct_total`, `llm_calls_kora_total`, and `llm_calls_reduced_total`.
-
-The offline comparison uses mock local behavior and does not call external APIs. Treat it as a first-run demonstration, not production benchmark evidence. For benchmark evidence and regeneration policy, see [experiments/README.md](experiments/README.md) and [benchmark_artifact_policy.md](docs/reports/benchmark_artifact_policy.md).
-
-If KORA is installed as a command-line package, the equivalent commands are:
-
-```bash
-kora --help
-kora examples list
-kora run hello_kora
-kora run retry_demo
-kora run direct_vs_kora -- --offline
-```
-
-Online variant:
-
-```bash
-kora run direct_vs_kora
-```
+## Current Examples
 
 Current examples available in this repository:
 
-- examples/hello_kora
-- examples/direct_vs_kora
-- examples/retry_demo
-- examples/real_workload_harness
-- examples/stress_test
+- `examples/hello_kora`
+- `examples/direct_vs_kora`
+- `examples/retry_demo`
+- `examples/real_workload_harness`
+- `examples/stress_test`
+- `examples/runtime_integrated_benchmark`
 
-`telemetry` can be run immediately with the committed sample input at `docs/reports/sample_telemetry_input.json`, or with a JSON artifact generated by a prior run or report flow. Counter definitions are in [telemetry-and-observability.md](docs/telemetry-and-observability.md#current-public-counters).
-After the first-run flow and telemetry summary, see `docs/benchmark-real-app.md` for the next-step benchmark/report path via `real_workload_harness`.
+Use `--offline` for reproducible first-run paths without OpenAI credentials.
 
-## Benchmark Evidence
+## Alpha Scope
 
-Safe claim:
-
-> In a reproducible 100-task deterministic-heavy benchmark workload, KORA-controlled execution avoided 80 of 100 simulated model invocations versus a naive direct baseline.
-
-Current `v0.2.0-alpha` counters:
-
-| Metric | Value |
-|---|---:|
-| Total tasks | `100` |
-| Direct-baseline simulated model invocations | `100` |
-| KORA-controlled simulated model invocations | `20` |
-| Avoided simulated model invocations | `80` |
-| Avoided invocation rate | `80%` |
-| Deterministic outputs checked | `80` |
-| Mismatches | `0` |
-| Fallback/model-candidate skipped | `20` |
-
-The tracked workload is `experiments/workloads/deterministic_heavy_v1_100.json`. Regeneration uses `experiments/generate_workload.py`, `experiments/run_benchmark.py`, and `experiments/summarize_benchmark_results.py`; commands are documented in [benchmark_artifact_policy.md](docs/reports/benchmark_artifact_policy.md).
-
-Raw benchmark JSON artifacts are reproducible outputs and are not frozen or committed for this alpha release. See the [raw artifact freeze decision](docs/reports/v0.2.0-alpha-raw-artifact-freeze-decision.md).
-
-This evidence does not claim production cost reduction proof, real API-cost reduction proof, production benchmark proof, full runtime-integrated benchmark evidence, broad workload superiority proof, or energy reduction evidence.
-
-## What KORA Does
-
-KORA structures requests before inference.
-
-In practice, that means:
-
-- separating deterministic work from inference work
-- making model invocation conditional instead of default
-- enforcing validation and retry boundaries around uncertain steps
-- exposing telemetry so execution can be measured, compared, and debugged
-
-KORA does not try to make models smarter. It controls when, why, and how they are used.
-
-## Why KORA Exists
-
-Many AI applications still default to a simple pattern:
-
-`request -> prompt -> model -> output`
-
-That pattern is easy to start with, but it makes several problems harder to control:
-
-- unnecessary model calls
-- unstable latency envelopes
-- weak execution visibility
-- fragile output handling
-- limited separation between deterministic logic and probabilistic logic
-
-KORA exists to make execution structure explicit. If part of a request can be handled deterministically, it should be handled deterministically first. Inference should be an escalation path, not the baseline.
-
-## Included in the Alpha Surface
+Included in the alpha surface:
 
 - execution-layer primitives for structured AI workloads
 - task graph and scheduler foundations
 - deterministic-first execution and verification components
 - telemetry summarization and reporting
-- repository examples covering direct-vs-structured execution, retries, and stress behavior
+- repository examples covering direct-vs-structured execution, retries, stress behavior, and runtime evidence flow
 - terminal-first developer workflow
 
-## Not Included in the Alpha Surface
+Not included in the alpha surface:
 
 - GUI-first product
-- KORA Studio in the main release
 - chatbot interface
 - desktop AI app
 - model hosting or model serving engine
-
-## Who KORA Is For
-
-KORA is for developers and researchers building AI systems that need stronger execution control.
-
-Typical users include:
-
-- engineers who want deterministic preprocessing and validation before model calls
-- teams comparing direct inference against structured execution
-- developers who need telemetry and bounded execution semantics
-- researchers exploring decomposition, verification, and escalation strategies
+- production cost-reduction proof
+- real API-cost reduction proof
+- energy reduction evidence
 
 ## What KORA Is Not
 
@@ -212,24 +179,29 @@ KORA is not:
 
 - a chatbot
 - a desktop AI app
-- a ChatGPT alternative
+- a hosted chat-product alternative
 - a model serving engine
 - another agent wrapper that only forwards prompts to providers
-- a dependent layer inside another platform
 
-KORA is a standalone open-source execution control layer.
+KORA is a standalone open-source execution-control layer for AI workloads.
 
-## Roadmap
+## Contribute
 
-Near-term alpha work:
+Want to contribute? Start with:
 
-- stabilize the terminal CLI around init, run, examples, and trace flows
-- expand example coverage around structured execution patterns
-- improve packaging and distribution for standard developer install paths
-- deepen documentation for task graphs, execution semantics, and telemetry inspection
-- continue benchmark and validation work for deterministic-first execution
+- [CONTRIBUTING.md](CONTRIBUTING.md)
+- [Good first issue candidates](docs/good_first_issues.md)
+- [SECURITY.md](SECURITY.md)
+- [GOVERNANCE.md](GOVERNANCE.md)
+- [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)
 
-Future work may include KORA Studio, but it is outside the main alpha CLI release surface.
+## Ecosystem
+
+KORA is part of the broader Krako infrastructure.
+
+Related repository:
+
+- Krako 2.0: TBD
 
 ## License
 

--- a/docs/EXECUTIVE-SUMMARY.md
+++ b/docs/EXECUTIVE-SUMMARY.md
@@ -1,24 +1,27 @@
 # KORA Executive Summary
 
-KORA is an inference-first execution architecture.
+KORA is an open-source execution-control layer for AI workloads.
 
 It does not build larger models.  
-It restructures how models are invoked.
+It changes when and why models are invoked.
 
 ---
 
 ## The Core Problem
 
-Modern AI systems are inference-reflexive.
+Most AI apps call the model too soon.
 
-Every request triggers a model call.
+Every request becomes a prompt.
+Every prompt becomes tokens.
+Every token becomes latency, cost, and infrastructure pressure.
 
 This leads to:
 
+- Unnecessary model invocation
 - Unnecessary token usage
 - Latency unpredictability
 - Centralized infrastructure dependence
-- Weak cost governance
+- Weak execution governance
 
 The limitation is not model capability.
 
@@ -37,7 +40,9 @@ Most systems answer both by invoking a model.
 
 KORA answers the first structurally.
 
-Only necessary tasks reach inference.
+Structure first. Inference second.
+
+Only necessary tasks reach model escalation.
 
 ---
 
@@ -84,21 +89,21 @@ Structure precedes scale.
 
 ---
 
-## Economic Model
+## Measurement Model
 
 If:
 
 - P = proportion of deterministic work
-- C = cost per model invocation
+- M = model invocation pressure
 - O = structural overhead
 
 KORA is beneficial when:
 
-P * C > O
+P * M > O
 
 This inequality is measurable.
 
-Savings scale with structural visibility.
+This is a measurement frame, not a production cost-reduction claim.
 
 ---
 
@@ -112,7 +117,7 @@ As deterministic coverage increases:
 
 - Model load decreases
 - Latency variance decreases
-- Cost becomes predictable
+- Model invocation pressure becomes more inspectable
 
 Parallel deterministic execution further improves throughput.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -112,11 +112,11 @@ Good candidate workloads:
 - [Manual GitHub setup checklist](ops/2026-05-06-kora-manual-github-setup-checklist.md)
 - [Repository hygiene audit](ops/2026-05-06-kora-repository-hygiene-audit.md)
 
-## Public / Private Boundary Note
+## Public Documentation Boundary Note
 
-Most docs in this repository are public-facing unless marked internal.
+Public KORA documentation should read as normal open-source project documentation.
 
-Internal EOD/SOD prompts are operating artifacts. They should not contain private credentials, personal data, private partner notes, unpublished investor conversations, or other sensitive information.
+Do not place private credentials, personal data, unpublished partner notes, or internal operating material in public docs.
 
 ## Evidence Preservation Note
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,23 +4,45 @@
 
 This is the starting point for navigating KORA documentation.
 
-KORA is an AI Execution Control Layer / Inference OS for AI systems. It structures requests into task graphs, runs deterministic work first, validates outputs, and escalates to model inference only when needed.
+KORA is an open-source execution-control layer that turns AI requests into structured execution paths before inference.
 
-The documentation is organized by audience and use case so developers, contributors, operators, paper readers, EIC/grant reviewers, investors, and partners can find the right files without relying on repository history.
+Most AI apps call the model too soon. KORA changes the default. Structure first. Inference second.
 
-## Start Here
+## Start
 
 - [Main README](../README.md)
 - [Current v0.3.0-alpha prerelease](https://github.com/Krako-Labs/KORA/releases/tag/v0.3.0-alpha)
-- [KORA Category Thesis](vision/2026-05-06-kora-category-thesis.md)
 - [KORA Project Source](context/KORA_PROJECT_SOURCE.md)
+- [KORA Current State](context/KORA_CURRENT_STATE.md)
+- [KORA Category Thesis](vision/2026-05-06-kora-category-thesis.md)
+
+## Understand
+
 - [KORA Claim Registry](claims/kora-claim-registry.md)
 - [KORA Public Language Guide](claims/kora-public-language-guide.md)
-- [KORA Current State](context/KORA_CURRENT_STATE.md)
-- [KORA OSS Operating System](ops/2026-05-06-kora-oss-operating-system.md)
-- [KORA GitHub Platform Setup Plan](ops/2026-05-06-kora-github-platform-setup-plan.md)
+- [Telemetry and observability counters](telemetry-and-observability.md#current-public-counters)
+- [Testing and validation strategy](testing-and-validation-strategy.md)
+- [Research agenda](research-agenda.md)
+- [Whitepaper](whitepaper.md)
 
-## Current Benchmark Evidence Path
+## Run
+
+- [Examples directory](../examples/)
+- [Experiments regeneration guide](../experiments/README.md)
+- [Benchmark real app guide](benchmark-real-app.md)
+- [Benchmark overview](benchmark.md)
+- [Good first issue candidates](good_first_issues.md)
+
+Core local commands:
+
+```bash
+python3 -m kora --help
+python3 -m kora examples list
+python3 -m kora run direct_vs_kora -- --offline
+python3 -m kora run runtime_integrated_benchmark -- --offline
+```
+
+## Inspect Evidence
 
 Use this path for the current `v0.3.0-alpha` prerelease runtime evidence and regeneration flow:
 
@@ -28,70 +50,48 @@ Use this path for the current `v0.3.0-alpha` prerelease runtime evidence and reg
 2. Workload generator: [`experiments/generate_workload.py`](../experiments/generate_workload.py)
 3. Benchmark runner: [`experiments/run_benchmark.py`](../experiments/run_benchmark.py)
 4. Summary generator: [`experiments/summarize_benchmark_results.py`](../experiments/summarize_benchmark_results.py)
-5. Experiments regeneration guide: [`experiments/README.md`](../experiments/README.md)
-6. Artifact policy and regeneration commands: [`docs/reports/benchmark_artifact_policy.md`](reports/benchmark_artifact_policy.md)
-7. Raw artifact freeze decision: [`docs/reports/v0.2.0-alpha-raw-artifact-freeze-decision.md`](reports/v0.2.0-alpha-raw-artifact-freeze-decision.md)
+5. Runtime benchmark example: [`examples/runtime_integrated_benchmark`](../examples/runtime_integrated_benchmark)
+6. Runtime evidence reviewer guide: [`docs/reports/v0.3.0-alpha-runtime-evidence-reviewer-guide.md`](reports/v0.3.0-alpha-runtime-evidence-reviewer-guide.md)
+7. Artifact policy and regeneration commands: [`docs/reports/benchmark_artifact_policy.md`](reports/benchmark_artifact_policy.md)
 8. Current benchmark summary: [`docs/benchmarks/kora_benchmark_result_v1_100.md`](benchmarks/kora_benchmark_result_v1_100.md)
-9. Release/changelog context: [`CHANGELOG.md`](../CHANGELOG.md)
+9. Validation roadmap: [`docs/benchmarks/validation-roadmap.md`](benchmarks/validation-roadmap.md)
 10. Claim boundary source: [`docs/claims/kora-claim-registry.md`](claims/kora-claim-registry.md)
 
-Next evidence architecture: [`docs/design/v0.3.0-runtime-integrated-benchmark-evidence-architecture.md`](design/v0.3.0-runtime-integrated-benchmark-evidence-architecture.md)
+Current approved public claim:
 
-Reviewer-facing runtime evidence flow: [`docs/reports/v0.3.0-alpha-runtime-evidence-reviewer-guide.md`](reports/v0.3.0-alpha-runtime-evidence-reviewer-guide.md)
-
-`v0.3.0-alpha` release-readiness checklist: [`docs/reports/v0.3.0-alpha-release-readiness-checklist.md`](reports/v0.3.0-alpha-release-readiness-checklist.md)
-
-Final `v0.3.0-alpha` docs and claim audit: [`docs/reports/v0.3.0-alpha-docs-claim-audit.md`](reports/v0.3.0-alpha-docs-claim-audit.md)
-
-`v0.3.0-alpha` release validation packet: [`docs/reports/v0.3.0-alpha-release-validation-packet.md`](reports/v0.3.0-alpha-release-validation-packet.md)
-
-`v0.3.0-alpha` release approval checkpoint: [`docs/reports/v0.3.0-alpha-release-approval-checkpoint.md`](reports/v0.3.0-alpha-release-approval-checkpoint.md)
-
-Post-release EOD report: [`docs/eod/kora_eod_2026_05_07_v0.3.0-alpha_release.md`](eod/kora_eod_2026_05_07_v0.3.0-alpha_release.md)
-
-Post-release cleanup plan: [`docs/reports/v0.3.0-alpha-post-release-cleanup-plan.md`](reports/v0.3.0-alpha-post-release-cleanup-plan.md)
-
-`v0.3.1-alpha` roadmap: [`docs/planning/v0.3.1-alpha-roadmap.md`](planning/v0.3.1-alpha-roadmap.md)
-
-Initial runtime-path harness command:
-
-```bash
-python3 -m kora run runtime_integrated_benchmark -- --offline
-```
-
-Safe claim:
-
-> In a reproducible 100-task deterministic-heavy benchmark workload, KORA-controlled execution avoided 80 of 100 simulated model invocations versus a naive direct baseline.
+> KORA reduced model invocations by 80% in a reproducible deterministic-heavy benchmark workload.
 
 This evidence does not claim production cost reduction proof, real API-cost reduction proof, production benchmark proof, full runtime-integrated benchmark evidence, broad workload superiority proof, or energy reduction evidence.
 
 Raw benchmark JSON artifacts are reproducible outputs and are not frozen or committed for this alpha release.
 
-## Document Status Labels
+Additional evidence and release docs:
 
-- **Current release evidence**: current release, benchmark, artifact, and claim-boundary docs for `v0.2.0-alpha`.
-- **Benchmark/artifact policy**: rules and commands for regenerating benchmark workloads, raw outputs, and generated summaries.
-- **Release preparation history**: readiness, merge, review, and release-prep reports preserved for auditability.
-- **EOD/SOD reports**: operating handoff records and dated continuity reports.
-- **Historical/background docs**: older benchmark notes, strategy, architecture, and context docs that may still be useful but are not the current evidence entry point.
+- [v0.3.0 runtime-integrated benchmark architecture](design/v0.3.0-runtime-integrated-benchmark-evidence-architecture.md)
+- [v0.3.0-alpha release-readiness checklist](reports/v0.3.0-alpha-release-readiness-checklist.md)
+- [v0.3.0-alpha docs and claim audit](reports/v0.3.0-alpha-docs-claim-audit.md)
+- [v0.3.0-alpha release validation packet](reports/v0.3.0-alpha-release-validation-packet.md)
+- [v0.3.0-alpha release approval checkpoint](reports/v0.3.0-alpha-release-approval-checkpoint.md)
+- [v0.3.0-alpha post-release EOD report](eod/kora_eod_2026_05_07_v0.3.0-alpha_release.md)
+- [v0.3.0-alpha post-release cleanup plan](reports/v0.3.0-alpha-post-release-cleanup-plan.md)
+- [v0.3.1-alpha roadmap](planning/v0.3.1-alpha-roadmap.md)
 
-## Documentation By Audience
+## Help Test
 
-### A. New Users And Developers
+- [Help Test KORA](community/help-test-kora.md)
+- [KORA validation roadmap](benchmarks/validation-roadmap.md)
+- [KORA social media announcement guide](community/KORA_SOCIAL_MEDIA_ANNOUNCEMENT_GUIDE.md)
+- [KORA community manager guide](community/KORA_COMMUNITY_MANAGER_GUIDE.md)
 
-- [Main README](../README.md)
-- [Examples directory](../examples/)
-- [Telemetry and observability counters](telemetry-and-observability.md#current-public-counters)
-- [Good first issue candidates](good_first_issues.md)
-- [Current benchmark evidence path](#current-benchmark-evidence-path)
-- [v0.3.0-alpha runtime evidence reviewer guide](reports/v0.3.0-alpha-runtime-evidence-reviewer-guide.md)
-- [Technical preview results](technical_preview_results.md) - historical/background benchmark context
-- [Benchmark real app guide](benchmark-real-app.md)
-- [Benchmark overview](benchmark.md) - historical/background benchmark note
-- [Benchmark summaries](benchmarks/) - current and historical benchmark summaries
-- [Experiments directory](../experiments/)
+Good candidate workloads:
 
-### B. Contributors And Community
+- customer-support triage
+- repetitive RAG workflows
+- agent workflows with budget or escalation rules
+- deterministic-heavy backend workflows
+- LLM apps with high repeated request patterns
+
+## Contribute
 
 - [Canonical governance document](../GOVERNANCE.md)
 - [Contributing guide](../CONTRIBUTING.md)
@@ -99,72 +99,18 @@ Raw benchmark JSON artifacts are reproducible outputs and are not frozen or comm
 - [Code of conduct](../CODE_OF_CONDUCT.md)
 - [KORA open roles](community/2026-05-06-kora-open-roles.md)
 - [AI-assisted contribution guide](community/2026-05-06-ai-assisted-contribution-guide.md)
-- [Albert-Sumanta GitHub sync](community/2026-05-06-albert-sumanta-github-sync.md)
 - [Community sync issue template](community/2026-05-06-community-sync-issue-template.md)
-- [KORA community manager guide](community/KORA_COMMUNITY_MANAGER_GUIDE.md)
-- [KORA social media announcement guide](community/KORA_SOCIAL_MEDIA_ANNOUNCEMENT_GUIDE.md)
 - [KORA OSS Operating System](ops/2026-05-06-kora-oss-operating-system.md)
 - [KORA GitHub Platform Setup Plan](ops/2026-05-06-kora-github-platform-setup-plan.md)
 - [Discussions and Wiki plan](ops/2026-05-06-kora-discussions-and-wiki-plan.md)
 - [Label taxonomy](ops/2026-05-06-kora-label-taxonomy.md)
 
-### C. Operators And Maintainers
+## Maintainers And Operators
 
 - [KORA OSS Operating System](ops/2026-05-06-kora-oss-operating-system.md)
 - [Korean ops coordinator handbook](ops/2026-05-06-kora-ops-coordinator-handbook-ko.md)
-- [GitHub platform setup plan](ops/2026-05-06-kora-github-platform-setup-plan.md)
 - [Manual GitHub setup checklist](ops/2026-05-06-kora-manual-github-setup-checklist.md)
 - [Repository hygiene audit](ops/2026-05-06-kora-repository-hygiene-audit.md)
-- [KORA Project Source](context/KORA_PROJECT_SOURCE.md)
-- [KORA ChatGPT Operating Context](context/KORA_CHATGPT_OPERATING_CONTEXT.md)
-- [KORA Codex Operating Context](context/KORA_CODEX_OPERATING_CONTEXT.md)
-- [KORA Current State](context/KORA_CURRENT_STATE.md)
-
-### D. Claims, Public Language, And Communications
-
-- [KORA Claim Registry](claims/kora-claim-registry.md)
-- [KORA Public Language Guide](claims/kora-public-language-guide.md)
-- [KORA Category Thesis](vision/2026-05-06-kora-category-thesis.md)
-- [Repository migration checklist](ops/2026-05-06-kora-repo-migration-checklist.md)
-
-### E. Paper And Research
-
-- [Authorship and contribution policy](paper/2026-05-06-kora-authorship-and-contribution-policy.md)
-- [KORA Category Thesis](vision/2026-05-06-kora-category-thesis.md)
-- [Technical preview results](technical_preview_results.md) - historical/background benchmark context
-- [Benchmark summaries](benchmarks/) - current and historical benchmark summaries
-- [Benchmark artifact policy](reports/benchmark_artifact_policy.md) - benchmark/artifact policy
-- [Research agenda](research-agenda.md)
-- [Whitepaper](whitepaper.md)
-
-### F. EIC, Investor, Partner, And Grant Readiness
-
-- [KORA Category Thesis](vision/2026-05-06-kora-category-thesis.md)
-- [KORA Project Source](context/KORA_PROJECT_SOURCE.md)
-- [KORA Claim Registry](claims/kora-claim-registry.md)
-- [Repository migration checklist](ops/2026-05-06-kora-repo-migration-checklist.md)
-- [KORA OSS Operating System](ops/2026-05-06-kora-oss-operating-system.md)
-- [KORA GitHub Platform Setup Plan](ops/2026-05-06-kora-github-platform-setup-plan.md)
-- [v0.2.0-alpha EOD report](reports/kora_eod_2026-05-05_v0.2.0-alpha.md)
-- [Current benchmark evidence path](#current-benchmark-evidence-path)
-- [v0.3.0-alpha release-readiness checklist](reports/v0.3.0-alpha-release-readiness-checklist.md)
-- [Benchmark evidence summaries](benchmarks/) - current and historical benchmark summaries
-
-### G. Internal Continuity And Handoff
-
-- [KORA_PROJECT_SOURCE.md](context/KORA_PROJECT_SOURCE.md)
-- [KORA_CHATGPT_OPERATING_CONTEXT.md](context/KORA_CHATGPT_OPERATING_CONTEXT.md)
-- [KORA_CODEX_OPERATING_CONTEXT.md](context/KORA_CODEX_OPERATING_CONTEXT.md)
-- [KORA_CURRENT_STATE.md](context/KORA_CURRENT_STATE.md)
-- [EOD reports](eod/)
-- [v0.3.0-alpha post-release EOD report](eod/kora_eod_2026_05_07_v0.3.0-alpha_release.md)
-- [Release and readiness reports](reports/)
-
-## Evidence Preservation Note
-
-Older reports, EOD documents, benchmark summaries, and migration docs may look historical, but they should not be deleted casually. They preserve release, benchmark, paper, EIC/grant, investor, and operating evidence.
-
-Use the [repository hygiene audit](ops/2026-05-06-kora-repository-hygiene-audit.md) before any cleanup.
 
 ## Public / Private Boundary Note
 
@@ -172,13 +118,8 @@ Most docs in this repository are public-facing unless marked internal.
 
 Internal EOD/SOD prompts are operating artifacts. They should not contain private credentials, personal data, private partner notes, unpublished investor conversations, or other sensitive information.
 
-## Next Cleanup Steps
+## Evidence Preservation Note
 
-Start with the [repository hygiene audit](ops/2026-05-06-kora-repository-hygiene-audit.md).
+Older reports, EOD documents, benchmark summaries, and migration docs may look historical, but they should not be deleted casually. They preserve release, benchmark, paper, EIC/grant, investor, and operating evidence.
 
-Future cleanup should proceed in this order:
-
-1. Audit first.
-2. Add safe links and indexes.
-3. Request explicit approval before moving, renaming, or removing files.
-4. Preserve release and benchmark evidence throughout cleanup.
+Use the [repository hygiene audit](ops/2026-05-06-kora-repository-hygiene-audit.md) before any cleanup.

--- a/docs/assets/kora-benchmark-evidence-card.svg
+++ b/docs/assets/kora-benchmark-evidence-card.svg
@@ -1,0 +1,22 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="420" viewBox="0 0 1200 420" role="img" aria-labelledby="title desc">
+  <title id="title">KORA benchmark evidence card</title>
+  <desc id="desc">A card summarizing the current alpha deterministic-heavy benchmark counters.</desc>
+  <rect width="1200" height="420" fill="#0b1220"/>
+  <text x="64" y="64" fill="#e5f6ff" font-family="Inter, Arial, sans-serif" font-size="30" font-weight="700">Current Alpha Evidence</text>
+  <text x="64" y="100" fill="#8bdcf8" font-family="Inter, Arial, sans-serif" font-size="18">Reproducible deterministic-heavy benchmark workload</text>
+  <g font-family="Inter, Arial, sans-serif" text-anchor="middle">
+    <rect x="80" y="150" width="240" height="150" rx="8" fill="#082f49" stroke="#22d3ee" stroke-width="2"/>
+    <rect x="350" y="150" width="240" height="150" rx="8" fill="#082f49" stroke="#22d3ee" stroke-width="2"/>
+    <rect x="620" y="150" width="240" height="150" rx="8" fill="#1c1917" stroke="#f59e0b" stroke-width="2"/>
+    <rect x="890" y="150" width="240" height="150" rx="8" fill="#082f49" stroke="#22d3ee" stroke-width="2"/>
+    <text x="200" y="220" fill="#e5f6ff" font-size="54" font-weight="800">100</text>
+    <text x="200" y="254" fill="#cbd5e1" font-size="16">tasks</text>
+    <text x="470" y="220" fill="#e5f6ff" font-size="54" font-weight="800">80</text>
+    <text x="470" y="254" fill="#cbd5e1" font-size="16">model invocations avoided</text>
+    <text x="740" y="220" fill="#fff7ed" font-size="54" font-weight="800">20</text>
+    <text x="740" y="254" fill="#fed7aa" font-size="16">model-candidate path</text>
+    <text x="1010" y="220" fill="#e5f6ff" font-size="54" font-weight="800">0</text>
+    <text x="1010" y="254" fill="#cbd5e1" font-size="16">deterministic mismatches</text>
+  </g>
+  <text x="64" y="360" fill="#cbd5e1" font-family="Inter, Arial, sans-serif" font-size="16">Boundary: alpha benchmark evidence, not a universal production cost-reduction claim.</text>
+</svg>

--- a/docs/assets/kora-execution-control-overview.svg
+++ b/docs/assets/kora-execution-control-overview.svg
@@ -1,0 +1,46 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="460" viewBox="0 0 1200 460" role="img" aria-labelledby="title desc">
+  <title id="title">KORA execution control overview</title>
+  <desc id="desc">A diagram comparing model-first execution with a KORA controlled execution path.</desc>
+  <rect width="1200" height="460" fill="#0b1220"/>
+  <text x="60" y="58" fill="#e5f6ff" font-family="Inter, Arial, sans-serif" font-size="28" font-weight="700">Most AI apps call the model too soon.</text>
+  <text x="60" y="92" fill="#8bdcf8" font-family="Inter, Arial, sans-serif" font-size="18">KORA turns requests into structured execution paths before inference.</text>
+  <g fill="none" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M140 178 H315 H490 H665" stroke="#64748b" stroke-width="4"/>
+    <path d="M645 166 L665 178 L645 190" stroke="#64748b" stroke-width="4"/>
+    <path d="M140 318 H315 H490 H665 H840 H1015" stroke="#22d3ee" stroke-width="4"/>
+    <path d="M995 306 L1015 318 L995 330" stroke="#22d3ee" stroke-width="4"/>
+  </g>
+  <g font-family="Inter, Arial, sans-serif" font-size="15" font-weight="700" text-anchor="middle">
+    <text x="90" y="184" fill="#cbd5e1">Before</text>
+    <text x="90" y="324" fill="#cbd5e1">After</text>
+  </g>
+  <g font-family="Inter, Arial, sans-serif" font-size="16" font-weight="600" text-anchor="middle">
+    <g fill="#111827" stroke="#94a3b8" stroke-width="2">
+      <rect x="120" y="140" width="120" height="76" rx="8"/>
+      <rect x="295" y="140" width="120" height="76" rx="8"/>
+      <rect x="470" y="140" width="120" height="76" rx="8"/>
+      <rect x="645" y="140" width="120" height="76" rx="8"/>
+    </g>
+    <text x="180" y="184" fill="#e5e7eb">request</text>
+    <text x="355" y="184" fill="#e5e7eb">prompt</text>
+    <text x="530" y="184" fill="#fbbf24">model</text>
+    <text x="705" y="184" fill="#e5e7eb">output</text>
+    <g fill="#082f49" stroke="#22d3ee" stroke-width="2">
+      <rect x="120" y="280" width="120" height="76" rx="8"/>
+      <rect x="285" y="280" width="140" height="76" rx="8"/>
+      <rect x="460" y="280" width="150" height="76" rx="8"/>
+      <rect x="645" y="280" width="130" height="76" rx="8"/>
+      <rect x="810" y="280" width="150" height="76" rx="8" stroke="#f59e0b"/>
+      <rect x="995" y="280" width="130" height="76" rx="8"/>
+    </g>
+    <text x="180" y="324" fill="#ecfeff">request</text>
+    <text x="355" y="324" fill="#ecfeff">task graph</text>
+    <text x="535" y="314" fill="#ecfeff">deterministic</text>
+    <text x="535" y="336" fill="#ecfeff">path</text>
+    <text x="710" y="324" fill="#ecfeff">validation</text>
+    <text x="885" y="314" fill="#fff7ed">model</text>
+    <text x="885" y="336" fill="#fff7ed">escalation</text>
+    <text x="1060" y="324" fill="#ecfeff">telemetry</text>
+  </g>
+  <text x="60" y="420" fill="#e5f6ff" font-family="Inter, Arial, sans-serif" font-size="22" font-weight="700">Structure first. Inference second.</text>
+</svg>

--- a/docs/assets/kora-help-test-flow.svg
+++ b/docs/assets/kora-help-test-flow.svg
@@ -1,0 +1,37 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="420" viewBox="0 0 1200 420" role="img" aria-labelledby="title desc">
+  <title id="title">KORA help-test flow</title>
+  <desc id="desc">A flow showing how developers can bring a workload, map deterministic paths, define escalation rules, run KORA, inspect telemetry, and share results.</desc>
+  <rect width="1200" height="420" fill="#f8fafc"/>
+  <text x="56" y="58" fill="#0f172a" font-family="Inter, Arial, sans-serif" font-size="30" font-weight="700">Help Test KORA</text>
+  <text x="56" y="90" fill="#475569" font-family="Inter, Arial, sans-serif" font-size="17">Bring a sanitized workload and measure the execution path.</text>
+  <g fill="none" stroke="#0891b2" stroke-width="3" stroke-linecap="round">
+    <path d="M165 230 H1010"/>
+    <path d="M990 218 L1010 230 L990 242"/>
+  </g>
+  <g font-family="Inter, Arial, sans-serif" text-anchor="middle">
+    <g fill="#ffffff" stroke="#0891b2" stroke-width="2">
+      <rect x="50" y="160" width="150" height="140" rx="8"/>
+      <rect x="240" y="160" width="150" height="140" rx="8"/>
+      <rect x="430" y="160" width="150" height="140" rx="8"/>
+      <rect x="620" y="160" width="150" height="140" rx="8"/>
+      <rect x="810" y="160" width="150" height="140" rx="8"/>
+      <rect x="1000" y="160" width="150" height="140" rx="8"/>
+    </g>
+    <text x="125" y="214" fill="#0f172a" font-size="16" font-weight="700">Bring</text>
+    <text x="125" y="238" fill="#475569" font-size="14">workload</text>
+    <text x="315" y="208" fill="#0f172a" font-size="16" font-weight="700">Map</text>
+    <text x="315" y="232" fill="#475569" font-size="14">deterministic</text>
+    <text x="315" y="252" fill="#475569" font-size="14">paths</text>
+    <text x="505" y="208" fill="#0f172a" font-size="16" font-weight="700">Define</text>
+    <text x="505" y="232" fill="#475569" font-size="14">escalation</text>
+    <text x="505" y="252" fill="#475569" font-size="14">rules</text>
+    <text x="695" y="214" fill="#0f172a" font-size="16" font-weight="700">Run KORA</text>
+    <text x="695" y="238" fill="#475569" font-size="14">locally</text>
+    <text x="885" y="208" fill="#0f172a" font-size="16" font-weight="700">Inspect</text>
+    <text x="885" y="232" fill="#475569" font-size="14">telemetry</text>
+    <text x="885" y="252" fill="#475569" font-size="14">counters</text>
+    <text x="1075" y="214" fill="#0f172a" font-size="16" font-weight="700">Share</text>
+    <text x="1075" y="238" fill="#475569" font-size="14">results</text>
+  </g>
+  <text x="56" y="360" fill="#0f172a" font-family="Inter, Arial, sans-serif" font-size="20" font-weight="700">Do not share secrets, API keys, private user data, or proprietary datasets in public channels.</text>
+</svg>

--- a/docs/assets/kora-validation-roadmap.svg
+++ b/docs/assets/kora-validation-roadmap.svg
@@ -1,0 +1,36 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="420" viewBox="0 0 1200 420" role="img" aria-labelledby="title desc">
+  <title id="title">KORA validation roadmap</title>
+  <desc id="desc">A roadmap from current alpha evidence to real model-call validation and workload-specific tests.</desc>
+  <rect width="1200" height="420" fill="#f8fafc"/>
+  <text x="56" y="58" fill="#0f172a" font-family="Inter, Arial, sans-serif" font-size="30" font-weight="700">KORA Validation Roadmap</text>
+  <text x="56" y="90" fill="#475569" font-family="Inter, Arial, sans-serif" font-size="17">Current alpha evidence moves toward real model-call and workload-specific validation.</text>
+  <g fill="none" stroke="#0891b2" stroke-width="4" stroke-linecap="round">
+    <path d="M170 222 H1000"/>
+    <path d="M980 210 L1000 222 L980 234"/>
+  </g>
+  <g font-family="Inter, Arial, sans-serif" text-anchor="middle">
+    <g fill="#ffffff" stroke="#0891b2" stroke-width="2">
+      <rect x="70" y="150" width="180" height="144" rx="8"/>
+      <rect x="290" y="150" width="180" height="144" rx="8"/>
+      <rect x="510" y="150" width="180" height="144" rx="8"/>
+      <rect x="730" y="150" width="180" height="144" rx="8"/>
+      <rect x="950" y="150" width="180" height="144" rx="8"/>
+    </g>
+    <text x="160" y="196" fill="#0f172a" font-size="17" font-weight="700">Current alpha</text>
+    <text x="160" y="226" fill="#475569" font-size="14">deterministic-heavy</text>
+    <text x="160" y="248" fill="#475569" font-size="14">benchmark</text>
+    <text x="380" y="190" fill="#0f172a" font-size="17" font-weight="700">Real model-call</text>
+    <text x="380" y="220" fill="#475569" font-size="14">runtime-integrated</text>
+    <text x="380" y="242" fill="#475569" font-size="14">paths</text>
+    <text x="600" y="196" fill="#0f172a" font-size="17" font-weight="700">Support triage</text>
+    <text x="600" y="226" fill="#475569" font-size="14">repetitive support</text>
+    <text x="600" y="248" fill="#475569" font-size="14">routing</text>
+    <text x="820" y="196" fill="#0f172a" font-size="17" font-weight="700">RAG routing</text>
+    <text x="820" y="226" fill="#475569" font-size="14">answer and refusal</text>
+    <text x="820" y="248" fill="#475569" font-size="14">paths</text>
+    <text x="1040" y="190" fill="#0f172a" font-size="17" font-weight="700">Agent budget</text>
+    <text x="1040" y="220" fill="#475569" font-size="14">guardrails and</text>
+    <text x="1040" y="242" fill="#475569" font-size="14">escalation</text>
+  </g>
+  <text x="56" y="360" fill="#0f172a" font-family="Inter, Arial, sans-serif" font-size="20" font-weight="700">Measure: requests, model calls, avoided calls, latency, tokens, cost where applicable, fallbacks, errors, validation.</text>
+</svg>

--- a/docs/benchmark-real-app.md
+++ b/docs/benchmark-real-app.md
@@ -128,4 +128,4 @@ Example snippet:
 - savings_usd: 0.00001665
 - savings_percent: 11.2462%
 
-KORA reduced estimated cost by ~11.25% in this long-request run mainly by reducing output tokens.
+This single long-request run showed lower estimated cost because output tokens were lower. Treat this as exploratory local-run telemetry, not a production cost-reduction claim or real API-cost reduction proof.

--- a/docs/benchmarks/kora_benchmark_result_v1_100.md
+++ b/docs/benchmarks/kora_benchmark_result_v1_100.md
@@ -6,13 +6,13 @@ Date: 2026-05-04
 
 This document records the current simulated benchmark result for KORA's reproducible 100-task deterministic-heavy workload.
 
-This is a controlled benchmark artifact for the path toward v0.2.0-alpha. It is not a production benchmark, does not use real model calls, and does not measure real API cost.
+This is a controlled benchmark artifact for the current alpha evidence path. It is not a production benchmark, does not use real model calls, and does not measure real API cost.
 
 ## Repository Context
 
 | Item | Value |
 |---|---|
-| Public HEAD | `origin/main b7c555e0dfe0687cdf05177c03eacac0743079a5` |
+| Public HEAD at original benchmark recording | `origin/main b7c555e0dfe0687cdf05177c03eacac0743079a5` |
 | Generator | `experiments/generate_workload.py` |
 | Workload | `experiments/workloads/deterministic_heavy_v1_100.json` |
 | Benchmark runner | `experiments/run_benchmark.py` |
@@ -75,11 +75,15 @@ The committed workload was regenerated with the same seed, count, and benchmark 
 | Avoided model invocations | 80 |
 | Avoided invocation rate | 80% |
 
+## Approved Public Claim
+
+KORA reduced model invocations by 80% in a reproducible deterministic-heavy benchmark workload.
+
 ## Safe Interpretation
 
-In a reproducible 100-task deterministic-heavy benchmark workload, KORA-controlled execution avoided 80 of 100 simulated model invocations versus a naive direct baseline.
+This should be interpreted as a reproducible deterministic-heavy alpha benchmark result. The simulated baseline and KORA-controlled counters explain the measurement method: the direct baseline counted 100 simulated model invocations while the KORA-controlled path counted 20.
 
-This should be interpreted as a reproducible simulated benchmark result. It shows that the current generator, workload, and benchmark runner can produce a stable deterministic-heavy comparison suitable for further v0.2.0-alpha benchmark hardening.
+This evidence is suitable for alpha validation and further runtime-integrated testing. It is not production cost reduction proof or real API-cost reduction proof.
 
 ## Non-Claims
 
@@ -143,7 +147,7 @@ Current validation status:
 - The avoided invocation rate is based on workload metadata and simulated benchmark modes.
 - Correctness scoring against deterministic `expected_output` fields is not yet reported as a benchmark metric.
 
-## Next Steps Toward v0.2.0-alpha
+## Next Steps
 
 1. Add stronger correctness checks for deterministic tasks.
 2. Add benchmark summary generation from structured result JSON.

--- a/docs/benchmarks/validation-roadmap.md
+++ b/docs/benchmarks/validation-roadmap.md
@@ -1,0 +1,210 @@
+# KORA Validation Roadmap
+
+## Purpose
+
+This document defines the public validation path for KORA after the `v0.3.0-alpha` release.
+
+KORA's message is simple:
+
+Most AI apps call the model too soon. KORA changes the default. Structure first. Inference second.
+
+The validation roadmap turns that message into measurable evidence. Each target below is designed to test whether KORA can reduce unnecessary model invocation while preserving useful outputs, validation results, and runtime telemetry.
+
+![KORA validation roadmap](../assets/kora-validation-roadmap.svg)
+
+## Current Alpha Evidence
+
+The current approved public claim is:
+
+> KORA reduced model invocations by 80% in a reproducible deterministic-heavy benchmark workload.
+
+This result is based on the current deterministic-heavy alpha benchmark. It should not be interpreted as production cost reduction proof, real API-cost reduction proof, production benchmark proof, broad workload superiority proof, or energy reduction evidence.
+
+## Next Validation Targets
+
+The next validation targets move from deterministic-heavy alpha evidence toward runtime-integrated and workload-specific evidence:
+
+1. Runtime-integrated benchmark paths with real model calls
+2. Customer-support triage workloads
+3. RAG answer-routing workloads
+4. Agent budget-guard workloads
+
+## Target 1: Runtime-integrated benchmark paths with real model calls
+
+Purpose:
+
+Test KORA-controlled execution against a baseline that uses real model calls under a documented runtime path.
+
+Example workload:
+
+A mixed set of deterministic requests, simple classification requests, and model-required reasoning requests executed with a real model provider in a controlled environment.
+
+Counters to measure:
+
+- total requests
+- baseline model calls
+- KORA-controlled model calls
+- avoided model calls
+- latency
+- token usage where applicable
+- estimated or measured cost where applicable
+- fallback count
+- error count
+- validation result
+
+What claim could become possible after validation:
+
+KORA may be able to say: "KORA reduced measured model invocations by X% in a runtime-integrated benchmark using real model calls."
+
+What still cannot be claimed:
+
+This would still not prove universal production cost reduction, broad workload superiority, energy reduction, or production validation.
+
+## Target 2: Customer-support triage workloads
+
+Purpose:
+
+Test whether repetitive support requests can be routed through deterministic classification, policy checks, and escalation rules before model use.
+
+Example workload:
+
+Support tickets that include password reset requests, order-status questions, refund-policy questions, account-risk cases, and ambiguous cases requiring model escalation.
+
+Counters to measure:
+
+- total requests
+- baseline model calls
+- KORA-controlled model calls
+- avoided model calls
+- latency
+- token usage where applicable
+- estimated or measured cost where applicable
+- fallback count
+- error count
+- validation result
+
+What claim could become possible after validation:
+
+KORA may be able to report measured model-call reduction for a documented customer-support triage workload.
+
+What still cannot be claimed:
+
+This would not prove results across all customer-support systems, all ticket distributions, production cost reduction, or customer satisfaction improvement.
+
+## Target 3: RAG answer-routing workloads
+
+Purpose:
+
+Test whether retrieval confidence, deterministic rules, and validation can decide when an answer can be returned, when it should be refused, and when a model call is needed.
+
+Example workload:
+
+Repeated internal knowledge-base questions where some answers are exact-match retrieval, some require synthesis, and some should be escalated or rejected because source evidence is missing.
+
+Counters to measure:
+
+- total requests
+- baseline model calls
+- KORA-controlled model calls
+- avoided model calls
+- latency
+- token usage where applicable
+- estimated or measured cost where applicable
+- fallback count
+- error count
+- validation result
+
+What claim could become possible after validation:
+
+KORA may be able to report measured model-call reduction and answer-routing outcomes for a documented RAG workload.
+
+What still cannot be claimed:
+
+This would not prove answer quality superiority, universal hallucination reduction, production cost reduction, or broad RAG workload superiority.
+
+## Target 4: Agent budget-guard workloads
+
+Purpose:
+
+Test whether KORA can enforce execution budgets, retry boundaries, and escalation rules around agent-like workflows.
+
+Example workload:
+
+Agent workflows that include deterministic preprocessing, tool selection, retry limits, model escalation rules, and budget stops for repeated or low-value requests.
+
+Counters to measure:
+
+- total requests
+- baseline model calls
+- KORA-controlled model calls
+- avoided model calls
+- latency
+- token usage where applicable
+- estimated or measured cost where applicable
+- fallback count
+- error count
+- validation result
+
+What claim could become possible after validation:
+
+KORA may be able to report measured model-call reduction and budget-rule enforcement for a documented agent workload.
+
+What still cannot be claimed:
+
+This would not prove general agent reliability, universal cost savings, production performance, or broad workload superiority.
+
+## What We Will Measure
+
+Every validation target should record:
+
+- total requests
+- baseline model calls
+- KORA-controlled model calls
+- avoided model calls
+- latency
+- token usage where applicable
+- estimated or measured cost where applicable
+- fallback count
+- error count
+- validation result
+
+Where possible, validation should also record workload distribution, model/provider configuration, prompt templates, deterministic rules, escalation rules, and telemetry event counts.
+
+## Claim Upgrade Path
+
+Current approved public claim:
+
+> KORA reduced model invocations by 80% in a reproducible deterministic-heavy benchmark workload.
+
+Future conditional claim after runtime-integrated real model-call validation:
+
+> KORA reduced measured model invocations by X% in a runtime-integrated benchmark using real model calls.
+
+That future claim is not approved as a current claim. It requires merged evidence, documented methodology, validation commands, reviewed results, and claim-registry approval.
+
+## Non-Claims
+
+Do not claim:
+
+- KORA reduces production AI costs by 80%.
+- KORA reduces real API costs by 80%.
+- KORA reduces energy consumption by 80%.
+- KORA proves broad workload superiority.
+- KORA is validated in production.
+- KORA guarantees cost reduction.
+- KORA is formally government validated.
+- KORA has signed partner validation unless actually signed and documented.
+
+## How To Help
+
+We are looking for early developers and AI app teams who want to test KORA against real workloads.
+
+Good starting points:
+
+- [Help Test KORA](../community/help-test-kora.md)
+- [Runtime evidence reviewer guide](../reports/v0.3.0-alpha-runtime-evidence-reviewer-guide.md)
+- [Claim registry](../claims/kora-claim-registry.md)
+
+Open a GitHub Discussion or contact the project maintainers with a sanitized workload description. Do not share secrets, API keys, private user data, or proprietary datasets in public channels.
+
+TODO: Add the canonical GitHub Discussions URL and maintainer contact route once they are finalized.

--- a/docs/claims/kora-claim-registry.md
+++ b/docs/claims/kora-claim-registry.md
@@ -20,7 +20,7 @@ Vision phrase:
 
 Approved category one-liner:
 
-> KORA is an AI Execution Control Layer that structures AI requests into verifiable task graphs before escalating to expensive model inference.
+> KORA is an open-source execution-control layer that turns AI requests into structured execution paths before inference.
 
 Approved technical one-liner:
 
@@ -28,13 +28,20 @@ Approved technical one-liner:
 
 Approved OSS one-liner:
 
-> KORA is an open-source infrastructure project for building inference-first AI systems.
+> KORA helps developers put structure before inference: task graphs, deterministic-first execution, validation, telemetry, and model escalation only when needed.
+
+Approved message spine:
+
+- Hook: Most AI apps call the model too soon.
+- Shift: KORA puts execution control before inference.
+- Mechanism: Task graphs. Deterministic-first execution. Validation before escalation. Telemetry around every path. Model calls only when needed.
+- Tagline: Structure first. Inference second.
 
 ## Current Approved Benchmark Claim
 
 Use exactly:
 
-> In a reproducible 100-task deterministic-heavy benchmark workload, KORA-controlled execution avoided 80 of 100 simulated model invocations versus a naive direct baseline.
+> KORA reduced model invocations by 80% in a reproducible deterministic-heavy benchmark workload.
 
 Supporting detail:
 
@@ -57,16 +64,16 @@ Supporting detail:
 | Claim | Status | Allowed wording | Forbidden wording | Required evidence before escalation | Approved channels |
 |---|---|---|---|---|---|
 | Category claim: KORA as AI Execution Control Layer | Approved | KORA is an AI Execution Control Layer. | KORA has already become the dominant execution-control standard. | Broader adoption evidence before dominance language. | README, docs, discussions, social, investor/EIC intro, partner intro |
-| vLLM analogy claim | Review required | KORA aims to become category-defining for execution control before unnecessary inference is invoked, similar to how vLLM became category-defining for LLM serving. | KORA is already the vLLM of execution control. | Adoption, deployment, and ecosystem evidence before stronger analogy. | Docs, investor/EIC drafts, partner drafts with Albert review |
-| v0.2.0-alpha release claim | Approved | KORA v0.2.0-alpha is a prerelease with bounded deterministic-heavy benchmark evidence. | v0.2.0-alpha proves broad operational impact. | Additional release evidence before expanded impact wording. | Releases, changelog, README, docs |
-| deterministic-heavy benchmark claim | Approved with exact wording | In a reproducible 100-task deterministic-heavy benchmark workload, KORA-controlled execution avoided 80 of 100 simulated model invocations versus a naive direct baseline. | KORA reduced real costs by 80%. | Runtime-integrated and real billing evidence before cost language. | README, docs, release notes, social with exact wording |
-| runtime-integrated benchmark claim | Not approved yet | Runtime-integrated benchmark evidence is planned. | KORA has full runtime-integrated benchmark proof. | Merged runtime-integrated benchmark, result artifacts, validation commands, reviewed report. | Internal roadmap until evidence exists |
+| vLLM analogy claim | Review required | KORA aims to become category-defining for execution control before unnecessary inference is invoked, similar to how vLLM became category-defining for LLM serving. | KORA is already the vLLM of execution control. | Adoption, deployment, and ecosystem evidence before stronger analogy. | Docs, investor/EIC drafts, partner drafts with maintainer review |
+| v0.3.0-alpha release claim | Approved | KORA v0.3.0-alpha is a prerelease with bounded deterministic-heavy benchmark evidence and an initial runtime-path evidence flow. | v0.3.0-alpha proves broad operational impact. | Additional release evidence before expanded impact wording. | Releases, changelog, README, docs |
+| deterministic-heavy benchmark claim | Approved with exact wording | KORA reduced model invocations by 80% in a reproducible deterministic-heavy benchmark workload. | KORA reduced real costs by 80%. | Runtime-integrated and real billing evidence before cost language. | README, docs, release notes, social with exact wording |
+| runtime-integrated benchmark claim | Not approved yet | Runtime-integrated benchmark evidence is planned. | KORA has full runtime-integrated benchmark proof. | Runtime-integrated benchmark with real model calls, result artifacts, validation commands, reviewed report. | Internal roadmap until evidence exists |
 | real application workload replay claim | Not approved yet | Real application workload replay is a future evidence track. | KORA has proven results on real application workloads. | Reproducible real workload replay, source path, validation, report. | Internal roadmap until evidence exists |
 | production cost reduction claim | Prohibited | Not currently supported. | KORA proves production cost reduction. | Production deployment evidence, baseline, billing data, methodology, review. | None until evidence exists |
 | real API cost reduction claim | Prohibited | Not currently supported. | KORA proves real API-cost reduction. | Real API usage data, billing methodology, baseline, review. | None until evidence exists |
 | cloud/data center validation claim | Prohibited unless documented | Exploratory infrastructure conversations may be tracked internally. | KORA is validated by cloud/data center partners. | Signed or documented validation, approved wording, source record. | Partner docs only after approval |
 | energy efficiency claim | Prohibited | Not currently supported. | KORA proves energy reduction. | Energy methodology, measurement, baseline, third-party review if needed. | None until evidence exists |
-| government/institution interest claim | Review required | Exploratory discussion or early interest, if true. | Government validation or government-approved KORA. | Written documentation and Albert approval. | Internal tracking or approved partner/EIC material |
+| government/institution interest claim | Review required | Exploratory discussion or early interest, if true. | Government validation or government-approved KORA. | Written documentation and maintainer approval. | Internal tracking or approved partner/EIC material |
 | partner/LOI claim | Review required | LOI candidate or partner discussion, if true. | Signed partnership unless actually signed. | Signed document or written record, approved wording. | Partner tracker, approved outreach |
 | community adoption claim | Review required | Early community feedback or initial contributors, if documented. | KORA has guaranteed adoption. | Public metrics, issue/discussion activity, contributor evidence. | Community updates with review if numeric |
 | paper/publication claim | Review required | Technical report in preparation. | Peer-reviewed proof or accepted paper unless accepted/published. | Accepted publication, DOI/proceedings link, paper artifact. | Paper roadmap, docs, investor/EIC drafts with review |
@@ -87,6 +94,14 @@ Forbidden:
 
 Do not claim:
 
+- KORA reduces production AI costs by 80%.
+- KORA reduces real API costs by 80%.
+- KORA reduces energy consumption by 80%.
+- KORA proves broad workload superiority.
+- KORA is validated in production.
+- KORA guarantees cost reduction.
+- KORA is formally government validated.
+- KORA has signed partner validation unless actually signed and documented.
 - production cost reduction proof
 - real API-cost reduction proof
 - production benchmark proof
@@ -100,9 +115,17 @@ Do not claim:
 - EIC approval or grant success
 - investor commitment unless documented
 
+## Next Possible Claim
+
+After runtime-integrated real model-call validation, KORA may be able to say:
+
+> KORA reduced measured model invocations by X% in a runtime-integrated benchmark using real model calls.
+
+This is a future conditional claim, not a current claim. It requires merged evidence, documented methodology, validation commands, reviewed results, and claim-registry approval.
+
 ## Channel Review Levels
 
-Level A: Safe to publish without Albert review.
+Level A: Safe to publish without maintainer review.
 
 Examples:
 
@@ -112,7 +135,7 @@ Examples:
 - Open-source contribution invitation.
 - "unpaid early contributor role" language.
 
-Level B: Requires Albert review.
+Level B: Requires maintainer review.
 
 Examples:
 
@@ -140,8 +163,8 @@ Examples:
 
 - Any LLM-generated KORA content must be checked against this registry.
 - LLMs must not invent evidence, partners, grants, investors, publications, or benchmark results.
-- LLM-generated content mentioning numbers, partners, grants, or papers requires Albert review.
-- If an LLM is uncertain whether a phrase is allowed, it should mark the phrase for Albert review instead of publishing it.
+- LLM-generated content mentioning numbers, partners, grants, or papers requires maintainer review.
+- If an LLM is uncertain whether a phrase is allowed, it should mark the phrase for maintainer review instead of publishing it.
 
 ## Update Policy
 

--- a/docs/claims/kora-public-language-guide.md
+++ b/docs/claims/kora-public-language-guide.md
@@ -10,35 +10,35 @@ Use it with `docs/claims/kora-claim-registry.md` when drafting README copy, GitH
 
 README:
 
-> KORA is an open-source AI Execution Control Layer that structures AI requests into verifiable task graphs before escalating to expensive model inference.
+> Most AI apps call the model too soon. KORA turns AI requests into structured execution paths before inference.
 
 GitHub Discussions:
 
-> KORA helps developers explore deterministic-first execution, validation, fallback, and telemetry before model calls become the default path.
+> KORA helps developers put execution control before inference: task graphs, deterministic-first execution, validation, telemetry, and model escalation only when needed.
 
 X/Twitter:
 
-> KORA is building an AI Execution Control Layer: task graphs, deterministic routing, validation, fallback, and telemetry before unnecessary inference.
+> Most AI apps call the model too soon. KORA changes the default. Structure first. Inference second.
 
 LinkedIn:
 
-> KORA is an open-source infrastructure project for AI execution control. It structures requests into verifiable task graphs and escalates to model inference only when needed.
+> KORA is an open-source execution-control layer for AI workloads. It turns requests into task graphs, runs deterministic work first, validates the path, records telemetry, and escalates to a model only when needed.
 
 Telegram:
 
-> KORA is the open-source AI Execution Control Layer project. Use this repo for issues, discussions, PRs, benchmark feedback, and community coordination: https://github.com/Krako-Labs/KORA
+> KORA is open-source execution control for AI workloads. Clone the repo, run the alpha, inspect the path, and bring a workload: https://github.com/Krako-Labs/KORA
 
 Investor intro:
 
-> KORA is building the AI Execution Control Layer: infrastructure that structures AI requests into task graphs, routes deterministic work away from unnecessary model invocation, and preserves validation and telemetry before inference escalation.
+> KORA is building open-source execution control for AI workloads: infrastructure that turns requests into task graphs, routes deterministic work before model invocation, and preserves validation and telemetry before inference escalation.
 
 EIC/grant intro:
 
-> KORA is an open-source AI infrastructure project focused on execution control before inference escalation, with a bounded public benchmark evidence path and a roadmap toward runtime-integrated evaluation.
+> KORA is an open-source AI infrastructure project focused on execution control before inference escalation, with bounded public alpha evidence and a roadmap toward runtime-integrated real model-call evaluation.
 
 Partner intro:
 
-> KORA explores how AI systems can control execution before inference escalation through task graphs, deterministic routing, validation, fallback, and telemetry.
+> KORA explores how AI systems can control execution before inference escalation through task graphs, deterministic-first execution, validation, fallback, and telemetry.
 
 Paper intro:
 
@@ -50,11 +50,13 @@ Paper intro:
 
 > Same code, same history, bigger mission.
 
+Do not make Krako the main README narrative. In the KORA README, Krako belongs near the bottom in an Ecosystem / Related Projects section.
+
 ## Approved Benchmark Wording
 
 Short version:
 
-> In a reproducible 100-task deterministic-heavy benchmark workload, KORA-controlled execution avoided 80 of 100 simulated model invocations versus a naive direct baseline.
+> KORA reduced model invocations by 80% in a reproducible deterministic-heavy benchmark workload.
 
 Technical version:
 
@@ -62,25 +64,34 @@ Technical version:
 
 Social media version:
 
-> In KORA's reproducible 100-task deterministic-heavy benchmark, KORA-controlled execution avoided 80 of 100 simulated model invocations versus a naive direct baseline. This is simulated benchmark evidence, not a production claim.
+> KORA reduced model invocations by 80% in a reproducible deterministic-heavy benchmark workload. This is alpha benchmark evidence, not a production claim.
 
 Paper-safe version:
 
-> In the current deterministic-heavy benchmark workload, KORA-controlled execution avoids 80 of 100 simulated model invocations relative to a naive direct baseline, with 80 deterministic outputs checked and 0 mismatches.
+> KORA reduced model invocations by 80% in the current reproducible deterministic-heavy benchmark workload, with 80 deterministic outputs checked and 0 mismatches.
 
 Investor/EIC-safe version:
 
-> KORA's current public evidence is a reproducible simulated benchmark: in a 100-task deterministic-heavy workload, KORA-controlled execution avoided 80 of 100 simulated model invocations versus a naive direct baseline. The next evidence track is runtime-integrated evaluation.
+> KORA's current public evidence is a reproducible deterministic-heavy benchmark workload where model invocations were reduced by 80%. The next evidence track is runtime-integrated validation with real model calls.
 
 ## Prohibited Rewrites
 
 Do not rewrite:
 
+- "KORA reduced model invocations by 80% in a reproducible deterministic-heavy benchmark workload" as "KORA reduces production AI costs by 80%."
 - "80 of 100 simulated model invocations avoided" as "80% cost reduction."
 - "simulated model invocation" as "real API call."
 - "benchmark workload" as "production workload."
 - "interest" as "partnership."
 - "planned validation" as "validated."
+
+## Next Possible Claim
+
+Future conditional language after runtime-integrated real model-call validation:
+
+> KORA reduced measured model invocations by X% in a runtime-integrated benchmark using real model calls.
+
+Do not use this as a current claim. It requires merged evidence, documented methodology, validation commands, reviewed results, and claim-registry approval.
 
 ## Public Contributor Role Boundary Language
 
@@ -126,15 +137,16 @@ Forbidden unless actually accepted or published:
 You are writing public KORA content.
 
 Use these approved one-liners:
-- KORA is an AI Execution Control Layer that structures AI requests into verifiable task graphs before escalating to expensive model inference.
+- Most AI apps call the model too soon.
+- KORA is an open-source execution-control layer that turns AI requests into structured execution paths before inference.
 - KORA routes deterministic work away from unnecessary model invocation through task graphs, validation, fallback, and telemetry.
 
 Preserve this benchmark wording exactly unless asked to omit the benchmark:
-"In a reproducible 100-task deterministic-heavy benchmark workload, KORA-controlled execution avoided 80 of 100 simulated model invocations versus a naive direct baseline."
+"KORA reduced model invocations by 80% in a reproducible deterministic-heavy benchmark workload."
 
 Do not rewrite simulated benchmark evidence as production evidence, cost reduction, real API-cost reduction, energy reduction, partner validation, government validation, investor commitment, or publication proof.
 
-If a draft mentions numbers, partners, grants, investors, institutions, papers, or adoption, mark it for Albert review.
+If a draft mentions numbers, partners, grants, investors, institutions, papers, or adoption, mark it for maintainer review.
 
 If evidence is missing, write "needs review" instead of inventing support.
 ```

--- a/docs/community/KORA_COMMUNITY_MANAGER_GUIDE.md
+++ b/docs/community/KORA_COMMUNITY_MANAGER_GUIDE.md
@@ -16,15 +16,17 @@ For channel-specific release copy and social/community announcement templates, u
 
 ## Social Launch Focus
 
-For the `v0.3.0-alpha` launch, start with the [KORA Social Media Announcement Guide](KORA_SOCIAL_MEDIA_ANNOUNCEMENT_GUIDE.md). It gives Sumanta ready-to-use launch hooks, post drafts, and reusable image-generation prompt samples.
+For the `v0.3.0-alpha` launch, start with the [KORA Social Media Announcement Guide](KORA_SOCIAL_MEDIA_ANNOUNCEMENT_GUIDE.md). It gives public-safe message examples, benchmark boundaries, and technical visual placeholder guidance.
 
 The main social emphasis should be:
 
-- short attention hooks that make developers stop scrolling
-- the `80 of 100 simulated model invocations` avoided benchmark point
-- the reproducible local evidence flow
+- Hook: Most AI apps call the model too soon.
+- Shift: KORA puts execution control before inference.
+- Mechanism: task graphs, deterministic-first execution, validation before escalation, telemetry around every path, and model calls only when needed.
+- Evidence: KORA reduced model invocations by 80% in a reproducible deterministic-heavy benchmark workload.
+- Next validation: real model-call runtime paths, support triage, RAG routing, and agent budget-guard workloads.
+- CTA: Clone the repo. Run the alpha. Inspect the path. Bring a workload.
 - the release URL: https://github.com/Krako-Labs/KORA/releases/tag/v0.3.0-alpha
-- LinkedIn first, then X/Twitter, Telegram/Discord, and GitHub Discussions
 
 Keep this section focused on launch momentum. Use the rest of this guide for moderation, issue triage, claim-boundary review, and maintainer escalation.
 
@@ -40,7 +42,7 @@ Keep this section focused on launch momentum. Use the rest of this guide for mod
 
 Use this wording when describing the current bounded benchmark result:
 
-> In a reproducible 100-task deterministic-heavy benchmark workload, KORA-controlled execution avoided 80 of 100 simulated model invocations versus a naive direct baseline.
+> KORA reduced model invocations by 80% in a reproducible deterministic-heavy benchmark workload.
 
 Do not strengthen, generalize, or shorten this claim in a way that removes the workload boundary.
 
@@ -53,6 +55,8 @@ Community managers may use these phrases:
 - KORA provides a reproducible local evidence-generation flow.
 - KORA includes JSON output, Markdown evidence packet generation, and telemetry summary commands.
 - KORA's current evidence is bounded to a deterministic-heavy 100-task benchmark workload.
+- KORA is expanding validation across real model-call paths, support triage, RAG routing, and agent budget-guard workloads.
+- Developers can clone the repo, run the alpha, inspect the path, and bring a workload.
 - KORA does not upload raw benchmark artifacts as release assets.
 - The current benchmark flow is a non-production benchmark scaffold.
 
@@ -67,7 +71,7 @@ Do not state or imply:
 - broad workload superiority proof
 - energy reduction evidence
 - formal government validation
-- signed partner validation
+- signed partner validation unless actually signed and documented
 - guaranteed adoption or funding
 
 Escalate to maintainers if a user asks for wording that would imply any of these claims.
@@ -177,7 +181,7 @@ Thanks for checking out KORA. The best starting points are the README, the docs 
 
 The current bounded benchmark claim is:
 
-> In a reproducible 100-task deterministic-heavy benchmark workload, KORA-controlled execution avoided 80 of 100 simulated model invocations versus a naive direct baseline.
+> KORA reduced model invocations by 80% in a reproducible deterministic-heavy benchmark workload.
 
 Please share the exact command you ran, your Python version, whether you used `--offline`, and the counters you saw for total tasks, deterministic routes, fallback/model-candidate routes, avoided simulated model invocations, mismatch count, and telemetry event count.
 
@@ -201,7 +205,11 @@ This now has enough detail to track as an Issue. Please include the command, env
 
 KORA `v0.3.0-alpha` is available as a GitHub prerelease: https://github.com/Krako-Labs/KORA/releases/tag/v0.3.0-alpha
 
-This prerelease includes an initial runtime-path benchmark harness, a reproducible local evidence-generation flow, Markdown evidence packet generation, and telemetry-connected summary commands. In a reproducible 100-task deterministic-heavy benchmark workload, KORA-controlled execution avoided 80 of 100 simulated model invocations versus a naive direct baseline.
+Most AI apps call the model too soon. KORA puts execution control before inference through task graphs, deterministic-first execution, validation before escalation, telemetry around every path, and model calls only when needed.
+
+KORA reduced model invocations by 80% in a reproducible deterministic-heavy benchmark workload.
+
+This prerelease includes an initial runtime-path benchmark harness, a reproducible local evidence-generation flow, Markdown evidence packet generation, and telemetry-connected summary commands.
 
 This is bounded prerelease evidence. It does not claim production cost reduction proof, real API-cost reduction proof, production benchmark proof, full runtime-integrated benchmark evidence, broad workload superiority proof, energy reduction evidence, formal government validation, signed partner validation, or guaranteed adoption or funding.
 
@@ -252,7 +260,7 @@ This prerelease adds an initial runtime-path benchmark harness, a reproducible l
 
 Current bounded benchmark claim:
 
-> In a reproducible 100-task deterministic-heavy benchmark workload, KORA-controlled execution avoided 80 of 100 simulated model invocations versus a naive direct baseline.
+> KORA reduced model invocations by 80% in a reproducible deterministic-heavy benchmark workload.
 
 This prerelease does not claim production cost reduction proof, real API-cost reduction proof, production benchmark proof, full runtime-integrated benchmark evidence, broad workload superiority proof, energy reduction evidence, formal government validation, signed partner validation, or guaranteed adoption or funding.
 

--- a/docs/community/KORA_SOCIAL_MEDIA_ANNOUNCEMENT_GUIDE.md
+++ b/docs/community/KORA_SOCIAL_MEDIA_ANNOUNCEMENT_GUIDE.md
@@ -1,209 +1,157 @@
 # KORA Social Media Announcement Guide
 
-Date: 2026-05-07
+Date: 2026-05-08
 
-Audience: Sumanta and KORA community managers
+Audience: KORA community managers, contributors, and maintainers
 
 Current release: `v0.3.0-alpha`
 
 Release URL: https://github.com/Krako-Labs/KORA/releases/tag/v0.3.0-alpha
 
+## Purpose
+
+This guide keeps public KORA messaging sharp, reproducible, and claim-safe.
+
+Use it for GitHub Discussions, LinkedIn, X/Twitter, Discord, Telegram, README-adjacent copy, and public community updates.
+
+## Public-Safe Message Spine
+
+Hook:
+
+> Most AI apps call the model too soon.
+
+Shift:
+
+> KORA puts execution control before inference.
+
+Mechanism:
+
+- Task graphs.
+- Deterministic-first execution.
+- Validation before escalation.
+- Telemetry around every path.
+- Model calls only when needed.
+
+Evidence:
+
+> KORA reduced model invocations by 80% in a reproducible deterministic-heavy benchmark workload.
+
+Next validation:
+
+> Now we are expanding validation across real model-call paths, support triage, RAG routing, and agent budget-guard workloads.
+
+CTA:
+
+> Clone the repo. Run the alpha. Inspect the path. Bring a workload.
+
+Tagline:
+
+> Structure first. Inference second.
+
 ## Launch Objective
 
-Sumanta's job is to make developers, AI infrastructure builders, open-source contributors, and benchmark-minded reviewers stop scrolling and click the release link.
+The launch message should make developers and AI infrastructure builders understand one thing quickly:
 
-The launch message should create curiosity around a reproducible execution-layer milestone:
+KORA changes the default from model-first execution to structured execution before inference.
 
-- KORA is moving AI execution away from "always call the model."
-- KORA is an execution-control layer for AI workloads.
-- `v0.3.0-alpha` introduces an initial runtime-path benchmark evidence flow.
-- The strongest attention number is: `80 of 100 simulated model invocations avoided`.
-- Developers and reviewers can reproduce the flow locally.
-
-The goal of the first post is not to argue about production proof. The first post should be short, sharp, and evidence-led.
-
-## One-Line Positioning
-
-Use these as opening lines, image overlays, or first-post variants:
-
-- KORA is an execution-control layer for AI workloads.
-- KORA helps decide when not to call the model.
-- Less blind model-calling. More governed execution.
-- AI infra needs a control layer before the model call.
-- KORA turns AI execution into a routed, measurable workflow.
-- `v0.3.0-alpha` makes KORA's runtime-path evidence flow reproducible.
-- Not every AI task needs to become a model call.
-- Structure first. Inference second.
+The release link should be paired with local reproduction and workload-testing invitations, not broad production claims.
 
 ## Strong Short Hooks
 
-Use these for LinkedIn, X/Twitter, Telegram, Discord, or visual overlays:
-
-- What if every AI task did not need to become a model call?
-- The next AI infra layer may be about deciding when not to call the model.
-- KORA `v0.3.0-alpha` is live.
-- 80 of 100 simulated model invocations avoided in a reproducible deterministic-heavy benchmark.
-- Less blind model-calling. More governed execution.
-- We are building the control layer before the model call.
-- KORA now has a runtime-path benchmark evidence flow reviewers can reproduce locally.
-- The release is not a claim. It is a reproducible evidence path.
-- AI execution should be routed, measured, and governed.
-- Not every task needs an LLM.
+- Most AI apps call the model too soon.
+- KORA changes the default.
+- Structure first. Inference second.
 - The model call should be a decision, not the default.
-- KORA brings routing, measurement, and evidence to AI execution.
-- Open-source AI infra needs reproducible evidence, not vague claims.
-- `v0.3.0-alpha`: benchmark command, JSON output, evidence packet, telemetry summary.
-- If deterministic execution is enough, why call the model?
+- Every request should not become a prompt by default.
+- KORA puts execution control before inference.
+- Clone the repo. Run the alpha. Inspect the path. Bring a workload.
+- KORA reduced model invocations by 80% in a reproducible deterministic-heavy benchmark workload.
 
 ## Core Message Pillars
 
-Emphasize these before getting into caveats:
+- **Pain**: Every request becomes a prompt. Every prompt becomes tokens. Every token becomes latency, cost, and infrastructure pressure.
+- **Mechanism**: KORA turns a request into a task graph, runs deterministic work first, validates the path, records telemetry, and escalates to a model only when needed.
+- **Evidence**: KORA reduced model invocations by 80% in a reproducible deterministic-heavy benchmark workload.
+- **Boundary**: This is alpha benchmark evidence, not a universal production cost-reduction claim.
+- **Next step**: KORA needs real workload validation across runtime-integrated model-call paths, support triage, RAG answer routing, and agent budget guards.
 
-- **Execution-control layer**: KORA routes AI workload execution before model invocation.
-- **Avoid unnecessary model calls when deterministic execution is enough**: model calls become an escalation path, not the default path.
-- **Reproducible local benchmark flow**: reviewers can run the same evidence path locally.
-- **Runtime-path benchmark harness**: `v0.3.0-alpha` exercises the runtime path, not only static documentation.
-- **Evidence packet generation**: JSON output can be turned into a Markdown evidence packet.
-- **Telemetry-connected summary**: benchmark output can be summarized through KORA telemetry.
-- **Transparent, bounded evidence**: the release gives a concrete benchmark result without overstating it.
-- **Open-source reviewer workflow**: developers can inspect, reproduce, and question the flow.
-
-## Channel Strategy
+## Channel Guidance
 
 ### LinkedIn
 
-- Lead with the strategic AI infrastructure narrative.
-- Use "not every task should become a model call" as the opening idea.
-- Bring in the `80 of 100 simulated model invocations` number as the concrete proof point.
-- Invite developers and infra builders to reproduce locally.
-- Best asset: clean 16:9 hero image or benchmark counter card.
+- Lead with the developer pain and strategic execution-control narrative.
+- Include the release URL.
+- Include the approved evidence claim.
+- Invite real workload testing.
 
 ### X/Twitter
 
 - Lead with the shortest hook.
-- Use `80 of 100 simulated model invocations` early.
-- Keep every post sharp.
-- Include the release URL.
-- Best asset: square quote card or counter card.
+- Keep the benchmark claim bounded.
+- Link to the release or repo.
+- Ask for workload examples, not hype.
 
-### Telegram/Discord
+### Discord And Telegram
 
-- Lead with "new release is live."
-- Give one command to try.
-- Invite questions and reproduction.
-- Keep it community-friendly.
-- Best asset: compact banner or terminal-first card.
+- Lead with the release and one command to try.
+- Ask people to bring sanitized workloads.
+- Route reproduction questions to GitHub Discussions.
 
 ### GitHub Discussions
 
-- Lead with exact commands, expected counters, and reproducibility.
-- Invite issues/questions if counters mismatch.
+- Lead with commands, expected counters, and reproducibility.
+- Ask for environment details if counters differ.
 - Make the artifact policy clear.
-- Best asset: runtime evidence flow diagram.
 
-## Short Post Formulas
+## Post Templates
 
-Use these formulas when writing new posts:
+### Short Post
 
-- **Hook + number + release link**: "Not every task needs an LLM. KORA `v0.3.0-alpha` avoided 80 of 100 simulated model invocations in a reproducible deterministic-heavy benchmark. Release: <link>"
-- **Problem + KORA framing + benchmark counter + release link**: "AI apps often default to model calls. KORA adds an execution-control layer before that decision. 80/100 simulated model invocations avoided in the current bounded benchmark. <link>"
-- **Number + why it matters + reproducibility + release link**: "80/100 simulated model invocations avoided. The point is not hype; it is a reproducible local evidence path. Try `v0.3.0-alpha`: <link>"
-- **Builder invitation + command + release link**: "Builders: run `python3 -m kora run runtime_integrated_benchmark -- --offline` and inspect the evidence flow. KORA `v0.3.0-alpha`: <link>"
-- **One-line thesis + evidence + call to reproduce**: "AI execution should be routed before inference. KORA now ships a reproducible runtime-path benchmark evidence flow. Reproduce locally: <link>"
+Most AI apps call the model too soon.
 
-## LinkedIn Short Post
-
-Not every AI task needs to become a model call.
-
-KORA `v0.3.0-alpha` is live: https://github.com/Krako-Labs/KORA/releases/tag/v0.3.0-alpha
-
-In the current reproducible deterministic-heavy benchmark, KORA-controlled execution avoided 80 of 100 simulated model invocations.
-
-This release adds a runtime-path benchmark evidence flow: command, JSON output, Markdown evidence packet, and telemetry summary.
-
-Try it locally and inspect the evidence path.
-
-## LinkedIn Longer Post
-
-AI execution should be routed before inference.
-
-Most AI systems still default to a simple pattern: request in, model call out. That is powerful, but it is not always the best execution strategy. Some work can be handled deterministically. Some work needs validation. Some work should only escalate to a model when the runtime path requires it.
-
-KORA is an open-source execution-control layer for AI workloads. It turns AI execution into a routed, measurable workflow before the model call.
-
-KORA `v0.3.0-alpha` is now available as a GitHub prerelease:
-
-https://github.com/Krako-Labs/KORA/releases/tag/v0.3.0-alpha
-
-This milestone adds an initial runtime-path benchmark evidence flow:
-
-- local runtime benchmark command
-- JSON output path
-- Markdown evidence packet/report generation
-- telemetry-connected summary
-- reviewer-facing reproduction path
-
-Current bounded benchmark claim:
-
-> In a reproducible 100-task deterministic-heavy benchmark workload, KORA-controlled execution avoided 80 of 100 simulated model invocations versus a naive direct baseline.
-
-This is an evidence-bounded open-source milestone. Reproduce it locally, inspect the generated evidence packet, and share questions in GitHub Discussions.
-
-## X/Twitter Single Post
-
-Not every AI task needs an LLM.
-
-KORA `v0.3.0-alpha` is live with a reproducible runtime-path benchmark evidence flow.
-
-80 of 100 simulated model invocations avoided in a deterministic-heavy benchmark.
-
-Try it: https://github.com/Krako-Labs/KORA/releases/tag/v0.3.0-alpha
-
-## X/Twitter Thread
-
-1. Not every AI task needs an LLM.
-
-KORA `v0.3.0-alpha` is live: https://github.com/Krako-Labs/KORA/releases/tag/v0.3.0-alpha
-
-2. KORA is an execution-control layer for AI workloads: route first, measure execution, escalate to the model only when needed.
-
-3. This release adds an initial runtime-path benchmark evidence flow: benchmark command, JSON output, Markdown evidence packet, and telemetry summary.
-
-4. Current bounded result: 80 of 100 simulated model invocations avoided in a reproducible deterministic-heavy benchmark.
-
-5. Try the local command:
-
-```bash
-python3 -m kora run runtime_integrated_benchmark -- --offline
-```
-
-6. This is a reproducible evidence path, not a production-cost claim. Run it locally and bring questions to GitHub Discussions.
-
-## Telegram/Discord Short Announcement
+KORA changes the default: structure first, inference second.
 
 KORA `v0.3.0-alpha` is live:
 
 https://github.com/Krako-Labs/KORA/releases/tag/v0.3.0-alpha
 
-This release adds a reproducible runtime-path benchmark evidence flow for KORA's execution-control layer.
+KORA reduced model invocations by 80% in a reproducible deterministic-heavy benchmark workload.
 
-Try it locally:
+Clone the repo. Run the alpha. Inspect the path. Bring a workload.
 
-```bash
-python3 -m kora run runtime_integrated_benchmark -- --offline
-```
+### Longer Post
 
-Current bounded result: 80 of 100 simulated model invocations avoided in a reproducible deterministic-heavy benchmark.
+Most AI apps call the model too soon.
 
-Questions and reproduction notes are welcome in GitHub Discussions.
+Every request becomes a prompt.
+Every prompt becomes tokens.
+Every token becomes latency, cost, and infrastructure pressure.
 
-## GitHub Discussions Announcement
+KORA is an open-source execution-control layer for AI workloads.
+
+It turns a request into a task graph, runs deterministic work first, validates the path, records telemetry, and escalates to a model only when needed.
+
+KORA `v0.3.0-alpha` is live:
+
+https://github.com/Krako-Labs/KORA/releases/tag/v0.3.0-alpha
+
+Current alpha evidence:
+
+KORA reduced model invocations by 80% in a reproducible deterministic-heavy benchmark workload.
+
+This is alpha benchmark evidence, not a universal production cost-reduction claim.
+
+Now we are expanding validation across real model-call paths, support triage, RAG routing, and agent budget-guard workloads.
+
+Clone the repo. Run the alpha. Inspect the path. Bring a workload.
+
+### GitHub Discussions Announcement
 
 KORA `v0.3.0-alpha` is available as a GitHub prerelease:
 
 https://github.com/Krako-Labs/KORA/releases/tag/v0.3.0-alpha
 
-This release adds an initial runtime-path benchmark evidence flow for KORA's execution-control layer.
+Most AI apps call the model too soon. KORA changes the default by putting execution control before inference.
 
 Run the runtime benchmark locally:
 
@@ -245,242 +193,68 @@ Expected runtime counters:
 
 If your counters differ, please open a Benchmark Reproduction discussion with your command, environment, and expected vs actual output.
 
-## Image And Visual Asset Prompts
+## Technical Visual Placeholders
 
-Do not generate images as part of this documentation task. These prompts are reusable samples for later use in image-generation tools.
+Do not generate final marketing images as part of this guide. Use technical diagrams and placeholders that can be reviewed in the repo.
 
-### Prompt 1: Hero Image For LinkedIn
+Preferred asset paths:
 
-Suggested aspect ratio: 16:9
+- `docs/assets/kora-execution-control-overview.svg`
+- `docs/assets/kora-validation-roadmap.svg`
+- `docs/assets/kora-benchmark-evidence-card.svg`
+- `docs/assets/kora-help-test-flow.svg`
 
-Suggested channel: LinkedIn
+Image guidance:
 
-Logo placeholder: include a small `KORA` logo placeholder in a corner.
+- README image: model-first vs KORA-controlled path
+- validation roadmap image: current alpha -> real model-call runtime -> support triage -> RAG routing -> agent budget guard
+- benchmark evidence image: 100 tasks / 80 avoided / 20 model-candidate or escalation path / 0 deterministic mismatches
+- help-test image: bring workload -> map deterministic paths -> define escalation rules -> run KORA -> inspect telemetry -> share results
 
-Prompt:
+Avoid:
 
-```text
-Create a clean technical hero image for an open-source AI infrastructure release. Concept: an AI user request flows into a routing/execution-control layer before any model call happens. The routing layer separates deterministic execution from fallback model-candidate execution. Highlight text: "Not every task needs a model call." Visual style: clean technical diagram, dark navy background with electric cyan routing lines, minimal UI labels, modern developer-tool aesthetic, high contrast, 16:9, no photorealistic people, no cost savings or energy savings claims.
-```
+- generic AI brain
+- fantasy AI art
+- crypto/NFT style
+- gold 3D text
+- people/robot mascot
+- exaggerated cost/energy saving imagery
+- money icons
+- GPU savings icons
+- energy-saving icons
+- unreadable tiny labels
 
-Avoid text implying production cost, real API cost, energy savings, or production validation.
-
-### Prompt 2: Benchmark Counter Card
-
-Suggested aspect ratio: 16:9 and square variants
-
-Suggested channel: LinkedIn, X/Twitter
-
-Logo placeholder: optional `KORA` mark placeholder.
-
-Prompt:
-
-```text
-Create a sharp social media benchmark counter card for an open-source AI execution-control project. Main visual: very large "80/100" number. Subtitle: "simulated model invocations avoided." Small caption: "reproducible deterministic-heavy benchmark." Style: crisp GitHub/Open Source feel, white or dark background option, subtle grid, clean typography, no exaggerated hype, no icons suggesting money savings, no energy imagery, 16:9 and square variants.
-```
-
-Avoid text implying production cost, real API cost, energy savings, or production validation.
-
-### Prompt 3: Runtime Evidence Flow
-
-Suggested aspect ratio: 16:9
-
-Suggested channel: GitHub Discussions, LinkedIn
-
-Logo placeholder: include `KORA` logo placeholder.
-
-Prompt:
-
-```text
-Create a clean developer documentation graphic showing a four-step runtime evidence flow: 1. runtime benchmark command, 2. JSON output, 3. Markdown evidence packet, 4. telemetry summary. Use simple connected blocks with terminal and document icons. Style: clean technical documentation graphic, dark text on light background or dark navy with cyan accents, readable labels, 16:9, no claims about production performance.
-```
-
-Avoid text implying production cost, real API cost, energy savings, or production validation.
-
-### Prompt 4: Before KORA / With KORA Conceptual Graphic
-
-Suggested aspect ratio: 16:9
-
-Suggested channel: LinkedIn
-
-Logo placeholder: optional.
-
-Prompt:
-
-```text
-Create a split-screen technical diagram. Left side titled "Before": many AI tasks all point directly to a model call. Right side titled "With KORA": deterministic tasks route through local execution, while fallback/model-candidate tasks route to a model candidate only when needed. Use clean arrows, simple nodes, minimal labels, dark navy and cyan palette, no cost or energy claims, no exaggerated benchmark language, 16:9.
-```
-
-Avoid text implying production cost, real API cost, energy savings, or production validation.
-
-### Prompt 5: Open-Source Release Card
-
-Suggested aspect ratio: 16:9
-
-Suggested channel: LinkedIn, Discord, Telegram
-
-Logo placeholder: include `KORA` logo placeholder.
-
-Prompt:
-
-```text
-Create a modern open-source release card for "KORA v0.3.0-alpha". Visual concept: GitHub-style prerelease card, terminal command snippet, small evidence-flow diagram, and release link placeholder. Style: modern OSS launch image, developer audience, restrained colors, crisp typography, 16:9. Text should say "GitHub prerelease" and "reproduce locally." Do not show release assets or raw benchmark artifact uploads.
-```
-
-Avoid text implying production cost, real API cost, energy savings, or production validation.
-
-### Prompt 6: Terminal-First Developer Graphic
-
-Suggested aspect ratio: 16:9
-
-Suggested channel: GitHub Discussions, Discord, Telegram
-
-Logo placeholder: optional.
-
-Prompt:
-
-```text
-Create a clean terminal screenshot mockup for a developer audience. The terminal shows this command: python3 -m kora run runtime_integrated_benchmark -- --offline. Surround it with subtle labels: "run locally", "inspect counters", "generate evidence packet". Style: clean terminal UI, dark background, cyan prompt, no fake output beyond simple placeholders, no production claims, 16:9.
-```
-
-Avoid text implying production cost, real API cost, energy savings, or production validation.
-
-### Prompt 7: X/Twitter Visual Card
-
-Suggested aspect ratio: square
-
-Suggested channel: X/Twitter
-
-Logo placeholder: include `KORA` logo placeholder.
-
-Prompt:
-
-```text
-Create a minimal high-contrast quote card for X/Twitter. Main text: "The next AI infra layer may be about deciding when not to call the model." Secondary text: "KORA v0.3.0-alpha". Include a small KORA logo placeholder. Style: bold typography, minimal layout, dark navy background, electric cyan accent, square format, no icons implying money or energy savings.
-```
-
-Avoid text implying production cost, real API cost, energy savings, or production validation.
-
-### Prompt 8: Community Announcement Banner
-
-Suggested aspect ratio: 16:9
-
-Suggested channel: Discord, Telegram, GitHub Discussions
-
-Logo placeholder: include `KORA` logo placeholder.
-
-Prompt:
-
-```text
-Create a friendly but technical community announcement banner. Main text: "KORA v0.3.0-alpha is live." Visual concept: open-source community, GitHub release, and runtime evidence flow. Include subtle terminal, JSON, Markdown, and telemetry symbols connected in a simple flow. Style: welcoming developer-community banner, clean, not corporate, 16:9, no hype, no production proof claims.
-```
-
-Avoid text implying production cost, real API cost, energy savings, or production validation.
-
-### Prompt 9: Execution Routing Diagram
-
-Suggested aspect ratio: 16:9
-
-Suggested channel: LinkedIn, GitHub Discussions
-
-Logo placeholder: include optional `KORA` logo placeholder.
-
-Prompt:
-
-```text
-Create a simple technical routing diagram for an AI execution-control layer. Show one incoming request flowing into a KORA routing layer, then splitting into three labeled paths: deterministic route, fallback route, and telemetry summary. Keep the diagram readable for developers, with clean arrows, restrained colors, dark navy and electric cyan accents, and no cost, savings, or production validation language. Include a small optional KORA logo placeholder.
-```
-
-Avoid text implying production cost, real API cost, energy savings, or production validation.
-
-### Prompt 10: Evidence Packet Visual
-
-Suggested aspect ratio: 16:9
-
-Suggested channel: LinkedIn, GitHub Discussions, Discord
-
-Logo placeholder: include optional `KORA` logo placeholder.
-
-Prompt:
-
-```text
-Create a polished documentation-style graphic showing KORA reviewer artifacts: JSON output, Markdown report, and telemetry summary. Arrange the artifacts as three clean panels connected to a local benchmark command. Main text: "Runtime-path benchmark evidence flow." Style: modern open-source developer documentation, crisp typography, neutral background with cyan accents, no production proof or cost-reduction language.
-```
-
-Avoid text implying production cost, real API cost, energy savings, or production validation.
-
-## Visual Text Snippets
-
-Use these as overlays, subtitles, or post openers:
-
-- Not every AI task needs a model call.
-- 80/100 simulated model invocations avoided.
-- Runtime-path benchmark evidence flow.
-- Reproduce locally.
-- JSON output. Markdown evidence. Telemetry summary.
-- KORA `v0.3.0-alpha` is live.
-- Execution control for AI workloads.
-- Structure first. Inference second.
-- The model call should be a decision.
-
-## Positive Comment Reply Templates
+## Reply Templates
 
 ### Does this reduce real API cost?
 
-Great question. The current milestone is a reproducible local benchmark path, not real API-cost proof. The best way to evaluate this release is to run the local command and inspect the generated evidence packet.
+Not yet. The current milestone is alpha benchmark evidence, not real API-cost proof. The best way to evaluate this release is to run the local command and inspect the generated evidence packet.
 
 ### Is this production benchmark evidence?
 
-For now, we are keeping the claim intentionally bounded to the 100-task deterministic-heavy benchmark. It is a reproducible evidence path, not production benchmark proof.
+No. The current claim is bounded to a reproducible deterministic-heavy benchmark workload. It is not production benchmark proof.
 
 ### Does this prove energy savings?
 
-Not yet. This release focuses on runtime-path benchmark evidence and telemetry summary. We are not making energy-savings claims from this milestone.
+No. KORA is not making energy-reduction claims from this milestone.
 
 ### Can I upload my benchmark JSON?
 
 Please keep generated JSON/Markdown outputs local unless a maintainer asks for a specific artifact. The release does not upload raw benchmark artifacts as assets.
 
-### How do I reproduce this locally?
-
-Run:
-
-```bash
-python3 -m kora run runtime_integrated_benchmark -- --offline
-```
-
-Then generate JSON, the Markdown evidence packet, and telemetry summary using the commands in the GitHub Discussions draft above.
-
 ### Can I compare my own workload?
 
-Yes. Own-workload experiments are welcome, but label them as your own experiment unless they are reviewed and documented as official KORA evidence.
+Yes. Sanitized own-workload experiments are welcome, but label them as your own experiment unless they are reviewed and documented as official KORA evidence.
 
 ### My counters are different.
 
-If your counters differ, please open a Benchmark Reproduction discussion with your command, environment, and expected vs actual counters. Maintainers should review mismatch reports.
-
-### Where should I ask questions?
-
-Use GitHub Discussions for reproduction questions, ideas, and community support. Open an Issue when you have an actionable bug report, docs fix, or scoped proposal.
-
-## Sumanta Launch Checklist
-
-- [ ] Post the LinkedIn short post first.
-- [ ] Share the LinkedIn post internally for amplification.
-- [ ] Post the X/Twitter single post.
-- [ ] Post the X/Twitter thread if useful.
-- [ ] Share the Telegram/Discord announcement.
-- [ ] Pin or repost the GitHub Release link.
-- [ ] Use one visual card for LinkedIn and one for X/Twitter.
-- [ ] Save strong comments/questions for a future FAQ.
-- [ ] Send technical questions to GitHub Discussions.
-- [ ] Escalate benchmark mismatch questions to maintainers.
+Open a Benchmark Reproduction discussion with your command, environment, and expected vs actual counters. Maintainers should review mismatch reports.
 
 ## Boundary Reminder
 
-Safe benchmark claim:
+Approved public benchmark claim:
 
-> In a reproducible 100-task deterministic-heavy benchmark workload, KORA-controlled execution avoided 80 of 100 simulated model invocations versus a naive direct baseline.
+> KORA reduced model invocations by 80% in a reproducible deterministic-heavy benchmark workload.
 
 Do not claim:
 
@@ -491,19 +265,7 @@ Do not claim:
 - broad workload superiority proof
 - energy reduction evidence
 - formal government validation
-- signed partner validation
+- signed partner validation unless actually signed and documented
 - guaranteed adoption or funding
 
-Keep launch posts focused on reproducible benchmark evidence, not production proof.
-
-## Escalation Rule
-
-Escalate to maintainers if:
-
-- someone makes production, API-cost, or energy claims
-- someone reports mismatched counters
-- someone wants to upload raw benchmark artifacts
-- a journalist or investor asks for production numbers
-- someone asks for partner or government validation
-- someone asks whether KORA is proven in production
-- someone proposes changing release assets, package version, tag state, or claim wording
+Keep launch posts focused on reproducible benchmark evidence, validation next steps, and workload invitations.

--- a/docs/community/help-test-kora.md
+++ b/docs/community/help-test-kora.md
@@ -1,0 +1,96 @@
+# Help Test KORA
+
+## Who This Is For
+
+This page is for developers and AI app teams who suspect their system calls the model too soon.
+
+KORA is especially relevant if your workload has repeated requests, deterministic branches, validation rules, escalation rules, or budget limits that should be enforced before inference.
+
+## Current Alpha Evidence
+
+Current approved public claim:
+
+> KORA reduced model invocations by 80% in a reproducible deterministic-heavy benchmark workload.
+
+This is alpha benchmark evidence. It is not production cost reduction proof, real API-cost reduction proof, production benchmark proof, broad workload superiority proof, or energy reduction evidence.
+
+## What We Want To Test Next
+
+KORA's next validation targets are:
+
+1. Runtime-integrated benchmark paths with real model calls
+2. Customer-support triage workloads
+3. RAG answer-routing workloads
+4. Agent budget-guard workloads
+
+The goal is to measure when structure, deterministic execution, validation, and telemetry can reduce unnecessary model invocation without hiding errors or weakening output checks.
+
+![KORA help-test flow](../assets/kora-help-test-flow.svg)
+
+## Good Candidate Workloads
+
+- customer-support triage
+- repetitive RAG workflows
+- agent workflows with budget or escalation rules
+- deterministic-heavy backend workflows
+- LLM apps with high repeated request patterns
+
+Good candidates usually have at least one of these properties:
+
+- some requests can be classified without a model
+- some responses follow strict templates or rules
+- some cases should escalate only after validation fails
+- some workflows need token, retry, or latency budgets
+- repeated requests make direct model-first execution wasteful or hard to inspect
+
+## Workload Submission Template
+
+Use this template for early discussion. Keep it sanitized.
+
+```text
+Workload type:
+
+Current model/API used:
+
+Approximate request volume:
+
+Which requests are repetitive or deterministic?
+
+What should trigger model escalation?
+
+Do you have sample inputs/outputs?
+
+Can results be shared publicly?
+
+Contact:
+```
+
+Do not include secrets, API keys, private user data, proprietary datasets, private credentials, or confidential customer information.
+
+Private or sanitized workloads are acceptable for early discussion. Public benchmark claims require reviewed evidence and explicit approval before publication.
+
+## How To Participate
+
+1. Clone the repo.
+2. Run the alpha locally.
+3. Inspect the execution path and telemetry.
+4. Prepare a sanitized workload description using the template above.
+5. Open a GitHub Discussion or contact the project maintainers.
+
+TODO: Add the canonical GitHub Discussions URL and maintainer contact route once they are finalized.
+
+## What Not To Expect Yet
+
+KORA is still alpha software.
+
+Do not expect:
+
+- production cost reduction proof
+- real API-cost reduction proof
+- production benchmark proof
+- broad workload superiority proof
+- energy reduction evidence
+- formal government validation
+- signed partner validation unless actually signed and documented
+- guaranteed adoption, funding, or support commitments
+

--- a/docs/design/v0.3.0-runtime-integrated-benchmark-evidence-architecture.md
+++ b/docs/design/v0.3.0-runtime-integrated-benchmark-evidence-architecture.md
@@ -6,7 +6,7 @@ This document defines the next benchmark evidence architecture for KORA. It does
 
 ## Current Evidence Baseline
 
-The current public benchmark evidence is the `v0.2.0-alpha` deterministic-heavy benchmark path:
+The current public benchmark evidence is the deterministic-heavy alpha benchmark path:
 
 - workload: `experiments/workloads/deterministic_heavy_v1_100.json`
 - generator: `experiments/generate_workload.py`
@@ -17,7 +17,7 @@ The current public benchmark evidence is the `v0.2.0-alpha` deterministic-heavy 
 
 Safe claim:
 
-> In a reproducible 100-task deterministic-heavy benchmark workload, KORA-controlled execution avoided 80 of 100 simulated model invocations versus a naive direct baseline.
+> KORA reduced model invocations by 80% in a reproducible deterministic-heavy benchmark workload.
 
 Current counters:
 
@@ -239,7 +239,7 @@ For runtime-integrated evidence, any frozen raw artifact decision should additio
 
 | Claim type | Status for `v0.3.0-alpha` design | Notes |
 |---|---|---|
-| Reproducible simulated deterministic-heavy benchmark avoided 80 of 100 simulated model invocations | Safe current claim | Already documented for `v0.2.0-alpha`. |
+| KORA reduced model invocations by 80% in a reproducible deterministic-heavy benchmark workload | Safe current claim | Current approved public claim. |
 | Runtime path benchmark executed through `kora.executor.run_graph` | Future safe claim only after implementation and validation | Requires Layer 1 evidence. |
 | Runtime events were summarized by KORA telemetry | Future safe claim only after implementation and validation | Requires Layer 2 evidence. |
 | Production cost reduction proof | Not safe | Requires production-grade evidence and billing data review. |

--- a/docs/planning/v0.3.1-alpha-roadmap.md
+++ b/docs/planning/v0.3.1-alpha-roadmap.md
@@ -42,7 +42,7 @@ Release state remains:
 
 ## Safe Current Claim
 
-> In a reproducible 100-task deterministic-heavy benchmark workload, KORA-controlled execution avoided 80 of 100 simulated model invocations versus a naive direct baseline.
+> KORA reduced model invocations by 80% in a reproducible deterministic-heavy benchmark workload.
 
 ## Explicit Non-Claims
 

--- a/docs/reports/benchmark_artifact_policy.md
+++ b/docs/reports/benchmark_artifact_policy.md
@@ -29,7 +29,7 @@ Frozen raw artifacts should be intentionally named and reviewed. They should not
 
 Current safe claim:
 
-> In a reproducible 100-task deterministic-heavy benchmark workload, KORA-controlled execution avoided 80 of 100 simulated model invocations versus a naive direct baseline.
+> KORA reduced model invocations by 80% in a reproducible deterministic-heavy benchmark workload.
 
 Forbidden claims:
 
@@ -40,7 +40,7 @@ Forbidden claims:
 - broad workload superiority
 - energy reduction evidence
 
-Benchmark summaries must state that the current evidence is reproducible benchmark evidence from simulated benchmark artifacts, not production cost/API/energy proof.
+Benchmark summaries may explain simulated baseline counters in methodology sections. Public headline claims should use the approved claim above and must not present the evidence as production cost/API/energy proof.
 
 ## Regeneration Guide
 

--- a/docs/reports/task214-pr50-messaging-docs-review.md
+++ b/docs/reports/task214-pr50-messaging-docs-review.md
@@ -1,0 +1,208 @@
+# Task 214 PR50 Messaging Docs Review
+
+Date: 2026-05-08
+
+Reviewer: `hkalbertkim <hkalbert71@gmail.com>`
+
+## PR Reviewed
+
+PR: https://github.com/Krako-Labs/KORA/pull/50
+
+Branch reviewed: `task213_messaging_docs_private_ops_split`
+
+Base reviewed: `origin/main`
+
+## Commit Reviewed
+
+Public KORA commit reviewed:
+
+```text
+595d4651b68813050810f60d52b83d80da493f3d
+```
+
+This review also adds a follow-up documentation-boundary correction and this review report on top of that commit.
+
+## Public Files Reviewed
+
+Reviewed changed public files:
+
+- `README.md`
+- `docs/README.md`
+- `docs/EXECUTIVE-SUMMARY.md`
+- `docs/benchmark-real-app.md`
+- `docs/benchmarks/kora_benchmark_result_v1_100.md`
+- `docs/benchmarks/validation-roadmap.md`
+- `docs/claims/kora-claim-registry.md`
+- `docs/claims/kora-public-language-guide.md`
+- `docs/community/KORA_COMMUNITY_MANAGER_GUIDE.md`
+- `docs/community/KORA_SOCIAL_MEDIA_ANNOUNCEMENT_GUIDE.md`
+- `docs/community/help-test-kora.md`
+- `docs/design/v0.3.0-runtime-integrated-benchmark-evidence-architecture.md`
+- `docs/planning/v0.3.1-alpha-roadmap.md`
+- `docs/reports/benchmark_artifact_policy.md`
+- `docs/reports/v0.3.0-alpha-runtime-evidence-reviewer-guide.md`
+- `docs/assets/kora-execution-control-overview.svg`
+- `docs/assets/kora-validation-roadmap.svg`
+- `docs/assets/kora-benchmark-evidence-card.svg`
+- `docs/assets/kora-help-test-flow.svg`
+
+No raw benchmark JSON artifacts, release assets, package version changes, tags, or release files were added.
+
+## Private Internals Repo Reviewed
+
+Private repository reviewed locally:
+
+```text
+/Users/albertkim/02_PROJECTS/05_KORA_Project/repo/internals
+```
+
+Remote:
+
+```text
+https://github.com/Krako-Labs/internals.git
+```
+
+Private commit reviewed:
+
+```text
+849e0ab77df79f7e593197452f531f5c6344e7fe
+```
+
+The private repo contains the internal KORA operations structure for messaging, community management, social media, visual assets, launch planning, and claim tracking. Those internal materials do not need to be mirrored into the public KORA repository.
+
+## Message Review Result
+
+Pass.
+
+The README opens with the developer pain message:
+
+```text
+Most AI apps call the model too soon.
+```
+
+The README defines KORA as open-source execution control for AI workloads, includes the before/after path, and uses:
+
+```text
+Structure first. Inference second.
+```
+
+Krako is not used as the README hero narrative. It appears near the bottom in the Ecosystem section with:
+
+```text
+KORA is part of the broader Krako infrastructure.
+Krako 2.0: TBD
+```
+
+## Claim Hygiene Review Result
+
+Pass.
+
+The current approved public alpha claim is used:
+
+```text
+KORA reduced model invocations by 80% in a reproducible deterministic-heavy benchmark workload.
+```
+
+The README keeps claim boundaries below the opening section. Benchmark methodology docs preserve the simulated-baseline details without turning the README headline into a simulated-counter explanation.
+
+Forbidden claims were checked and not introduced as current claims:
+
+- production cost reduction proof
+- real API-cost reduction proof
+- production benchmark proof
+- full runtime-integrated benchmark evidence
+- broad workload superiority proof
+- energy reduction evidence
+- formal government validation
+- signed partner validation unless actually signed and documented
+- guaranteed adoption or funding
+
+## Public/Private Separation Review Result
+
+Pass after follow-up correction.
+
+The public PR docs do not add private operating playbooks, private prompt materials, or person-specific operating instructions.
+
+During review, `docs/README.md` still contained internal-style operating-handoff wording. That was replaced with a public documentation boundary note suitable for an open-source docs index.
+
+## Image Placeholder Review Result
+
+Pass.
+
+The SVG files are valid technical placeholders. They show execution-control paths, validation-roadmap structure, benchmark counters, and help-test flow. They do not imply production cost savings, energy savings, GPU savings, real API-cost reduction, or production validation.
+
+## Validation Commands And Results
+
+Public KORA validation:
+
+```bash
+git diff --check
+```
+
+Result: passed.
+
+```bash
+xmllint --noout docs/assets/kora-execution-control-overview.svg docs/assets/kora-validation-roadmap.svg docs/assets/kora-benchmark-evidence-card.svg docs/assets/kora-help-test-flow.svg
+```
+
+Result: passed.
+
+```bash
+python3 -m pytest
+```
+
+Result: `54 passed`.
+
+```bash
+python3 -m kora --help
+```
+
+Result: passed.
+
+```bash
+python3 -m kora examples list
+```
+
+Result: passed.
+
+```bash
+python3 -m kora run direct_vs_kora -- --offline
+```
+
+Result: passed.
+
+```bash
+python3 -m kora run runtime_integrated_benchmark -- --offline
+```
+
+Result: passed with `ok: true`, `total_tasks: 100`, `avoided_simulated_model_invocations: 80`, and `mismatch_count: 0`.
+
+Private internals validation:
+
+```bash
+git status --short --branch
+```
+
+Result: clean on `main...origin/main`.
+
+```bash
+git diff --check
+```
+
+Result: passed.
+
+File tree inspection confirmed the expected private internal structure under `projects/kora/`, `functions/`, and `templates/`.
+
+Secret-pattern grep found no committed secrets. Matches were limited to policy language such as "API keys", "passwords", "credentials", or ordinary words such as "tokens".
+
+## Remaining TODOs
+
+- `Krako 2.0: TBD` remains intentionally because no canonical public repo URL is known from official repo context.
+- Public docs still use a TODO for the canonical GitHub Discussions URL and maintainer contact route.
+- SVG files are technical placeholders, not final marketing images.
+
+## Merge Recommendation
+
+Recommended to merge after this review report commit is pushed and CI, if any, remains green.
+
+Do not create tags, releases, release assets, package version changes, GitHub issues, project boards, repository settings changes, or raw benchmark artifact uploads as part of the merge.

--- a/docs/reports/v0.3.0-alpha-runtime-evidence-reviewer-guide.md
+++ b/docs/reports/v0.3.0-alpha-runtime-evidence-reviewer-guide.md
@@ -100,9 +100,9 @@ python3 -m kora telemetry \
 
 ## Safe Current Claim
 
-> In a reproducible 100-task deterministic-heavy benchmark workload, KORA-controlled execution avoided 80 of 100 simulated model invocations versus a naive direct baseline.
+> KORA reduced model invocations by 80% in a reproducible deterministic-heavy benchmark workload.
 
-This wording remains the approved bounded claim for this evidence path.
+This wording remains the approved bounded public claim for this evidence path. The simulated baseline counters above explain the benchmark methodology and should not be rewritten as production cost reduction, real API-cost reduction, or real API-call reduction proof.
 
 ## Artifact Policy
 


### PR DESCRIPTION
## Summary
- Refactors README around the problem-first message: most AI apps call the model too soon, KORA changes the default, structure first, inference second.
- Adds the approved Current Alpha Evidence wording without using simulated baseline wording as the README headline.
- Adds a validation roadmap and Help Test KORA contributor path.
- Updates claim docs, benchmark docs, and public-safe community/social guidance.
- Adds technical SVG placeholders for execution control, validation roadmap, benchmark evidence, and help-test flow.
- Removes internal workflow links from the public docs index.

## Validation
- git diff --check: passed
- xmllint --noout docs/assets/kora-execution-control-overview.svg docs/assets/kora-validation-roadmap.svg docs/assets/kora-benchmark-evidence-card.svg docs/assets/kora-help-test-flow.svg: passed
- python3 -m pytest: 54 passed
- python3 -m kora --help: passed
- python3 -m kora examples list: passed
- python3 -m kora run direct_vs_kora -- --offline: passed
- python3 -m kora run runtime_integrated_benchmark -- --offline: passed

## Notes
- Krako 2.0 remains TBD because no canonical repository URL was found in official repo docs.
- No releases, tags, release assets, package version changes, GitHub issues, project boards, repository settings, collaborator changes, or raw benchmark artifact uploads were created.