### PR TITLE
Add provider-neutral model-call adapter interface

### DIFF
--- a/docs/benchmarks/real-model-call-validation-design.md
+++ b/docs/benchmarks/real-model-call-validation-design.md
@@ -21,6 +21,7 @@ Current relevant public surfaces:
 - `examples/runtime_integrated_benchmark/`
 - `experiments/workloads/deterministic_heavy_v1_100.json`
 - `experiments/run_benchmark.py`
+- `kora/model_call.py`
 - `kora/adapters/base.py`
 - `kora/adapters/mock.py`
 - `kora/adapters/openai_adapter.py`
@@ -239,6 +240,23 @@ Every validation run should report:
 - `measured_cost`, only if provider billing data is explicitly supplied later
 
 Cost counters must not be used to claim real API-cost reduction unless billing data, methodology, baseline, and claim language are separately reviewed.
+
+## Provider-Neutral Adapter Interface
+
+KORA uses a provider-neutral adapter boundary for model-call measurement in future validation harnesses.
+
+Current implementation:
+
+- `ModelCallRequest`: normalized request with `request_id`, `prompt`, metadata, and privacy class.
+- `ModelCallResponse`: normalized response with measured model-call count, latency, token counters where available, provider/model labels, and metadata.
+- `ModelCallAdapter`: protocol for adapters that return measured model-call counters.
+- `DeterministicFakeModelCallAdapter`: local, deterministic, no-network adapter for tests and harness development.
+- `BlockedModelCallAdapter`: fail-closed adapter for cases where real provider use has not been explicitly configured.
+- `ModelCallSummary`: aggregate counter helper for validation reports.
+
+The fake deterministic adapter is the only local implementation added at this stage. It requires no credentials, performs no external calls, and records provider/model as `fake` / `deterministic-fake`.
+
+Future local or remote provider adapters can plug into the same interface. Remote provider calls must use environment variables for configuration and must not commit secrets, raw prompts, raw responses, private user data, or proprietary datasets.
 
 ## Telemetry Output
 

--- a/docs/benchmarks/real-model-call-validation-report-template.md
+++ b/docs/benchmarks/real-model-call-validation-report-template.md
@@ -41,6 +41,9 @@ Sanitized environment details:
 - Python version:
 - Operating system:
 - Adapter mode:
+- Adapter:
+- Model-call counter source:
+- Token counter source:
 - Provider configuration source: environment variables only, if remote provider mode is used
 
 Do not include API keys, tokens, credentials, private hostnames, private dataset names, or raw provider response IDs unless explicitly approved.

--- a/kora/__init__.py
+++ b/kora/__init__.py
@@ -6,4 +6,5 @@ __all__ = [
     "executor",
     "budget",
     "verification",
+    "model_call",
 ]

