### PR TITLE
Add KORA technical diagrams to README and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,10 @@ For methodology, counters, artifact policy, and reproduction commands, see:
 
 We are looking for early developers and AI app teams who want to test KORA against real workloads.
 
+![KORA validation roadmap](docs/assets/kora-validation-roadmap.svg)
+
+KORA validation roadmap.
+
 See the [KORA validation roadmap](docs/benchmarks/validation-roadmap.md) for the measurement plan.
 
 ## Help Test KORA
@@ -101,6 +105,10 @@ Good candidate workloads:
 To participate, open a GitHub Discussion or contact the project maintainers.
 
 TODO: Add the canonical GitHub Discussions URL and maintainer contact route once they are finalized.
+
+![KORA help-test flow](docs/assets/kora-help-test-flow.svg)
+
+How to help test KORA with a real workload.
 
 See [Help Test KORA](docs/community/help-test-kora.md) for the workload submission template.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -18,6 +18,10 @@ Most AI apps call the model too soon. KORA changes the default. Structure first.
 
 ## Understand
 
+![KORA control layer architecture](assets/kora-control-layer-architecture.svg)
+
+KORA control layer architecture.
+
 - [KORA Claim Registry](claims/kora-claim-registry.md)
 - [KORA Public Language Guide](claims/kora-public-language-guide.md)
 - [Telemetry and observability counters](telemetry-and-observability.md#current-public-counters)

--- a/docs/assets/kora-benchmark-evidence-card.svg
+++ b/docs/assets/kora-benchmark-evidence-card.svg
@@ -1,22 +1,26 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="420" viewBox="0 0 1200 420" role="img" aria-labelledby="title desc">
+<svg xmlns="http://www.w3.org/2000/svg" width="1280" height="430" viewBox="0 0 1280 430" role="img" aria-labelledby="title desc">
   <title id="title">KORA benchmark evidence card</title>
-  <desc id="desc">A card summarizing the current alpha deterministic-heavy benchmark counters.</desc>
-  <rect width="1200" height="420" fill="#0b1220"/>
-  <text x="64" y="64" fill="#e5f6ff" font-family="Inter, Arial, sans-serif" font-size="30" font-weight="700">Current Alpha Evidence</text>
-  <text x="64" y="100" fill="#8bdcf8" font-family="Inter, Arial, sans-serif" font-size="18">Reproducible deterministic-heavy benchmark workload</text>
+  <desc id="desc">A technical benchmark evidence card showing 100 tasks, 80 model invocations avoided, 20 model-candidate path tasks, and 0 deterministic mismatches.</desc>
+  <rect width="1280" height="430" fill="#08111f"/>
+  <text x="64" y="66" fill="#e6f6ff" font-family="Inter, Arial, sans-serif" font-size="34" font-weight="800">Current Alpha Evidence</text>
+  <text x="64" y="100" fill="#8bdcf8" font-family="Inter, Arial, sans-serif" font-size="17">Reproducible deterministic-heavy benchmark workload.</text>
   <g font-family="Inter, Arial, sans-serif" text-anchor="middle">
-    <rect x="80" y="150" width="240" height="150" rx="8" fill="#082f49" stroke="#22d3ee" stroke-width="2"/>
-    <rect x="350" y="150" width="240" height="150" rx="8" fill="#082f49" stroke="#22d3ee" stroke-width="2"/>
-    <rect x="620" y="150" width="240" height="150" rx="8" fill="#1c1917" stroke="#f59e0b" stroke-width="2"/>
-    <rect x="890" y="150" width="240" height="150" rx="8" fill="#082f49" stroke="#22d3ee" stroke-width="2"/>
-    <text x="200" y="220" fill="#e5f6ff" font-size="54" font-weight="800">100</text>
-    <text x="200" y="254" fill="#cbd5e1" font-size="16">tasks</text>
-    <text x="470" y="220" fill="#e5f6ff" font-size="54" font-weight="800">80</text>
-    <text x="470" y="254" fill="#cbd5e1" font-size="16">model invocations avoided</text>
-    <text x="740" y="220" fill="#fff7ed" font-size="54" font-weight="800">20</text>
-    <text x="740" y="254" fill="#fed7aa" font-size="16">model-candidate path</text>
-    <text x="1010" y="220" fill="#e5f6ff" font-size="54" font-weight="800">0</text>
-    <text x="1010" y="254" fill="#cbd5e1" font-size="16">deterministic mismatches</text>
+    <rect x="66" y="150" width="250" height="150" rx="12" fill="#0f1f33" stroke="#22d3ee" stroke-width="2"/>
+    <rect x="366" y="150" width="250" height="150" rx="12" fill="#0f1f33" stroke="#22d3ee" stroke-width="2"/>
+    <rect x="666" y="150" width="250" height="150" rx="12" fill="#2a1805" stroke="#f59e0b" stroke-width="2"/>
+    <rect x="966" y="150" width="250" height="150" rx="12" fill="#0f1f33" stroke="#22d3ee" stroke-width="2"/>
+    <text x="191" y="218" fill="#e6f6ff" font-size="56" font-weight="900">100</text>
+    <text x="191" y="255" fill="#b9d7e8" font-size="16" font-weight="700">tasks</text>
+    <text x="491" y="218" fill="#e6f6ff" font-size="56" font-weight="900">80</text>
+    <text x="491" y="250" fill="#b9d7e8" font-size="15" font-weight="700">model invocations</text>
+    <text x="491" y="272" fill="#b9d7e8" font-size="15" font-weight="700">avoided</text>
+    <text x="791" y="218" fill="#fff7ed" font-size="56" font-weight="900">20</text>
+    <text x="791" y="250" fill="#fed7aa" font-size="15" font-weight="700">model-candidate</text>
+    <text x="791" y="272" fill="#fed7aa" font-size="15" font-weight="700">or escalation path</text>
+    <text x="1091" y="218" fill="#e6f6ff" font-size="56" font-weight="900">0</text>
+    <text x="1091" y="250" fill="#b9d7e8" font-size="15" font-weight="700">deterministic</text>
+    <text x="1091" y="272" fill="#b9d7e8" font-size="15" font-weight="700">mismatches</text>
   </g>
-  <text x="64" y="360" fill="#cbd5e1" font-family="Inter, Arial, sans-serif" font-size="16">Boundary: alpha benchmark evidence, not a universal production cost-reduction claim.</text>
+  <rect x="64" y="346" width="1152" height="44" rx="8" fill="#0f1f33" stroke="#17334d"/>
+  <text x="86" y="374" fill="#cbd5e1" font-family="Inter, Arial, sans-serif" font-size="14">Boundary: alpha benchmark evidence, not production cost reduction, real API-cost reduction, energy reduction, or production validation.</text>
 </svg>

--- a/docs/assets/kora-control-layer-architecture.svg
+++ b/docs/assets/kora-control-layer-architecture.svg
@@ -1,0 +1,61 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1280" height="520" viewBox="0 0 1280 520" role="img" aria-labelledby="title desc">
+  <title id="title">KORA control layer architecture</title>
+  <desc id="desc">A technical architecture diagram showing AI Request to KORA Control Layer to Output, with conditional model escalation and telemetry observing the full path.</desc>
+  <defs>
+    <filter id="shadow" x="-12%" y="-18%" width="124%" height="136%">
+      <feDropShadow dx="0" dy="10" stdDeviation="12" flood-color="#020617" flood-opacity="0.35"/>
+    </filter>
+    <marker id="arrowCyan" markerWidth="12" markerHeight="12" refX="10" refY="6" orient="auto">
+      <path d="M2 2 L10 6 L2 10 Z" fill="#22d3ee"/>
+    </marker>
+    <marker id="arrowAmber" markerWidth="12" markerHeight="12" refX="10" refY="6" orient="auto">
+      <path d="M2 2 L10 6 L2 10 Z" fill="#f59e0b"/>
+    </marker>
+  </defs>
+  <rect width="1280" height="520" fill="#08111f"/>
+  <text x="64" y="66" fill="#e6f6ff" font-family="Inter, Arial, sans-serif" font-size="34" font-weight="800">KORA Control Layer Architecture</text>
+  <text x="64" y="100" fill="#8bdcf8" font-family="Inter, Arial, sans-serif" font-size="17">KORA sits between the request and inference. Model escalation is conditional, not default.</text>
+  <g filter="url(#shadow)">
+    <rect x="70" y="220" width="160" height="96" rx="12" fill="#0f1f33" stroke="#22d3ee" stroke-width="2"/>
+    <rect x="340" y="140" width="560" height="256" rx="16" fill="#0c1a2b" stroke="#22d3ee" stroke-width="2.5"/>
+    <rect x="1050" y="220" width="160" height="96" rx="12" fill="#0f1f33" stroke="#22d3ee" stroke-width="2"/>
+    <rect x="548" y="430" width="160" height="58" rx="10" fill="#0f1f33" stroke="#64748b" stroke-width="2"/>
+    <rect x="745" y="44" width="190" height="66" rx="10" fill="#2a1805" stroke="#f59e0b" stroke-width="2"/>
+  </g>
+  <g fill="none" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M230 268 H340" stroke="#22d3ee" stroke-width="5" marker-end="url(#arrowCyan)"/>
+    <path d="M900 268 H1050" stroke="#22d3ee" stroke-width="5" marker-end="url(#arrowCyan)"/>
+    <path d="M800 140 C820 112 838 95 745 82" stroke="#f59e0b" stroke-width="4" marker-end="url(#arrowAmber)"/>
+    <path d="M806 110 C868 132 900 170 870 220" stroke="#f59e0b" stroke-width="3" stroke-dasharray="8 8"/>
+    <path d="M420 396 C455 430 500 452 548 459" stroke="#64748b" stroke-width="3"/>
+    <path d="M820 396 C785 430 755 452 708 459" stroke="#64748b" stroke-width="3"/>
+  </g>
+  <g font-family="Inter, Arial, sans-serif" text-anchor="middle">
+    <text x="150" y="258" fill="#e6f6ff" font-size="19" font-weight="800">AI</text>
+    <text x="150" y="284" fill="#e6f6ff" font-size="19" font-weight="800">Request</text>
+    <text x="1130" y="258" fill="#e6f6ff" font-size="19" font-weight="800">Output</text>
+    <text x="1130" y="286" fill="#9fb6c9" font-size="13">validated result</text>
+    <text x="620" y="178" fill="#e6f6ff" font-size="24" font-weight="800">KORA Control Layer</text>
+    <text x="620" y="205" fill="#8bdcf8" font-size="14">structure first, inference second</text>
+    <text x="840" y="72" fill="#fff7ed" font-size="16" font-weight="800">Model Escalation</text>
+    <text x="840" y="94" fill="#fed7aa" font-size="12">conditional path</text>
+    <text x="628" y="466" fill="#cbd5e1" font-size="15" font-weight="800">Telemetry</text>
+  </g>
+  <g font-family="Inter, Arial, sans-serif" text-anchor="middle" filter="url(#shadow)">
+    <rect x="380" y="240" width="130" height="82" rx="8" fill="#10263a" stroke="#1f9fc1"/>
+    <rect x="535" y="240" width="130" height="82" rx="8" fill="#10263a" stroke="#1f9fc1"/>
+    <rect x="690" y="240" width="130" height="82" rx="8" fill="#10263a" stroke="#1f9fc1"/>
+  </g>
+  <g font-family="Inter, Arial, sans-serif" text-anchor="middle">
+    <text x="445" y="272" fill="#e6f6ff" font-size="15" font-weight="800">Task</text>
+    <text x="445" y="294" fill="#e6f6ff" font-size="15" font-weight="800">Graph</text>
+    <text x="600" y="266" fill="#e6f6ff" font-size="15" font-weight="800">Deterministic</text>
+    <text x="600" y="288" fill="#e6f6ff" font-size="15" font-weight="800">Handlers</text>
+    <text x="755" y="272" fill="#e6f6ff" font-size="15" font-weight="800">Validation</text>
+    <text x="755" y="294" fill="#9fb6c9" font-size="12">before escalation</text>
+  </g>
+  <g fill="none" stroke="#22d3ee" stroke-width="3" stroke-linecap="round" marker-end="url(#arrowCyan)">
+    <path d="M510 281 H535"/>
+    <path d="M665 281 H690"/>
+  </g>
+</svg>

--- a/docs/assets/kora-help-test-flow.svg
+++ b/docs/assets/kora-help-test-flow.svg
@@ -1,37 +1,56 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="420" viewBox="0 0 1200 420" role="img" aria-labelledby="title desc">
+<svg xmlns="http://www.w3.org/2000/svg" width="1280" height="460" viewBox="0 0 1280 460" role="img" aria-labelledby="title desc">
   <title id="title">KORA help-test flow</title>
-  <desc id="desc">A flow showing how developers can bring a workload, map deterministic paths, define escalation rules, run KORA, inspect telemetry, and share results.</desc>
-  <rect width="1200" height="420" fill="#f8fafc"/>
-  <text x="56" y="58" fill="#0f172a" font-family="Inter, Arial, sans-serif" font-size="30" font-weight="700">Help Test KORA</text>
-  <text x="56" y="90" fill="#475569" font-family="Inter, Arial, sans-serif" font-size="17">Bring a sanitized workload and measure the execution path.</text>
-  <g fill="none" stroke="#0891b2" stroke-width="3" stroke-linecap="round">
-    <path d="M165 230 H1010"/>
-    <path d="M990 218 L1010 230 L990 242"/>
+  <desc id="desc">A six-step workflow for external developers to bring a workload, identify deterministic paths, define escalation rules, run KORA, inspect telemetry, and share results.</desc>
+  <defs>
+    <filter id="shadow" x="-10%" y="-20%" width="120%" height="140%">
+      <feDropShadow dx="0" dy="8" stdDeviation="10" flood-color="#020617" flood-opacity="0.22"/>
+    </filter>
+  </defs>
+  <rect width="1280" height="460" fill="#f8fafc"/>
+  <text x="58" y="62" fill="#0f172a" font-family="Inter, Arial, sans-serif" font-size="32" font-weight="800">How To Help Test KORA</text>
+  <text x="58" y="96" fill="#475569" font-family="Inter, Arial, sans-serif" font-size="17">Bring a sanitized workload and inspect the execution path.</text>
+  <g fill="none" stroke="#0891b2" stroke-width="4" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M160 240 H1120"/>
+    <path d="M1095 224 L1120 240 L1095 256"/>
+  </g>
+  <g filter="url(#shadow)">
+    <rect x="50" y="160" width="160" height="160" rx="10" fill="#ffffff" stroke="#0891b2" stroke-width="2"/>
+    <rect x="250" y="160" width="160" height="160" rx="10" fill="#ffffff" stroke="#0891b2" stroke-width="2"/>
+    <rect x="450" y="145" width="160" height="175" rx="10" fill="#fff7ed" stroke="#f59e0b" stroke-width="2.5"/>
+    <rect x="650" y="160" width="160" height="160" rx="10" fill="#ffffff" stroke="#0891b2" stroke-width="2"/>
+    <rect x="850" y="160" width="160" height="160" rx="10" fill="#ffffff" stroke="#0891b2" stroke-width="2"/>
+    <rect x="1050" y="160" width="160" height="160" rx="10" fill="#ffffff" stroke="#0891b2" stroke-width="2"/>
   </g>
   <g font-family="Inter, Arial, sans-serif" text-anchor="middle">
-    <g fill="#ffffff" stroke="#0891b2" stroke-width="2">
-      <rect x="50" y="160" width="150" height="140" rx="8"/>
-      <rect x="240" y="160" width="150" height="140" rx="8"/>
-      <rect x="430" y="160" width="150" height="140" rx="8"/>
-      <rect x="620" y="160" width="150" height="140" rx="8"/>
-      <rect x="810" y="160" width="150" height="140" rx="8"/>
-      <rect x="1000" y="160" width="150" height="140" rx="8"/>
+    <g fill="#0891b2" font-size="14" font-weight="800">
+      <text x="130" y="190">01</text>
+      <text x="330" y="190">02</text>
+      <text x="730" y="190">04</text>
+      <text x="930" y="190">05</text>
+      <text x="1130" y="190">06</text>
     </g>
-    <text x="125" y="214" fill="#0f172a" font-size="16" font-weight="700">Bring</text>
-    <text x="125" y="238" fill="#475569" font-size="14">workload</text>
-    <text x="315" y="208" fill="#0f172a" font-size="16" font-weight="700">Map</text>
-    <text x="315" y="232" fill="#475569" font-size="14">deterministic</text>
-    <text x="315" y="252" fill="#475569" font-size="14">paths</text>
-    <text x="505" y="208" fill="#0f172a" font-size="16" font-weight="700">Define</text>
-    <text x="505" y="232" fill="#475569" font-size="14">escalation</text>
-    <text x="505" y="252" fill="#475569" font-size="14">rules</text>
-    <text x="695" y="214" fill="#0f172a" font-size="16" font-weight="700">Run KORA</text>
-    <text x="695" y="238" fill="#475569" font-size="14">locally</text>
-    <text x="885" y="208" fill="#0f172a" font-size="16" font-weight="700">Inspect</text>
-    <text x="885" y="232" fill="#475569" font-size="14">telemetry</text>
-    <text x="885" y="252" fill="#475569" font-size="14">counters</text>
-    <text x="1075" y="214" fill="#0f172a" font-size="16" font-weight="700">Share</text>
-    <text x="1075" y="238" fill="#475569" font-size="14">results</text>
+    <text x="530" y="176" fill="#b45309" font-size="14" font-weight="800">03</text>
+    <text x="130" y="224" fill="#0f172a" font-size="17" font-weight="800">Bring a</text>
+    <text x="130" y="248" fill="#0f172a" font-size="17" font-weight="800">Workload</text>
+    <text x="130" y="286" fill="#64748b" font-size="13">sanitized inputs</text>
+    <text x="330" y="216" fill="#0f172a" font-size="17" font-weight="800">Identify</text>
+    <text x="330" y="240" fill="#0f172a" font-size="17" font-weight="800">Deterministic</text>
+    <text x="330" y="264" fill="#0f172a" font-size="17" font-weight="800">Paths</text>
+    <text x="330" y="296" fill="#64748b" font-size="13">rules and repeats</text>
+    <text x="530" y="210" fill="#92400e" font-size="17" font-weight="800">Define</text>
+    <text x="530" y="234" fill="#92400e" font-size="17" font-weight="800">Escalation</text>
+    <text x="530" y="258" fill="#92400e" font-size="17" font-weight="800">Rules</text>
+    <text x="530" y="296" fill="#b45309" font-size="13">when model calls are needed</text>
+    <text x="730" y="224" fill="#0f172a" font-size="17" font-weight="800">Run</text>
+    <text x="730" y="248" fill="#0f172a" font-size="17" font-weight="800">KORA</text>
+    <text x="730" y="286" fill="#64748b" font-size="13">local runtime path</text>
+    <text x="930" y="224" fill="#0f172a" font-size="17" font-weight="800">Inspect</text>
+    <text x="930" y="248" fill="#0f172a" font-size="17" font-weight="800">Telemetry</text>
+    <text x="930" y="286" fill="#64748b" font-size="13">counters and events</text>
+    <text x="1130" y="224" fill="#0f172a" font-size="17" font-weight="800">Share</text>
+    <text x="1130" y="248" fill="#0f172a" font-size="17" font-weight="800">Results</text>
+    <text x="1130" y="286" fill="#64748b" font-size="13">reviewed evidence</text>
   </g>
-  <text x="56" y="360" fill="#0f172a" font-family="Inter, Arial, sans-serif" font-size="20" font-weight="700">Do not share secrets, API keys, private user data, or proprietary datasets in public channels.</text>
+  <rect x="58" y="370" width="1164" height="44" rx="8" fill="#e0f2fe" stroke="#bae6fd"/>
+  <text x="82" y="398" fill="#0f172a" font-family="Inter, Arial, sans-serif" font-size="14">Do not share secrets, API keys, private user data, or proprietary datasets in public channels.</text>
 </svg>

--- a/docs/assets/kora-validation-roadmap.svg
+++ b/docs/assets/kora-validation-roadmap.svg
@@ -1,36 +1,61 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="420" viewBox="0 0 1200 420" role="img" aria-labelledby="title desc">
+<svg xmlns="http://www.w3.org/2000/svg" width="1280" height="520" viewBox="0 0 1280 520" role="img" aria-labelledby="title desc">
   <title id="title">KORA validation roadmap</title>
-  <desc id="desc">A roadmap from current alpha evidence to real model-call validation and workload-specific tests.</desc>
-  <rect width="1200" height="420" fill="#f8fafc"/>
-  <text x="56" y="58" fill="#0f172a" font-family="Inter, Arial, sans-serif" font-size="30" font-weight="700">KORA Validation Roadmap</text>
-  <text x="56" y="90" fill="#475569" font-family="Inter, Arial, sans-serif" font-size="17">Current alpha evidence moves toward real model-call and workload-specific validation.</text>
-  <g fill="none" stroke="#0891b2" stroke-width="4" stroke-linecap="round">
-    <path d="M170 222 H1000"/>
-    <path d="M980 210 L1000 222 L980 234"/>
+  <desc id="desc">A technical roadmap from current alpha benchmark evidence to real model-call runtime validation, customer-support triage, RAG answer routing, and agent budget guard workloads.</desc>
+  <defs>
+    <filter id="shadow" x="-10%" y="-20%" width="120%" height="140%">
+      <feDropShadow dx="0" dy="10" stdDeviation="12" flood-color="#020617" flood-opacity="0.35"/>
+    </filter>
+    <linearGradient id="panel" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#0f1f33"/>
+      <stop offset="1" stop-color="#0a1322"/>
+    </linearGradient>
+  </defs>
+  <rect width="1280" height="520" fill="#08111f"/>
+  <path d="M0 420 C220 350 330 470 540 390 C780 300 930 360 1280 250 L1280 520 L0 520 Z" fill="#0b1b2d" opacity="0.8"/>
+  <text x="64" y="70" fill="#e6f6ff" font-family="Inter, Arial, sans-serif" font-size="34" font-weight="800">KORA Validation Roadmap</text>
+  <text x="64" y="105" fill="#8bdcf8" font-family="Inter, Arial, sans-serif" font-size="17">From current alpha benchmark evidence toward real workload testing.</text>
+  <g fill="none" stroke="#22d3ee" stroke-width="5" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M170 288 H1078"/>
+    <path d="M1052 272 L1078 288 L1052 304"/>
+  </g>
+  <g font-family="Inter, Arial, sans-serif" text-anchor="middle" filter="url(#shadow)">
+    <g fill="url(#panel)" stroke="#1f9fc1" stroke-width="2">
+      <rect x="58" y="185" width="196" height="156" rx="10"/>
+      <rect x="294" y="155" width="196" height="186" rx="10" stroke="#f59e0b"/>
+      <rect x="530" y="185" width="196" height="156" rx="10"/>
+      <rect x="766" y="185" width="196" height="156" rx="10"/>
+      <rect x="1002" y="185" width="196" height="156" rx="10"/>
+    </g>
+    <circle cx="156" cy="288" r="9" fill="#22d3ee"/>
+    <circle cx="392" cy="288" r="10" fill="#f59e0b"/>
+    <circle cx="628" cy="288" r="9" fill="#22d3ee"/>
+    <circle cx="864" cy="288" r="9" fill="#22d3ee"/>
+    <circle cx="1100" cy="288" r="9" fill="#22d3ee"/>
   </g>
   <g font-family="Inter, Arial, sans-serif" text-anchor="middle">
-    <g fill="#ffffff" stroke="#0891b2" stroke-width="2">
-      <rect x="70" y="150" width="180" height="144" rx="8"/>
-      <rect x="290" y="150" width="180" height="144" rx="8"/>
-      <rect x="510" y="150" width="180" height="144" rx="8"/>
-      <rect x="730" y="150" width="180" height="144" rx="8"/>
-      <rect x="950" y="150" width="180" height="144" rx="8"/>
-    </g>
-    <text x="160" y="196" fill="#0f172a" font-size="17" font-weight="700">Current alpha</text>
-    <text x="160" y="226" fill="#475569" font-size="14">deterministic-heavy</text>
-    <text x="160" y="248" fill="#475569" font-size="14">benchmark</text>
-    <text x="380" y="190" fill="#0f172a" font-size="17" font-weight="700">Real model-call</text>
-    <text x="380" y="220" fill="#475569" font-size="14">runtime-integrated</text>
-    <text x="380" y="242" fill="#475569" font-size="14">paths</text>
-    <text x="600" y="196" fill="#0f172a" font-size="17" font-weight="700">Support triage</text>
-    <text x="600" y="226" fill="#475569" font-size="14">repetitive support</text>
-    <text x="600" y="248" fill="#475569" font-size="14">routing</text>
-    <text x="820" y="196" fill="#0f172a" font-size="17" font-weight="700">RAG routing</text>
-    <text x="820" y="226" fill="#475569" font-size="14">answer and refusal</text>
-    <text x="820" y="248" fill="#475569" font-size="14">paths</text>
-    <text x="1040" y="190" fill="#0f172a" font-size="17" font-weight="700">Agent budget</text>
-    <text x="1040" y="220" fill="#475569" font-size="14">guardrails and</text>
-    <text x="1040" y="242" fill="#475569" font-size="14">escalation</text>
+    <text x="156" y="225" fill="#e6f6ff" font-size="18" font-weight="800">Current Alpha</text>
+    <text x="156" y="251" fill="#e6f6ff" font-size="18" font-weight="800">Benchmark</text>
+    <text x="156" y="318" fill="#9fb6c9" font-size="13">deterministic-heavy</text>
+    <text x="156" y="337" fill="#9fb6c9" font-size="13">evidence baseline</text>
+    <text x="392" y="202" fill="#fff7ed" font-size="18" font-weight="800">Real Model-Call</text>
+    <text x="392" y="228" fill="#fff7ed" font-size="18" font-weight="800">Runtime Path</text>
+    <text x="392" y="318" fill="#fed7aa" font-size="13">conditional escalation</text>
+    <text x="392" y="337" fill="#fed7aa" font-size="13">with measured calls</text>
+    <text x="628" y="225" fill="#e6f6ff" font-size="18" font-weight="800">Customer-Support</text>
+    <text x="628" y="251" fill="#e6f6ff" font-size="18" font-weight="800">Triage</text>
+    <text x="628" y="318" fill="#9fb6c9" font-size="13">policy and routing</text>
+    <text x="628" y="337" fill="#9fb6c9" font-size="13">workloads</text>
+    <text x="864" y="225" fill="#e6f6ff" font-size="18" font-weight="800">RAG Answer</text>
+    <text x="864" y="251" fill="#e6f6ff" font-size="18" font-weight="800">Routing</text>
+    <text x="864" y="318" fill="#9fb6c9" font-size="13">source-backed paths</text>
+    <text x="864" y="337" fill="#9fb6c9" font-size="13">and escalation</text>
+    <text x="1100" y="225" fill="#e6f6ff" font-size="18" font-weight="800">Agent Budget</text>
+    <text x="1100" y="251" fill="#e6f6ff" font-size="18" font-weight="800">Guard</text>
+    <text x="1100" y="318" fill="#9fb6c9" font-size="13">retry and budget</text>
+    <text x="1100" y="337" fill="#9fb6c9" font-size="13">boundaries</text>
   </g>
-  <text x="56" y="360" fill="#0f172a" font-family="Inter, Arial, sans-serif" font-size="20" font-weight="700">Measure: requests, model calls, avoided calls, latency, tokens, cost where applicable, fallbacks, errors, validation.</text>
+  <g font-family="Inter, Arial, sans-serif" font-size="14">
+    <rect x="64" y="425" width="1152" height="44" rx="8" fill="#0f1f33" stroke="#17334d"/>
+    <text x="86" y="453" fill="#b9d7e8">Measure: total requests, baseline calls, KORA-controlled calls, avoided calls, latency, tokens, fallback count, error count, validation result.</text>
+  </g>
 </svg>

--- a/docs/benchmarks/validation-roadmap.md
+++ b/docs/benchmarks/validation-roadmap.md
@@ -12,6 +12,8 @@ The validation roadmap turns that message into measurable evidence. Each target 
 
 ![KORA validation roadmap](../assets/kora-validation-roadmap.svg)
 
+KORA validation roadmap.
+
 ## Current Alpha Evidence
 
 The current approved public claim is:

--- a/docs/community/help-test-kora.md
+++ b/docs/community/help-test-kora.md
@@ -27,6 +27,8 @@ The goal is to measure when structure, deterministic execution, validation, and 
 
 ![KORA help-test flow](../assets/kora-help-test-flow.svg)
 
+How to help test KORA with a real workload.
+
 ## Good Candidate Workloads
 
 - customer-support triage
@@ -93,4 +95,3 @@ Do not expect:
 - formal government validation
 - signed partner validation unless actually signed and documented
 - guaranteed adoption, funding, or support commitments
-


### PR DESCRIPTION
## Summary

Adds polished, GitHub README-friendly technical diagrams for the KORA documentation set.

## Changes

- Updated the validation roadmap SVG with a dark navy roadmap and claim-safe validation targets.
- Updated the help-test workflow SVG with a contributor-friendly workload testing flow.
- Added a control-layer architecture SVG showing KORA between request and output with conditional model escalation.
- Improved the benchmark evidence card SVG with clear alpha benchmark metrics and boundary language.
- Inserted roadmap and help-test images into the README.
- Added diagram captions to the validation roadmap and help-test docs.
- Added the control-layer architecture diagram to the docs index.

## Claim Safety

- No production cost-reduction claims added.
- No real API-cost reduction claims added.
- No energy-reduction claims added.
- No production validation or broad workload superiority claims added.
- Public docs do not expose internal ChatGPT/Codex/private prompt workflow material.

## Validation

- `git diff --check` passed.
- `xmllint --noout docs/assets/*.svg` passed.
- `python3 -m pytest` passed: 54 passed.
- `python3 -m kora --help` passed.
- `python3 -m kora examples list` passed.
- `python3 -m kora run direct_vs_kora -- --offline` passed.
- `python3 -m kora run runtime_integrated_benchmark -- --offline` passed.
