### PR TITLE
Unify KORA README diagram visual system

### DIFF
--- a/docs/assets/kora-benchmark-evidence-card.svg
+++ b/docs/assets/kora-benchmark-evidence-card.svg
@@ -1,26 +1,60 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="1280" height="430" viewBox="0 0 1280 430" role="img" aria-labelledby="title desc">
-  <title id="title">KORA benchmark evidence card</title>
-  <desc id="desc">A technical benchmark evidence card showing 100 tasks, 80 model invocations avoided, 20 model-candidate path tasks, and 0 deterministic mismatches.</desc>
-  <rect width="1280" height="430" fill="#08111f"/>
-  <text x="64" y="66" fill="#e6f6ff" font-family="Inter, Arial, sans-serif" font-size="34" font-weight="800">Current Alpha Evidence</text>
-  <text x="64" y="100" fill="#8bdcf8" font-family="Inter, Arial, sans-serif" font-size="17">Reproducible deterministic-heavy benchmark workload.</text>
-  <g font-family="Inter, Arial, sans-serif" text-anchor="middle">
-    <rect x="66" y="150" width="250" height="150" rx="12" fill="#0f1f33" stroke="#22d3ee" stroke-width="2"/>
-    <rect x="366" y="150" width="250" height="150" rx="12" fill="#0f1f33" stroke="#22d3ee" stroke-width="2"/>
-    <rect x="666" y="150" width="250" height="150" rx="12" fill="#2a1805" stroke="#f59e0b" stroke-width="2"/>
-    <rect x="966" y="150" width="250" height="150" rx="12" fill="#0f1f33" stroke="#22d3ee" stroke-width="2"/>
-    <text x="191" y="218" fill="#e6f6ff" font-size="56" font-weight="900">100</text>
-    <text x="191" y="255" fill="#b9d7e8" font-size="16" font-weight="700">tasks</text>
-    <text x="491" y="218" fill="#e6f6ff" font-size="56" font-weight="900">80</text>
-    <text x="491" y="250" fill="#b9d7e8" font-size="15" font-weight="700">model invocations</text>
-    <text x="491" y="272" fill="#b9d7e8" font-size="15" font-weight="700">avoided</text>
-    <text x="791" y="218" fill="#fff7ed" font-size="56" font-weight="900">20</text>
-    <text x="791" y="250" fill="#fed7aa" font-size="15" font-weight="700">model-candidate</text>
-    <text x="791" y="272" fill="#fed7aa" font-size="15" font-weight="700">or escalation path</text>
-    <text x="1091" y="218" fill="#e6f6ff" font-size="56" font-weight="900">0</text>
-    <text x="1091" y="250" fill="#b9d7e8" font-size="15" font-weight="700">deterministic</text>
-    <text x="1091" y="272" fill="#b9d7e8" font-size="15" font-weight="700">mismatches</text>
+<svg xmlns="http://www.w3.org/2000/svg" width="1920" height="1080" viewBox="0 0 1920 1080" role="img" aria-labelledby="title desc">
+  <title id="title">Current Alpha Evidence</title>
+  <desc id="desc">Current alpha benchmark evidence with four metric cards and claim boundary.</desc>
+  <defs>
+    <radialGradient id="bg" cx="50%" cy="48%" r="64%">
+      <stop offset="0" stop-color="#071A2F"/><stop offset="0.6" stop-color="#04111F"/><stop offset="1" stop-color="#020B18"/>
+    </radialGradient>
+    <filter id="cyanGlow" x="-40%" y="-40%" width="180%" height="180%"><feGaussianBlur stdDeviation="3.5" result="b"/><feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge></filter>
+    <filter id="amberGlow" x="-40%" y="-40%" width="180%" height="180%"><feGaussianBlur stdDeviation="4.5" result="b"/><feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge></filter>
+    <style>
+      .font { font-family: "IBM Plex Mono", "JetBrains Mono", "Roboto Mono", Menlo, Consolas, monospace; }
+      .title { fill: #F4F7FB; font-size: 68px; font-weight: 800; }
+      .subtitle { fill: #5BE7F2; font-size: 30px; }
+      .card { fill: #071629; stroke: #25D9E6; stroke-width: 2.5; }
+      .amberCard { fill: #071629; stroke: #F5B82E; stroke-width: 2.7; }
+      .cyan { fill: #5BE7F2; stroke: #25D9E6; }
+      .amber { fill: #F5B82E; stroke: #F5B82E; }
+      .muted { fill: #A8B3C7; }
+    </style>
+  </defs>
+  <rect width="1920" height="1080" fill="url(#bg)"/>
+  <rect x="135" y="355" width="1650" height="385" rx="10" fill="#020B18" opacity="0.25"/>
+  <text x="960" y="208" class="font title" text-anchor="middle">Current Alpha Evidence</text>
+  <text x="960" y="270" class="font subtitle" text-anchor="middle">Reproducible deterministic-heavy benchmark workload</text>
+  <g class="font" filter="url(#cyanGlow)">
+    <g transform="translate(206 371)">
+      <rect class="card" width="356" height="355" rx="18"/>
+      <text x="178" y="526" transform="translate(0 -370)" class="cyan" font-size="118" font-weight="800" text-anchor="middle">100</text>
+      <path d="M34 199 h288" class="cyan" stroke-width="2.4"/>
+      <text x="178" y="258" fill="#5BE7F2" font-size="26" font-weight="700" text-anchor="middle">tasks</text>
+    </g>
+    <g transform="translate(590 371)">
+      <rect class="card" width="356" height="355" rx="18"/>
+      <text x="178" y="156" class="cyan" font-size="118" font-weight="800" text-anchor="middle">80</text>
+      <path d="M34 199 h288" class="cyan" stroke-width="2.4"/>
+      <text x="178" y="258" fill="#5BE7F2" font-size="24" font-weight="700" text-anchor="middle">model invocations</text>
+      <text x="178" y="296" fill="#5BE7F2" font-size="24" font-weight="700" text-anchor="middle">avoided</text>
+    </g>
+    <g transform="translate(974 371)" filter="url(#amberGlow)">
+      <rect class="amberCard" width="356" height="355" rx="18"/>
+      <text x="178" y="156" class="amber" font-size="118" font-weight="800" text-anchor="middle">20</text>
+      <path d="M34 199 h288" class="amber" stroke-width="2.4"/>
+      <text x="178" y="258" fill="#F5B82E" font-size="23" font-weight="700" text-anchor="middle">model-candidate path</text>
+    </g>
+    <g transform="translate(1358 371)">
+      <rect class="card" width="356" height="355" rx="18"/>
+      <text x="178" y="156" class="cyan" font-size="118" font-weight="800" text-anchor="middle">0</text>
+      <path d="M34 199 h288" class="cyan" stroke-width="2.4"/>
+      <text x="178" y="258" fill="#5BE7F2" font-size="24" font-weight="700" text-anchor="middle">deterministic</text>
+      <text x="178" y="296" fill="#5BE7F2" font-size="24" font-weight="700" text-anchor="middle">mismatches</text>
+    </g>
   </g>
-  <rect x="64" y="346" width="1152" height="44" rx="8" fill="#0f1f33" stroke="#17334d"/>
-  <text x="86" y="374" fill="#cbd5e1" font-family="Inter, Arial, sans-serif" font-size="14">Boundary: alpha benchmark evidence, not production cost reduction, real API-cost reduction, energy reduction, or production validation.</text>
+  <g class="font" filter="url(#cyanGlow)">
+    <rect x="207" y="798" width="1506" height="114" rx="9" fill="#071629" stroke="#25D9E6" stroke-width="2.2"/>
+    <text x="242" y="853" fill="#25D9E6" font-size="42" font-weight="700">&gt;_</text>
+    <path d="M316 811 v88" stroke="#25455B" stroke-width="2" stroke-dasharray="4 7"/>
+    <text x="342" y="848" fill="#5BE7F2" font-size="23">Boundary: alpha benchmark evidence, not production cost reduction, real API-cost reduction,</text>
+    <text x="342" y="880" fill="#5BE7F2" font-size="23">energy reduction, or production validation.</text>
+  </g>
 </svg>

--- a/docs/assets/kora-execution-control-overview.svg
+++ b/docs/assets/kora-execution-control-overview.svg
@@ -1,46 +1,148 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="460" viewBox="0 0 1200 460" role="img" aria-labelledby="title desc">
-  <title id="title">KORA execution control overview</title>
-  <desc id="desc">A diagram comparing model-first execution with a KORA controlled execution path.</desc>
-  <rect width="1200" height="460" fill="#0b1220"/>
-  <text x="60" y="58" fill="#e5f6ff" font-family="Inter, Arial, sans-serif" font-size="28" font-weight="700">Most AI apps call the model too soon.</text>
-  <text x="60" y="92" fill="#8bdcf8" font-family="Inter, Arial, sans-serif" font-size="18">KORA turns requests into structured execution paths before inference.</text>
-  <g fill="none" stroke-linecap="round" stroke-linejoin="round">
-    <path d="M140 178 H315 H490 H665" stroke="#64748b" stroke-width="4"/>
-    <path d="M645 166 L665 178 L645 190" stroke="#64748b" stroke-width="4"/>
-    <path d="M140 318 H315 H490 H665 H840 H1015" stroke="#22d3ee" stroke-width="4"/>
-    <path d="M995 306 L1015 318 L995 330" stroke="#22d3ee" stroke-width="4"/>
-  </g>
-  <g font-family="Inter, Arial, sans-serif" font-size="15" font-weight="700" text-anchor="middle">
-    <text x="90" y="184" fill="#cbd5e1">Before</text>
-    <text x="90" y="324" fill="#cbd5e1">After</text>
-  </g>
-  <g font-family="Inter, Arial, sans-serif" font-size="16" font-weight="600" text-anchor="middle">
-    <g fill="#111827" stroke="#94a3b8" stroke-width="2">
-      <rect x="120" y="140" width="120" height="76" rx="8"/>
-      <rect x="295" y="140" width="120" height="76" rx="8"/>
-      <rect x="470" y="140" width="120" height="76" rx="8"/>
-      <rect x="645" y="140" width="120" height="76" rx="8"/>
+<svg xmlns="http://www.w3.org/2000/svg" width="1920" height="1080" viewBox="0 0 1920 1080" role="img" aria-labelledby="title desc">
+  <title id="title">Most AI apps call the model too soon.</title>
+  <desc id="desc">Before model-first path and after KORA structured execution with deterministic and escalation branches.</desc>
+  <defs>
+    <radialGradient id="bg" cx="50%" cy="48%" r="65%">
+      <stop offset="0" stop-color="#071A2F"/><stop offset="0.62" stop-color="#04111F"/><stop offset="1" stop-color="#020B18"/>
+    </radialGradient>
+    <filter id="cyanGlow" x="-40%" y="-40%" width="180%" height="180%"><feGaussianBlur stdDeviation="3" result="b"/><feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge></filter>
+    <filter id="amberGlow" x="-40%" y="-40%" width="180%" height="180%"><feGaussianBlur stdDeviation="4" result="b"/><feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge></filter>
+    <marker id="arrowCyan" markerWidth="14" markerHeight="14" refX="10" refY="7" orient="auto"><path d="M2 2 L10 7 L2 12" fill="none" stroke="#25D9E6" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"/></marker>
+    <marker id="arrowAmber" markerWidth="14" markerHeight="14" refX="10" refY="7" orient="auto"><path d="M2 2 L10 7 L2 12" fill="none" stroke="#F5B82E" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"/></marker>
+    <style>
+      .font { font-family: "IBM Plex Mono", "JetBrains Mono", "Roboto Mono", Menlo, Consolas, monospace; }
+      .title { fill: #F4F7FB; font-size: 64px; font-weight: 800; }
+      .subtitle { fill: #5BE7F2; font-size: 30px; }
+      .cyanBox { fill: #071629; stroke: #25D9E6; stroke-width: 2.3; }
+      .amberBox { fill: #071629; stroke: #F5B82E; stroke-width: 2.3; }
+      .control { fill: #071629; stroke: #25D9E6; stroke-width: 2.2; }
+      .cyan { fill: #5BE7F2; stroke: #25D9E6; }
+      .amber { fill: #F5B82E; stroke: #F5B82E; }
+      .white { fill: #F4F7FB; }
+      .muted { fill: #A8B3C7; }
+      .line { stroke: #25D9E6; stroke-width: 2.8; fill: none; }
+      .lineAmber { stroke: #F5B82E; stroke-width: 2.8; fill: none; }
+    </style>
+  </defs>
+  <rect width="1920" height="1080" fill="url(#bg)"/>
+  <text x="960" y="98" class="font title" text-anchor="middle">Most AI apps call the model too soon.</text>
+  <text x="960" y="160" class="font subtitle" text-anchor="middle">KORA routes requests through structured execution before inference.</text>
+
+  <g class="font" filter="url(#cyanGlow)">
+    <text x="206" y="257" class="muted" font-size="28" font-weight="800">Before</text>
+    <g transform="translate(208 289)">
+      <rect width="304" height="120" rx="12" class="cyanBox"/>
+      <path d="M44 26 h36 l24 24 v56 h-60z M80 26 v24 h24 M58 56 h20 M58 76 h38 M58 96 h32" class="line"/>
+      <text x="132" y="70" class="white" font-size="23">Request</text>
     </g>
-    <text x="180" y="184" fill="#e5e7eb">request</text>
-    <text x="355" y="184" fill="#e5e7eb">prompt</text>
-    <text x="530" y="184" fill="#fbbf24">model</text>
-    <text x="705" y="184" fill="#e5e7eb">output</text>
-    <g fill="#082f49" stroke="#22d3ee" stroke-width="2">
-      <rect x="120" y="280" width="120" height="76" rx="8"/>
-      <rect x="285" y="280" width="140" height="76" rx="8"/>
-      <rect x="460" y="280" width="150" height="76" rx="8"/>
-      <rect x="645" y="280" width="130" height="76" rx="8"/>
-      <rect x="810" y="280" width="150" height="76" rx="8" stroke="#f59e0b"/>
-      <rect x="995" y="280" width="130" height="76" rx="8"/>
+    <path d="M526 349 h64" class="line" marker-end="url(#arrowCyan)"/>
+    <g transform="translate(608 289)">
+      <rect width="310" height="120" rx="12" class="cyanBox"/>
+      <path d="M45 34 h60 q8 0 8 8 v35 q0 8 -8 8 h-31 l-24 24 v-24 h-5 q-8 0 -8 -8 v-35 q0 -8 8 -8z M58 55 h5 M76 55 h5 M94 55 h5" class="line"/>
+      <text x="132" y="70" class="white" font-size="23">Prompt</text>
     </g>
-    <text x="180" y="324" fill="#ecfeff">request</text>
-    <text x="355" y="324" fill="#ecfeff">task graph</text>
-    <text x="535" y="314" fill="#ecfeff">deterministic</text>
-    <text x="535" y="336" fill="#ecfeff">path</text>
-    <text x="710" y="324" fill="#ecfeff">validation</text>
-    <text x="885" y="314" fill="#fff7ed">model</text>
-    <text x="885" y="336" fill="#fff7ed">escalation</text>
-    <text x="1060" y="324" fill="#ecfeff">telemetry</text>
+    <path d="M932 349 h64" class="line" marker-end="url(#arrowCyan)"/>
+    <g transform="translate(1009 289)">
+      <rect width="310" height="120" rx="12" class="cyanBox"/>
+      <path d="M88 26 l31 18 v36 l-31 18 l-31 -18 v-36z M57 44 l31 18 l31 -18 M88 62 v36" class="line"/>
+      <text x="152" y="70" class="white" font-size="23">Model</text>
+    </g>
+    <path d="M1333 349 h64" class="line" marker-end="url(#arrowCyan)"/>
+    <g transform="translate(1408 289)">
+      <rect width="304" height="120" rx="12" class="cyanBox"/>
+      <path d="M44 26 h36 l24 24 v56 h-60z M80 26 v24 h24 M58 56 h20 M58 76 h38 M58 96 h32" class="line"/>
+      <text x="132" y="70" class="white" font-size="23">Output</text>
+    </g>
+    <path d="M186 486 H1742" stroke="#25D9E6" stroke-width="2.5" stroke-dasharray="2 8" opacity="0.9"/>
   </g>
-  <text x="60" y="420" fill="#e5f6ff" font-family="Inter, Arial, sans-serif" font-size="22" font-weight="700">Structure first. Inference second.</text>
+
+  <g class="font">
+    <text x="208" y="585" fill="#F5B82E" font-size="28" font-weight="800">After</text>
+    <g filter="url(#cyanGlow)">
+      <g transform="translate(208 667)">
+        <rect width="188" height="108" rx="10" class="cyanBox"/>
+        <path d="M25 27 h35 l22 22 v50 h-57z M60 27 v22 h22 M38 56 h20 M38 75 h35 M38 94 h28" class="line"/>
+        <text x="86" y="64" class="white" font-size="21">Request</text>
+      </g>
+      <path d="M400 721 h33" class="line" marker-end="url(#arrowCyan)"/>
+      <g transform="translate(442 591)">
+        <rect width="468" height="258" rx="12" class="control"/>
+        <text x="234" y="632" transform="translate(0 -591)" fill="#5BE7F2" font-size="23" font-weight="700" text-anchor="middle">KORA Control Layer</text>
+        <g transform="translate(23 74)">
+          <rect width="175" height="145" rx="10" class="cyanBox"/>
+          <circle cx="62" cy="43" r="10" class="line"/><circle cx="105" cy="29" r="10" class="line"/><circle cx="62" cy="87" r="10" class="line"/><circle cx="142" cy="86" r="10" class="line"/>
+          <path d="M71 40 l24 -8 M62 53 v24 M74 87 h45 M105 39 v25 M105 64 h35 v12" class="line" stroke-dasharray="8 7"/>
+          <text x="88" y="120" class="white" font-size="19" text-anchor="middle">Task Graph</text>
+        </g>
+        <path d="M214 147 h55" class="line" marker-end="url(#arrowCyan)"/>
+        <g transform="translate(248 74)">
+          <rect width="190" height="145" rx="10" class="cyanBox"/>
+          <path d="M95 29 l39 15 v39 q0 28 -39 45 q-39 -17 -39 -45 v-39z M77 75 l14 14 l29 -37" class="line"/>
+          <text x="95" y="120" class="white" font-size="18" text-anchor="middle">Validation / Policy</text>
+        </g>
+      </g>
+      <path d="M910 721 h38" class="line"/>
+      <circle cx="948" cy="721" r="8" fill="#071629" stroke="#25D9E6" stroke-width="2.8"/>
+      <text x="1010" y="580" fill="#5BE7F2" font-size="23" font-weight="700">Deterministic Path (Preferred)</text>
+      <path d="M948 721 v-38 q0 -42 42 -42 h16" class="line" marker-end="url(#arrowCyan)"/>
+      <g transform="translate(1009 596)">
+        <rect width="247" height="89" rx="9" class="cyanBox"/>
+        <path d="M32 26 h41 v41 h-41z M25 36 h14 M25 57 h14 M66 36 h14 M66 57 h14 M43 19 v14 M62 19 v14 M43 60 v14 M62 60 v14" class="line"/>
+        <text x="106" y="40" class="white" font-size="20">CPU / Rules</text>
+        <text x="106" y="67" class="white" font-size="20">/ Cache</text>
+      </g>
+      <path d="M1262 640 h34" class="line" marker-end="url(#arrowCyan)"/>
+      <g transform="translate(1299 596)">
+        <rect width="203" height="89" rx="9" class="cyanBox"/>
+        <path d="M26 25 h40 a5 5 0 0 1 0 10 h-40 a5 5 0 0 1 0 -10z M26 44 h40 a5 5 0 0 1 0 10 h-40 a5 5 0 0 1 0 -10z M26 63 h40 a5 5 0 0 1 0 10 h-40 a5 5 0 0 1 0 -10z" class="line"/>
+        <text x="76" y="40" class="white" font-size="20">Structured</text>
+        <text x="76" y="67" class="white" font-size="20">Handler</text>
+      </g>
+      <path d="M1508 640 h30" class="line" marker-end="url(#arrowCyan)"/>
+      <g transform="translate(1540 596)">
+        <rect width="174" height="89" rx="9" class="cyanBox"/>
+        <circle cx="39" cy="45" r="22" class="line"/><path d="M29 45 l9 10 l18 -22" class="line"/>
+        <text x="76" y="40" class="white" font-size="19">Verified</text>
+        <text x="76" y="67" class="white" font-size="19">Output</text>
+      </g>
+    </g>
+
+    <g filter="url(#amberGlow)">
+      <text x="1010" y="745" fill="#F5B82E" font-size="22" font-weight="700">Model Escalation (Only When Needed)</text>
+      <path d="M948 721 v38 q0 42 42 42 h16" class="lineAmber" marker-end="url(#arrowAmber)"/>
+      <circle cx="948" cy="721" r="8" fill="#071629" stroke="#F5B82E" stroke-width="2.8"/>
+      <g transform="translate(1009 766)">
+        <rect width="247" height="90" rx="9" class="amberBox"/>
+        <path d="M48 21 l34 58 h-68z M48 39 v21 M48 70 v3" class="lineAmber"/>
+        <text x="104" y="42" class="white" font-size="20">Model</text>
+        <text x="104" y="69" class="white" font-size="20">Escalation</text>
+      </g>
+      <path d="M1262 811 h34" class="lineAmber" marker-end="url(#arrowAmber)"/>
+      <g transform="translate(1299 766)">
+        <rect width="203" height="90" rx="9" class="amberBox"/>
+        <path d="M44 22 q22 4 22 24 q0 20 -22 24 q-22 -4 -22 -24 q0 -20 22 -24z M44 25 v44 M31 36 h-10 M31 56 h-10 M57 36 h10 M57 56 h10" class="lineAmber"/>
+        <text x="85" y="42" class="white" font-size="19">LLM only</text>
+        <text x="85" y="69" class="white" font-size="19">when needed</text>
+      </g>
+      <path d="M1508 811 h30" class="lineAmber" marker-end="url(#arrowAmber)"/>
+      <g transform="translate(1540 766)">
+        <rect width="174" height="90" rx="9" class="amberBox"/>
+        <path d="M30 23 h34 l22 22 v45 h-56z M64 23 v22 h22 M43 52 h21 M43 69 h30" class="lineAmber"/>
+        <text x="100" y="57" class="white" font-size="20">Output</text>
+      </g>
+    </g>
+  </g>
+
+  <g class="font" filter="url(#cyanGlow)">
+    <rect x="258" y="920" width="1425" height="91" rx="12" fill="#071629" stroke="#25D9E6" stroke-width="2" stroke-dasharray="7 8"/>
+    <path d="M304 979 h80 M316 979 v-23 h10 v23 M334 979 v-35 h10 v35 M352 979 v-50 h10 v50 M370 979 v-68 h10 v68" class="line"/>
+    <text x="407" y="977" fill="#5BE7F2" font-size="24">Telemetry</text>
+    <path d="M562 943 v45" stroke="#25455B" stroke-width="2"/>
+    <text x="596" y="977" class="muted" font-size="21">Observability across all execution paths</text>
+    <path d="M664 920 V858" stroke="#25D9E6" stroke-width="2.2" stroke-dasharray="7 8"/>
+    <path d="M1124 920 V858" stroke="#25D9E6" stroke-width="2.2" stroke-dasharray="7 8"/>
+    <path d="M1402 920 V858" stroke="#25D9E6" stroke-width="2.2" stroke-dasharray="7 8"/>
+    <path d="M1626 920 V858" stroke="#25D9E6" stroke-width="2.2" stroke-dasharray="7 8"/>
+    <text x="960" y="1042" fill="#F4F7FB" font-size="25" font-weight="700" text-anchor="middle">Structure first. Inference second.</text>
+  </g>
 </svg>

--- a/docs/assets/kora-help-test-flow.svg
+++ b/docs/assets/kora-help-test-flow.svg
@@ -1,56 +1,114 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="1280" height="460" viewBox="0 0 1280 460" role="img" aria-labelledby="title desc">
-  <title id="title">KORA help-test flow</title>
-  <desc id="desc">A six-step workflow for external developers to bring a workload, identify deterministic paths, define escalation rules, run KORA, inspect telemetry, and share results.</desc>
+<svg xmlns="http://www.w3.org/2000/svg" width="1920" height="1080" viewBox="0 0 1920 1080" role="img" aria-labelledby="title desc">
+  <title id="title">How To Help Test KORA</title>
+  <desc id="desc">Six-step KORA workload testing workflow with sanitized workload warning.</desc>
   <defs>
-    <filter id="shadow" x="-10%" y="-20%" width="120%" height="140%">
-      <feDropShadow dx="0" dy="8" stdDeviation="10" flood-color="#020617" flood-opacity="0.22"/>
+    <radialGradient id="bg" cx="50%" cy="48%" r="64%">
+      <stop offset="0" stop-color="#071A2F"/>
+      <stop offset="0.58" stop-color="#04111F"/>
+      <stop offset="1" stop-color="#020B18"/>
+    </radialGradient>
+    <filter id="cyanGlow" x="-40%" y="-40%" width="180%" height="180%">
+      <feGaussianBlur stdDeviation="3.5" result="blur"/>
+      <feMerge><feMergeNode in="blur"/><feMergeNode in="SourceGraphic"/></feMerge>
     </filter>
+    <filter id="amberGlow" x="-40%" y="-40%" width="180%" height="180%">
+      <feGaussianBlur stdDeviation="4" result="blur"/>
+      <feMerge><feMergeNode in="blur"/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+    <marker id="arrowCyan" markerWidth="14" markerHeight="14" refX="10" refY="7" orient="auto">
+      <path d="M2 2 L10 7 L2 12" fill="none" stroke="#25D9E6" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+    </marker>
+    <style>
+      .font { font-family: "IBM Plex Mono", "JetBrains Mono", "Roboto Mono", Menlo, Consolas, monospace; }
+      .title { fill: #F4F7FB; font-size: 68px; font-weight: 800; letter-spacing: 1px; }
+      .subtitle { fill: #5BE7F2; font-size: 30px; }
+      .card { fill: #071629; stroke: #25D9E6; stroke-width: 2.4; }
+      .cardAmber { fill: #071629; stroke: #F5B82E; stroke-width: 2.5; }
+      .cyan { fill: #5BE7F2; stroke: #25D9E6; }
+      .amber { fill: #F5B82E; stroke: #F5B82E; }
+      .white { fill: #F4F7FB; }
+      .muted { fill: #A8B3C7; }
+      .line { stroke: #25D9E6; stroke-width: 2.4; fill: none; }
+      .lineAmber { stroke: #F5B82E; stroke-width: 2.4; fill: none; }
+    </style>
   </defs>
-  <rect width="1280" height="460" fill="#f8fafc"/>
-  <text x="58" y="62" fill="#0f172a" font-family="Inter, Arial, sans-serif" font-size="32" font-weight="800">How To Help Test KORA</text>
-  <text x="58" y="96" fill="#475569" font-family="Inter, Arial, sans-serif" font-size="17">Bring a sanitized workload and inspect the execution path.</text>
-  <g fill="none" stroke="#0891b2" stroke-width="4" stroke-linecap="round" stroke-linejoin="round">
-    <path d="M160 240 H1120"/>
-    <path d="M1095 224 L1120 240 L1095 256"/>
-  </g>
-  <g filter="url(#shadow)">
-    <rect x="50" y="160" width="160" height="160" rx="10" fill="#ffffff" stroke="#0891b2" stroke-width="2"/>
-    <rect x="250" y="160" width="160" height="160" rx="10" fill="#ffffff" stroke="#0891b2" stroke-width="2"/>
-    <rect x="450" y="145" width="160" height="175" rx="10" fill="#fff7ed" stroke="#f59e0b" stroke-width="2.5"/>
-    <rect x="650" y="160" width="160" height="160" rx="10" fill="#ffffff" stroke="#0891b2" stroke-width="2"/>
-    <rect x="850" y="160" width="160" height="160" rx="10" fill="#ffffff" stroke="#0891b2" stroke-width="2"/>
-    <rect x="1050" y="160" width="160" height="160" rx="10" fill="#ffffff" stroke="#0891b2" stroke-width="2"/>
-  </g>
-  <g font-family="Inter, Arial, sans-serif" text-anchor="middle">
-    <g fill="#0891b2" font-size="14" font-weight="800">
-      <text x="130" y="190">01</text>
-      <text x="330" y="190">02</text>
-      <text x="730" y="190">04</text>
-      <text x="930" y="190">05</text>
-      <text x="1130" y="190">06</text>
+  <rect width="1920" height="1080" fill="url(#bg)"/>
+  <rect x="142" y="334" width="1636" height="485" rx="10" fill="#020B18" opacity="0.24"/>
+  <text x="960" y="208" class="font title" text-anchor="middle">How To Help Test KORA</text>
+  <text x="960" y="270" class="font subtitle" text-anchor="middle">Bring a sanitized workload and inspect the execution path</text>
+
+  <g class="font" filter="url(#cyanGlow)">
+    <g transform="translate(208 342)">
+      <rect class="card" width="205" height="442" rx="17"/>
+      <path class="line" d="M62 42 h55 l32 32 v114 h-87z M117 42 v32 h32 M78 82 h30 M78 112 h55 M78 142 h55 M78 172 h55"/>
+      <path class="line" d="M20 192 h165"/>
+      <text x="102.5" y="247" class="cyan" font-size="27" text-anchor="middle">01</text>
+      <text x="102.5" y="294" class="white" font-size="27" font-weight="700" text-anchor="middle">Bring a</text>
+      <text x="102.5" y="331" class="white" font-size="27" font-weight="700" text-anchor="middle">Workload</text>
+      <text x="102.5" y="394" class="muted" font-size="16" text-anchor="middle">sanitized inputs</text>
     </g>
-    <text x="530" y="176" fill="#b45309" font-size="14" font-weight="800">03</text>
-    <text x="130" y="224" fill="#0f172a" font-size="17" font-weight="800">Bring a</text>
-    <text x="130" y="248" fill="#0f172a" font-size="17" font-weight="800">Workload</text>
-    <text x="130" y="286" fill="#64748b" font-size="13">sanitized inputs</text>
-    <text x="330" y="216" fill="#0f172a" font-size="17" font-weight="800">Identify</text>
-    <text x="330" y="240" fill="#0f172a" font-size="17" font-weight="800">Deterministic</text>
-    <text x="330" y="264" fill="#0f172a" font-size="17" font-weight="800">Paths</text>
-    <text x="330" y="296" fill="#64748b" font-size="13">rules and repeats</text>
-    <text x="530" y="210" fill="#92400e" font-size="17" font-weight="800">Define</text>
-    <text x="530" y="234" fill="#92400e" font-size="17" font-weight="800">Escalation</text>
-    <text x="530" y="258" fill="#92400e" font-size="17" font-weight="800">Rules</text>
-    <text x="530" y="296" fill="#b45309" font-size="13">when model calls are needed</text>
-    <text x="730" y="224" fill="#0f172a" font-size="17" font-weight="800">Run</text>
-    <text x="730" y="248" fill="#0f172a" font-size="17" font-weight="800">KORA</text>
-    <text x="730" y="286" fill="#64748b" font-size="13">local runtime path</text>
-    <text x="930" y="224" fill="#0f172a" font-size="17" font-weight="800">Inspect</text>
-    <text x="930" y="248" fill="#0f172a" font-size="17" font-weight="800">Telemetry</text>
-    <text x="930" y="286" fill="#64748b" font-size="13">counters and events</text>
-    <text x="1130" y="224" fill="#0f172a" font-size="17" font-weight="800">Share</text>
-    <text x="1130" y="248" fill="#0f172a" font-size="17" font-weight="800">Results</text>
-    <text x="1130" y="286" fill="#64748b" font-size="13">reviewed evidence</text>
+    <path d="M419 476 h34" class="line" marker-end="url(#arrowCyan)"/>
+    <g transform="translate(467 342)">
+      <rect class="card" width="205" height="442" rx="17"/>
+      <circle cx="58" cy="74" r="13" class="line"/><circle cx="119" cy="60" r="13" class="line"/><circle cx="58" cy="126" r="13" class="line"/><circle cx="154" cy="126" r="13" class="line"/>
+      <path class="line" d="M70 70 L107 62 M58 87 v26 M71 126 h46 M119 73 v30 M119 103 h34 v12"/>
+      <path class="line" stroke-dasharray="9 8" d="M80 126 h52"/>
+      <path class="line" d="M20 192 h165"/>
+      <text x="102.5" y="247" class="cyan" font-size="27" text-anchor="middle">02</text>
+      <text x="102.5" y="294" class="white" font-size="27" font-weight="700" text-anchor="middle">Identify</text>
+      <text x="102.5" y="331" class="white" font-size="27" font-weight="700" text-anchor="middle">Deterministic</text>
+      <text x="102.5" y="368" class="white" font-size="27" font-weight="700" text-anchor="middle">Paths</text>
+      <text x="102.5" y="409" class="muted" font-size="16" text-anchor="middle">rules and repeats</text>
+    </g>
+    <path d="M678 476 h34" class="line" marker-end="url(#arrowCyan)"/>
+    <g transform="translate(720 342)" filter="url(#amberGlow)">
+      <rect class="cardAmber" width="220" height="442" rx="17"/>
+      <path class="lineAmber" d="M82 48 h74 v110 h-74z M105 48 q0 -18 16 -18 q16 0 16 18 M93 84 l12 12 l24 -28 M93 119 l12 12 l24 -28 M93 154 l12 12 l24 -28"/>
+      <path class="lineAmber" d="M148 136 l31 55 h-62z M148 154 v17 M148 181 v3"/>
+      <path class="lineAmber" d="M20 192 h180"/>
+      <text x="110" y="247" class="amber" font-size="27" text-anchor="middle">03</text>
+      <text x="110" y="294" class="white" font-size="27" font-weight="700" text-anchor="middle">Define</text>
+      <text x="110" y="331" class="white" font-size="27" font-weight="700" text-anchor="middle">Escalation</text>
+      <text x="110" y="368" class="white" font-size="27" font-weight="700" text-anchor="middle">Rules</text>
+      <text x="110" y="409" fill="#F5B82E" font-size="13" text-anchor="middle">when model calls are needed</text>
+    </g>
+    <path d="M946 476 h34" class="line" marker-end="url(#arrowCyan)"/>
+    <g transform="translate(990 342)">
+      <rect class="card" width="205" height="442" rx="17"/>
+      <rect x="40" y="50" width="120" height="104" rx="6" class="line"/><path class="line" d="M40 74 h120 M55 62 h4 M70 62 h4 M85 62 h4 M64 94 l20 22 l-20 22 M94 139 h24"/>
+      <path class="line" d="M20 192 h165"/>
+      <text x="102.5" y="247" class="cyan" font-size="27" text-anchor="middle">04</text>
+      <text x="102.5" y="294" class="white" font-size="27" font-weight="700" text-anchor="middle">Run</text>
+      <text x="102.5" y="331" class="white" font-size="27" font-weight="700" text-anchor="middle">KORA</text>
+      <text x="102.5" y="394" class="muted" font-size="16" text-anchor="middle">local runtime path</text>
+    </g>
+    <path d="M1201 476 h34" class="line" marker-end="url(#arrowCyan)"/>
+    <g transform="translate(1248 342)">
+      <rect class="card" width="205" height="442" rx="17"/>
+      <path class="line" d="M42 155 h132 M50 155 v-56 h16 v56 M85 155 v-84 h16 v84 M120 155 v-49 h16 v49 M155 155 v-112 h16 v112"/>
+      <path class="line" d="M50 93 l36 -31 l36 21 l48 -60"/><circle cx="50" cy="93" r="6" class="line"/><circle cx="86" cy="62" r="6" class="line"/><circle cx="122" cy="83" r="6" class="line"/><circle cx="170" cy="23" r="6" class="line"/>
+      <path class="line" d="M20 192 h165"/>
+      <text x="102.5" y="247" class="cyan" font-size="27" text-anchor="middle">05</text>
+      <text x="102.5" y="294" class="white" font-size="27" font-weight="700" text-anchor="middle">Inspect</text>
+      <text x="102.5" y="331" class="white" font-size="27" font-weight="700" text-anchor="middle">Telemetry</text>
+      <text x="102.5" y="394" class="muted" font-size="16" text-anchor="middle">counters and events</text>
+    </g>
+    <path d="M1459 476 h34" class="line" marker-end="url(#arrowCyan)"/>
+    <g transform="translate(1506 342)">
+      <rect class="card" width="205" height="442" rx="17"/>
+      <path class="line" d="M50 42 h55 l32 32 v114 h-87z M105 42 v32 h32 M66 82 h30 M66 112 h55 M66 142 h48"/>
+      <circle cx="132" cy="128" r="8" class="line"/><circle cx="166" cy="106" r="8" class="line"/><circle cx="166" cy="154" r="8" class="line"/><path class="line" d="M139 124 l20 -13 M139 132 l20 17"/>
+      <path class="line" d="M20 192 h165"/>
+      <text x="102.5" y="247" class="cyan" font-size="27" text-anchor="middle">06</text>
+      <text x="102.5" y="294" class="white" font-size="27" font-weight="700" text-anchor="middle">Share</text>
+      <text x="102.5" y="331" class="white" font-size="27" font-weight="700" text-anchor="middle">Results</text>
+      <text x="102.5" y="394" class="muted" font-size="16" text-anchor="middle">reviewed evidence</text>
+    </g>
   </g>
-  <rect x="58" y="370" width="1164" height="44" rx="8" fill="#e0f2fe" stroke="#bae6fd"/>
-  <text x="82" y="398" fill="#0f172a" font-family="Inter, Arial, sans-serif" font-size="14">Do not share secrets, API keys, private user data, or proprietary datasets in public channels.</text>
+
+  <g class="font" filter="url(#cyanGlow)">
+    <rect x="207" y="848" width="1506" height="89" rx="12" fill="#071629" stroke="#25D9E6" stroke-width="2.2"/>
+    <path d="M258 874 l18 8 v20 q0 21 -18 30 q-18 -9 -18 -30 v-20z M258 887 v20 M258 918 v3" fill="none" stroke="#25D9E6" stroke-width="2.2"/>
+    <text x="296" y="902" fill="#5BE7F2" font-size="24">Do not share secrets, API keys, private user data, or proprietary datasets in public channels</text>
+  </g>
 </svg>

--- a/docs/assets/kora-validation-roadmap.svg
+++ b/docs/assets/kora-validation-roadmap.svg
@@ -1,61 +1,95 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="1280" height="520" viewBox="0 0 1280 520" role="img" aria-labelledby="title desc">
-  <title id="title">KORA validation roadmap</title>
-  <desc id="desc">A technical roadmap from current alpha benchmark evidence to real model-call runtime validation, customer-support triage, RAG answer routing, and agent budget guard workloads.</desc>
+<svg xmlns="http://www.w3.org/2000/svg" width="1920" height="1080" viewBox="0 0 1920 1080" role="img" aria-labelledby="title desc">
+  <title id="title">KORA Validation Roadmap</title>
+  <desc id="desc">Roadmap from current alpha benchmark evidence toward real workload testing.</desc>
   <defs>
-    <filter id="shadow" x="-10%" y="-20%" width="120%" height="140%">
-      <feDropShadow dx="0" dy="10" stdDeviation="12" flood-color="#020617" flood-opacity="0.35"/>
-    </filter>
-    <linearGradient id="panel" x1="0" y1="0" x2="1" y2="1">
-      <stop offset="0" stop-color="#0f1f33"/>
-      <stop offset="1" stop-color="#0a1322"/>
-    </linearGradient>
+    <radialGradient id="bg" cx="50%" cy="50%" r="64%">
+      <stop offset="0" stop-color="#071A2F"/>
+      <stop offset="0.6" stop-color="#04111F"/>
+      <stop offset="1" stop-color="#020B18"/>
+    </radialGradient>
+    <filter id="cyanGlow" x="-40%" y="-40%" width="180%" height="180%"><feGaussianBlur stdDeviation="3.5" result="b"/><feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge></filter>
+    <filter id="amberGlow" x="-40%" y="-40%" width="180%" height="180%"><feGaussianBlur stdDeviation="4.5" result="b"/><feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge></filter>
+    <style>
+      .font { font-family: "IBM Plex Mono", "JetBrains Mono", "Roboto Mono", Menlo, Consolas, monospace; }
+      .title { fill: #F4F7FB; font-size: 68px; font-weight: 800; }
+      .subtitle { fill: #5BE7F2; font-size: 30px; }
+      .card { fill: #071629; stroke: #25D9E6; stroke-width: 2.4; }
+      .amberCard { fill: #071629; stroke: #F5B82E; stroke-width: 2.6; }
+      .cyan { fill: #5BE7F2; stroke: #25D9E6; }
+      .amber { fill: #F5B82E; stroke: #F5B82E; }
+      .white { fill: #F4F7FB; }
+      .muted { fill: #A8B3C7; }
+      .line { stroke: #25D9E6; stroke-width: 4; fill: none; }
+      .thin { stroke-width: 2.2; fill: none; }
+    </style>
   </defs>
-  <rect width="1280" height="520" fill="#08111f"/>
-  <path d="M0 420 C220 350 330 470 540 390 C780 300 930 360 1280 250 L1280 520 L0 520 Z" fill="#0b1b2d" opacity="0.8"/>
-  <text x="64" y="70" fill="#e6f6ff" font-family="Inter, Arial, sans-serif" font-size="34" font-weight="800">KORA Validation Roadmap</text>
-  <text x="64" y="105" fill="#8bdcf8" font-family="Inter, Arial, sans-serif" font-size="17">From current alpha benchmark evidence toward real workload testing.</text>
-  <g fill="none" stroke="#22d3ee" stroke-width="5" stroke-linecap="round" stroke-linejoin="round">
-    <path d="M170 288 H1078"/>
-    <path d="M1052 272 L1078 288 L1052 304"/>
-  </g>
-  <g font-family="Inter, Arial, sans-serif" text-anchor="middle" filter="url(#shadow)">
-    <g fill="url(#panel)" stroke="#1f9fc1" stroke-width="2">
-      <rect x="58" y="185" width="196" height="156" rx="10"/>
-      <rect x="294" y="155" width="196" height="186" rx="10" stroke="#f59e0b"/>
-      <rect x="530" y="185" width="196" height="156" rx="10"/>
-      <rect x="766" y="185" width="196" height="156" rx="10"/>
-      <rect x="1002" y="185" width="196" height="156" rx="10"/>
+  <rect width="1920" height="1080" fill="url(#bg)"/>
+  <rect x="154" y="354" width="1612" height="392" rx="10" fill="#020B18" opacity="0.25"/>
+  <text x="960" y="208" class="font title" text-anchor="middle">KORA Validation Roadmap</text>
+  <text x="960" y="270" class="font subtitle" text-anchor="middle">From current alpha benchmark evidence toward real workload testing</text>
+
+  <g class="font" filter="url(#cyanGlow)">
+    <path class="line" d="M469 535 H516 M784 535 H827 M1092 535 H1139 M1404 535 H1452"/>
+    <circle cx="469" cy="535" r="8" class="cyan"/>
+    <circle cx="516" cy="535" r="8" class="cyan"/>
+    <circle cx="784" cy="535" r="8" fill="#F5B82E" stroke="#F5B82E"/>
+    <circle cx="827" cy="535" r="8" fill="#F5B82E" stroke="#F5B82E"/>
+    <circle cx="1092" cy="535" r="8" class="cyan"/>
+    <circle cx="1139" cy="535" r="8" class="cyan"/>
+    <circle cx="1404" cy="535" r="8" class="cyan"/>
+    <circle cx="1452" cy="535" r="8" class="cyan"/>
+
+    <g transform="translate(208 371)">
+      <rect width="262" height="335" rx="18" class="card"/>
+      <circle cx="131" cy="53" r="19" fill="#25D9E6"/>
+      <text x="131" y="124" class="white" font-size="27" font-weight="700" text-anchor="middle">Current Alpha</text>
+      <text x="131" y="160" class="white" font-size="27" font-weight="700" text-anchor="middle">Benchmark</text>
+      <path d="M34 197 h194" class="cyan thin"/><circle cx="131" cy="197" r="4" class="cyan"/>
+      <text x="131" y="249" class="muted" font-size="20" text-anchor="middle">deterministic-heavy</text>
+      <text x="131" y="285" class="muted" font-size="20" text-anchor="middle">evidence baseline</text>
     </g>
-    <circle cx="156" cy="288" r="9" fill="#22d3ee"/>
-    <circle cx="392" cy="288" r="10" fill="#f59e0b"/>
-    <circle cx="628" cy="288" r="9" fill="#22d3ee"/>
-    <circle cx="864" cy="288" r="9" fill="#22d3ee"/>
-    <circle cx="1100" cy="288" r="9" fill="#22d3ee"/>
+    <g transform="translate(516 365)" filter="url(#amberGlow)">
+      <rect width="268" height="345" rx="18" class="amberCard"/>
+      <circle cx="134" cy="59" r="19" fill="#F5B82E"/>
+      <text x="134" y="128" class="white" font-size="26" font-weight="700" text-anchor="middle">Real Model-Call</text>
+      <text x="134" y="165" class="white" font-size="26" font-weight="700" text-anchor="middle">Runtime Path</text>
+      <path d="M36 203 h196" class="amber thin"/><circle cx="134" cy="203" r="4" class="amber"/>
+      <text x="134" y="254" fill="#F5B82E" font-size="19" text-anchor="middle">conditional escalation</text>
+      <text x="134" y="290" fill="#F5B82E" font-size="19" text-anchor="middle">with measured calls</text>
+    </g>
+    <g transform="translate(828 371)">
+      <rect width="264" height="335" rx="18" class="card"/>
+      <circle cx="132" cy="53" r="19" fill="#25D9E6"/>
+      <text x="132" y="124" class="white" font-size="25" font-weight="700" text-anchor="middle">Customer-Support</text>
+      <text x="132" y="160" class="white" font-size="27" font-weight="700" text-anchor="middle">Triage</text>
+      <path d="M35 197 h194" class="cyan thin"/><circle cx="132" cy="197" r="4" class="cyan"/>
+      <text x="132" y="249" class="muted" font-size="19" text-anchor="middle">policy and routing</text>
+      <text x="132" y="285" class="muted" font-size="19" text-anchor="middle">workloads</text>
+    </g>
+    <g transform="translate(1140 371)">
+      <rect width="264" height="335" rx="18" class="card"/>
+      <circle cx="132" cy="53" r="19" fill="#25D9E6"/>
+      <text x="132" y="124" class="white" font-size="27" font-weight="700" text-anchor="middle">RAG Answer</text>
+      <text x="132" y="160" class="white" font-size="27" font-weight="700" text-anchor="middle">Routing</text>
+      <path d="M35 197 h194" class="cyan thin"/><circle cx="132" cy="197" r="4" class="cyan"/>
+      <text x="132" y="249" class="muted" font-size="19" text-anchor="middle">source-backed paths</text>
+      <text x="132" y="285" class="muted" font-size="19" text-anchor="middle">and escalation</text>
+    </g>
+    <g transform="translate(1452 371)">
+      <rect width="262" height="335" rx="18" class="card"/>
+      <circle cx="131" cy="53" r="19" fill="#25D9E6"/>
+      <text x="131" y="124" class="white" font-size="27" font-weight="700" text-anchor="middle">Agent Budget</text>
+      <text x="131" y="160" class="white" font-size="27" font-weight="700" text-anchor="middle">Guard</text>
+      <path d="M34 197 h194" class="cyan thin"/><circle cx="131" cy="197" r="4" class="cyan"/>
+      <text x="131" y="249" class="muted" font-size="19" text-anchor="middle">retry and budget</text>
+      <text x="131" y="285" class="muted" font-size="19" text-anchor="middle">boundaries</text>
+    </g>
   </g>
-  <g font-family="Inter, Arial, sans-serif" text-anchor="middle">
-    <text x="156" y="225" fill="#e6f6ff" font-size="18" font-weight="800">Current Alpha</text>
-    <text x="156" y="251" fill="#e6f6ff" font-size="18" font-weight="800">Benchmark</text>
-    <text x="156" y="318" fill="#9fb6c9" font-size="13">deterministic-heavy</text>
-    <text x="156" y="337" fill="#9fb6c9" font-size="13">evidence baseline</text>
-    <text x="392" y="202" fill="#fff7ed" font-size="18" font-weight="800">Real Model-Call</text>
-    <text x="392" y="228" fill="#fff7ed" font-size="18" font-weight="800">Runtime Path</text>
-    <text x="392" y="318" fill="#fed7aa" font-size="13">conditional escalation</text>
-    <text x="392" y="337" fill="#fed7aa" font-size="13">with measured calls</text>
-    <text x="628" y="225" fill="#e6f6ff" font-size="18" font-weight="800">Customer-Support</text>
-    <text x="628" y="251" fill="#e6f6ff" font-size="18" font-weight="800">Triage</text>
-    <text x="628" y="318" fill="#9fb6c9" font-size="13">policy and routing</text>
-    <text x="628" y="337" fill="#9fb6c9" font-size="13">workloads</text>
-    <text x="864" y="225" fill="#e6f6ff" font-size="18" font-weight="800">RAG Answer</text>
-    <text x="864" y="251" fill="#e6f6ff" font-size="18" font-weight="800">Routing</text>
-    <text x="864" y="318" fill="#9fb6c9" font-size="13">source-backed paths</text>
-    <text x="864" y="337" fill="#9fb6c9" font-size="13">and escalation</text>
-    <text x="1100" y="225" fill="#e6f6ff" font-size="18" font-weight="800">Agent Budget</text>
-    <text x="1100" y="251" fill="#e6f6ff" font-size="18" font-weight="800">Guard</text>
-    <text x="1100" y="318" fill="#9fb6c9" font-size="13">retry and budget</text>
-    <text x="1100" y="337" fill="#9fb6c9" font-size="13">boundaries</text>
-  </g>
-  <g font-family="Inter, Arial, sans-serif" font-size="14">
-    <rect x="64" y="425" width="1152" height="44" rx="8" fill="#0f1f33" stroke="#17334d"/>
-    <text x="86" y="453" fill="#b9d7e8">Measure: total requests, baseline calls, KORA-controlled calls, avoided calls, latency, tokens, fallback count, error count, validation result.</text>
+  <g class="font" filter="url(#cyanGlow)">
+    <rect x="207" y="762" width="1506" height="113" rx="10" fill="#071629" stroke="#25D9E6" stroke-width="2.2"/>
+    <text x="254" y="816" fill="#25D9E6" font-size="42" font-weight="700">&gt;_</text>
+    <text x="340" y="810" fill="#5BE7F2" font-size="24">Measure:</text>
+    <text x="489" y="810" class="muted" font-size="22">total requests, baseline calls, KORA-controlled calls, avoided calls,</text>
+    <text x="489" y="844" class="muted" font-size="22">latency, tokens, fallback count, error count, validation result.</text>
   </g>
 </svg>


### PR DESCRIPTION
## Summary
- Rebuilt the four README/docs SVG diagrams from the attached approved reference images.
- Applied a unified dark navy / cyan / amber technical visual system.
- Updated the Help Test diagram warning text and corrected `privatee` to `private`.
- Updated the execution-control overview so the after path visibly branches into deterministic preferred execution and conditional model escalation.

## SVGs updated
- `docs/assets/kora-help-test-flow.svg`
- `docs/assets/kora-validation-roadmap.svg`
- `docs/assets/kora-benchmark-evidence-card.svg`
- `docs/assets/kora-execution-control-overview.svg`

## Validation
- `git diff --check` passed.
- `xmllint --noout docs/assets/*.svg` passed.
- `python3 -m pytest` passed: 54 tests.
- `python3 -m kora --help` passed.
- `python3 -m kora examples list` passed.
- `python3 -m kora run direct_vs_kora -- --offline` passed.
- `python3 -m kora run runtime_integrated_benchmark -- --offline` passed.

## Claim safety
- No production cost-reduction claim added.
- No real API-cost reduction claim added.
- No energy-reduction claim added.
- Benchmark evidence card uses explicit non-claim boundary language only.
- No internal prompt workflow, private campaign operations, or private internals content was added to public docs.