--- a/kora/model_call.py
+++ b/kora/model_call.py
@@ -1,0 +1,126 @@
+"""Provider-neutral model-call measurement primitives."""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass, field
+from typing import Any, Protocol
+
+
+def _estimate_tokens(text: str) -> int:
+    """Return a stable, conservative token estimate for local validation."""
+    return len(text.split()) if text.strip() else 0
+
+
+@dataclass(frozen=True)
+class ModelCallRequest:
+    """Provider-neutral model-call request for validation harnesses."""
+
+    request_id: str
+    prompt: str
+    metadata: dict[str, Any] = field(default_factory=dict)
+    privacy_class: str = "synthetic"
+
+
+@dataclass(frozen=True)
+class ModelCallResponse:
+    """Provider-neutral model-call response with measurement counters."""
+
+    request_id: str
+    output: str
+    model_calls: int
+    latency_ms: float | None
+    input_tokens: int | None
+    output_tokens: int | None
+    provider: str | None
+    model: str | None
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+class ModelCallAdapter(Protocol):
+    """Protocol implemented by model-call adapters used in validation."""
+
+    def call(self, request: ModelCallRequest) -> ModelCallResponse:
+        """Execute one model-call request and return measured counters."""
+
+
+class DeterministicFakeModelCallAdapter:
+    """Local no-network adapter for deterministic validation tests."""
+
+    provider = "fake"
+    model = "deterministic-fake"
+
+    def call(self, request: ModelCallRequest) -> ModelCallResponse:
+        start = time.perf_counter()
+        output = f"fake:{request.request_id}:{request.prompt.strip()[:80]}"
+        latency_ms = (time.perf_counter() - start) * 1000.0
+        return ModelCallResponse(
+            request_id=request.request_id,
+            output=output,
+            model_calls=1,
+            latency_ms=latency_ms,
+            input_tokens=_estimate_tokens(request.prompt),
+            output_tokens=_estimate_tokens(output),
+            provider=self.provider,
+            model=self.model,
+            metadata={
+                "privacy_class": request.privacy_class,
+                "adapter": self.provider,
+                "network": "none",
+                "deterministic": True,
+            },
+        )
+
+
+class BlockedModelCallAdapter:
+    """Adapter that fails closed when real provider use is not configured."""
+
+    def call(self, request: ModelCallRequest) -> ModelCallResponse:
+        del request
+        raise RuntimeError(
+            "Real model-call adapter is not configured. Use an explicit local "
+            "or remote adapter in a validation harness."
+        )
+
+
+@dataclass(frozen=True)
+class ModelCallSummary:
+    """Aggregate model-call counters for validation reports."""
+
+    total_requests: int
+    model_calls: int
+    input_tokens_total: int | None
+    output_tokens_total: int | None
+    latency_total_ms: float | None
+    error_count: int
+
+    @classmethod
+    def from_responses(
+        cls,
+        responses: list[ModelCallResponse],
+        *,
+        error_count: int = 0,
+    ) -> "ModelCallSummary":
+        input_tokens = [response.input_tokens for response in responses]
+        output_tokens = [response.output_tokens for response in responses]
+        latencies = [response.latency_ms for response in responses]
+        return cls(
+            total_requests=len(responses) + error_count,
+            model_calls=sum(response.model_calls for response in responses),
+            input_tokens_total=(
+                sum(token for token in input_tokens if token is not None)
+                if all(token is not None for token in input_tokens)
+                else None
+            ),
+            output_tokens_total=(
+                sum(token for token in output_tokens if token is not None)
+                if all(token is not None for token in output_tokens)
+                else None
+            ),
+            latency_total_ms=(
+                sum(latency for latency in latencies if latency is not None)
+                if all(latency is not None for latency in latencies)
+                else None
+            ),
+            error_count=error_count,
+        )

--- a/tests/test_model_call.py
+++ b/tests/test_model_call.py
@@ -1,0 +1,117 @@
+import os
+
+import pytest
+
+from kora.model_call import (
+    BlockedModelCallAdapter,
+    DeterministicFakeModelCallAdapter,
+    ModelCallRequest,
+    ModelCallSummary,
+)
+
+
+def test_fake_adapter_returns_deterministic_response() -> None:
+    adapter = DeterministicFakeModelCallAdapter()
+    request = ModelCallRequest(request_id="req-1", prompt="Classify this request")
+
+    first = adapter.call(request)
+    second = adapter.call(request)
+
+    assert first.output == second.output
+    assert first.request_id == "req-1"
+    assert first.output == "fake:req-1:Classify this request"
+
+
+def test_fake_adapter_records_one_model_call_per_call() -> None:
+    adapter = DeterministicFakeModelCallAdapter()
+
+    response = adapter.call(ModelCallRequest(request_id="req-2", prompt="Hello"))
+
+    assert response.model_calls == 1
+    assert response.latency_ms is not None
+    assert response.latency_ms >= 0
+
+
+def test_fake_adapter_token_estimates_are_stable() -> None:
+    adapter = DeterministicFakeModelCallAdapter()
+    request = ModelCallRequest(request_id="req-3", prompt="one two three")
+
+    response = adapter.call(request)
+
+    assert response.input_tokens == 3
+    assert response.output_tokens == 3
+
+
+def test_fake_adapter_provider_model_and_metadata_are_local_safe() -> None:
+    adapter = DeterministicFakeModelCallAdapter()
+    request = ModelCallRequest(
+        request_id="req-4",
+        prompt="safe synthetic prompt",
+        privacy_class="synthetic",
+    )
+
+    response = adapter.call(request)
+
+    assert response.provider == "fake"
+    assert response.model == "deterministic-fake"
+    assert response.metadata["privacy_class"] == "synthetic"
+    assert response.metadata["network"] == "none"
+    assert response.metadata["deterministic"] is True
+
+
+def test_fake_adapter_requires_no_secrets_or_environment(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+
+    response = DeterministicFakeModelCallAdapter().call(
+        ModelCallRequest(request_id="req-5", prompt="local only")
+    )
+
+    assert response.model_calls == 1
+    assert "OPENAI_API_KEY" not in os.environ
+    assert "ANTHROPIC_API_KEY" not in os.environ
+
+
+def test_model_call_summary_aggregates_counters() -> None:
+    adapter = DeterministicFakeModelCallAdapter()
+    responses = [
+        adapter.call(ModelCallRequest(request_id="req-6", prompt="alpha beta")),
+        adapter.call(ModelCallRequest(request_id="req-7", prompt="gamma")),
+    ]
+
+    summary = ModelCallSummary.from_responses(responses, error_count=1)
+
+    assert summary.total_requests == 3
+    assert summary.model_calls == 2
+    assert summary.input_tokens_total == 3
+    assert summary.output_tokens_total == 3
+    assert summary.latency_total_ms is not None
+    assert summary.error_count == 1
+
+
+def test_model_call_summary_preserves_unknown_token_totals() -> None:
+    adapter = DeterministicFakeModelCallAdapter()
+    response = adapter.call(ModelCallRequest(request_id="req-8", prompt="known"))
+    response_without_tokens = type(response)(
+        request_id=response.request_id,
+        output=response.output,
+        model_calls=response.model_calls,
+        latency_ms=response.latency_ms,
+        input_tokens=None,
+        output_tokens=response.output_tokens,
+        provider=response.provider,
+        model=response.model,
+        metadata=response.metadata,
+    )
+
+    summary = ModelCallSummary.from_responses([response, response_without_tokens])
+
+    assert summary.input_tokens_total is None
+    assert summary.output_tokens_total is not None
+
+
+def test_blocked_adapter_fails_closed() -> None:
+    adapter = BlockedModelCallAdapter()
+
+    with pytest.raises(RuntimeError, match="Real model-call adapter is not configured"):
+        adapter.call(ModelCallRequest(request_id="req-9", prompt="blocked"))


### PR DESCRIPTION
## Summary
- Add a provider-neutral model-call request/response/adapter interface for future runtime validation.
- Add a deterministic fake no-network adapter, fail-closed blocked adapter, and aggregate counter helper.
- Add tests for deterministic behavior, one-call accounting, token estimates, local-safe metadata, no-secret operation, summary aggregation, and fail-closed behavior.
- Update real model-call validation docs and report template with adapter/counter fields.

## Validation
- git diff --check
- python3 -m pytest
- python3 -m kora --help
- python3 -m kora examples list
- python3 -m kora run direct_vs_kora -- --offline
- python3 -m kora run runtime_integrated_benchmark -- --offline

## Claim and safety notes
- No real provider API calls implemented.
- No external provider dependencies added.
- No secrets, API keys, raw provider responses, private data, or proprietary datasets added.
- No production cost-reduction, real API-cost reduction, production benchmark, or energy-reduction claims added.