### PR TITLE
Add fake model-call runtime validation example

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,8 @@ See the [KORA validation roadmap](docs/benchmarks/validation-roadmap.md) for the
 
 See the [real model-call validation design](docs/benchmarks/real-model-call-validation-design.md) for the next measurement path.
 
+A no-network fake model-call validation example is available for testing the measured invocation counter path.
+
 ## Help Test KORA
 
 Good candidate workloads:

--- a/docs/README.md
+++ b/docs/README.md
@@ -40,6 +40,7 @@ Core local commands:
 ```bash
 python3 -m kora --help
 python3 -m kora examples list
+python3 -m kora run real_model_call_validation_fake -- --offline
 python3 -m kora run direct_vs_kora -- --offline
 python3 -m kora run runtime_integrated_benchmark -- --offline
 ```
@@ -59,7 +60,8 @@ Use this path for the current `v0.3.0-alpha` prerelease runtime evidence and reg
 9. Validation roadmap: [`docs/benchmarks/validation-roadmap.md`](benchmarks/validation-roadmap.md)
 10. Real model-call validation design: [`docs/benchmarks/real-model-call-validation-design.md`](benchmarks/real-model-call-validation-design.md)
 11. Real model-call validation report template: [`docs/benchmarks/real-model-call-validation-report-template.md`](benchmarks/real-model-call-validation-report-template.md)
-12. Claim boundary source: [`docs/claims/kora-claim-registry.md`](claims/kora-claim-registry.md)
+12. Fake model-call validation example: [`examples/real_model_call_validation_fake`](../examples/real_model_call_validation_fake)
+13. Claim boundary source: [`docs/claims/kora-claim-registry.md`](claims/kora-claim-registry.md)
 
 Current approved public claim:
 

--- a/docs/benchmarks/real-model-call-validation-design.md
+++ b/docs/benchmarks/real-model-call-validation-design.md
@@ -258,6 +258,20 @@ The fake deterministic adapter is the only local implementation added at this st
 
 Future local or remote provider adapters can plug into the same interface. Remote provider calls must use environment variables for configuration and must not commit secrets, raw prompts, raw responses, private user data, or proprietary datasets.
 
+## Fake Model-Call Runtime Example
+
+The first runtime validation example is a no-network fake model-call path:
+
+```bash
+python3 -m kora run real_model_call_validation_fake -- --offline
+```
+
+This example uses `DeterministicFakeModelCallAdapter` with a synthetic 10-request workload. The direct baseline calls the fake adapter for every request. The KORA-controlled path handles deterministic routes without fake model calls and escalates only model-required routes through the provider-neutral adapter boundary.
+
+The example validates model-call counter plumbing before real local or remote provider adapters are added. It requires no secrets, uses no network, emits aggregate counters only, and does not commit raw prompts or raw provider responses.
+
+Claim boundary: this is not real provider validation, real API-cost validation, production validation, production cost reduction proof, broad workload superiority proof, or energy reduction evidence.
+
 ## Telemetry Output
 
 Real model-call validation should emit sanitized artifacts only.

--- a/docs/benchmarks/real-model-call-validation-report-template.md
+++ b/docs/benchmarks/real-model-call-validation-report-template.md
@@ -46,6 +46,13 @@ Sanitized environment details:
 - Token counter source:
 - Provider configuration source: environment variables only, if remote provider mode is used
 
+For the no-network fake validation example, use:
+
+- Mode: `fake_model_call_validation`
+- Provider/runtime: `fake`
+- Model: `deterministic-fake`
+- Cost summary: `N/A` unless a real provider with explicit pricing is configured later
+
 Do not include API keys, tokens, credentials, private hostnames, private dataset names, or raw provider response IDs unless explicitly approved.
 
 ## Commands

--- a/examples/real_model_call_validation_fake/run.py
+++ b/examples/real_model_call_validation_fake/run.py
@@ -1,0 +1,256 @@
+"""No-network fake model-call validation example.
+
+This example exercises the provider-neutral model-call adapter boundary with
+synthetic data only. It is intended to validate local model-call counters before
+real local or remote provider adapters are added.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from dataclasses import dataclass
+from typing import Any, Literal
+
+from kora.model_call import (
+    DeterministicFakeModelCallAdapter,
+    ModelCallRequest,
+    ModelCallResponse,
+    ModelCallSummary,
+)
+
+Route = Literal["deterministic", "model_required"]
+
+CLAIM_BOUNDARY = (
+    "This fake/local no-network validation example tests the measured model-call "
+    "counter path. It is not real provider validation, real API-cost validation, "
+    "production validation, production cost reduction proof, broad workload "
+    "superiority proof, or energy reduction evidence."
+)
+
+
+@dataclass(frozen=True)
+class SyntheticRequest:
+    request_id: str
+    input: str
+    expected_route: Route
+    expected_output: str | None
+    privacy_class: str = "synthetic"
+
+
+WORKLOAD: tuple[SyntheticRequest, ...] = (
+    SyntheticRequest(
+        request_id="req-001",
+        input="Return the current order status label for delivered.",
+        expected_route="deterministic",
+        expected_output="status:delivered",
+    ),
+    SyntheticRequest(
+        request_id="req-002",
+        input="Normalize the refund-policy category.",
+        expected_route="deterministic",
+        expected_output="category:refund_policy",
+    ),
+    SyntheticRequest(
+        request_id="req-003",
+        input="Route a billing receipt request.",
+        expected_route="deterministic",
+        expected_output="route:billing_receipt",
+    ),
+    SyntheticRequest(
+        request_id="req-004",
+        input="Classify a password reset request.",
+        expected_route="deterministic",
+        expected_output="route:account_recovery",
+    ),
+    SyntheticRequest(
+        request_id="req-005",
+        input="Identify a shipping-address update.",
+        expected_route="deterministic",
+        expected_output="route:shipping_update",
+    ),
+    SyntheticRequest(
+        request_id="req-006",
+        input="Return a canned support-hours answer.",
+        expected_route="deterministic",
+        expected_output="answer:support_hours",
+    ),
+    SyntheticRequest(
+        request_id="req-007",
+        input="Draft a nuanced apology for a delayed enterprise shipment.",
+        expected_route="model_required",
+        expected_output=None,
+    ),
+    SyntheticRequest(
+        request_id="req-008",
+        input="Summarize an ambiguous customer escalation note.",
+        expected_route="model_required",
+        expected_output=None,
+    ),
+    SyntheticRequest(
+        request_id="req-009",
+        input="Generate a context-aware response for a billing dispute.",
+        expected_route="model_required",
+        expected_output=None,
+    ),
+    SyntheticRequest(
+        request_id="req-010",
+        input="Explain an edge-case refund decision in plain language.",
+        expected_route="model_required",
+        expected_output=None,
+    ),
+)
+
+
+def _model_request(item: SyntheticRequest) -> ModelCallRequest:
+    return ModelCallRequest(
+        request_id=item.request_id,
+        prompt=item.input,
+        privacy_class=item.privacy_class,
+        metadata={"expected_route": item.expected_route},
+    )
+
+
+def _run_direct_baseline(
+    workload: tuple[SyntheticRequest, ...],
+    adapter: DeterministicFakeModelCallAdapter,
+) -> list[ModelCallResponse]:
+    return [adapter.call(_model_request(item)) for item in workload]
+
+
+def _run_deterministic_handler(item: SyntheticRequest) -> str:
+    if item.expected_output is None:
+        raise ValueError(f"deterministic request {item.request_id} has no expected output")
+    return item.expected_output
+
+
+def _run_kora_controlled_path(
+    workload: tuple[SyntheticRequest, ...],
+    adapter: DeterministicFakeModelCallAdapter,
+) -> tuple[list[ModelCallResponse], int, int, int, int, int]:
+    model_responses: list[ModelCallResponse] = []
+    deterministic_routes = 0
+    model_escalations = 0
+    validation_pass_count = 0
+    validation_fail_count = 0
+    error_count = 0
+
+    for item in workload:
+        try:
+            if item.expected_route == "deterministic":
+                deterministic_routes += 1
+                output = _run_deterministic_handler(item)
+                if output == item.expected_output:
+                    validation_pass_count += 1
+                else:
+                    validation_fail_count += 1
+                continue
+
+            model_escalations += 1
+            response = adapter.call(_model_request(item))
+            model_responses.append(response)
+            if response.output:
+                validation_pass_count += 1
+            else:
+                validation_fail_count += 1
+        except Exception:
+            error_count += 1
+
+    return (
+        model_responses,
+        deterministic_routes,
+        model_escalations,
+        validation_pass_count,
+        validation_fail_count,
+        error_count,
+    )
+
+
+def build_fake_model_call_validation_summary(
+    *,
+    offline: bool = True,
+    workload: tuple[SyntheticRequest, ...] = WORKLOAD,
+) -> dict[str, Any]:
+    if not offline:
+        raise ValueError("real_model_call_validation_fake supports --offline only")
+
+    baseline_adapter = DeterministicFakeModelCallAdapter()
+    kora_adapter = DeterministicFakeModelCallAdapter()
+
+    baseline_responses = _run_direct_baseline(workload, baseline_adapter)
+    (
+        kora_responses,
+        deterministic_routes,
+        model_escalations,
+        validation_pass_count,
+        validation_fail_count,
+        error_count,
+    ) = _run_kora_controlled_path(workload, kora_adapter)
+
+    baseline_summary = ModelCallSummary.from_responses(baseline_responses)
+    kora_summary = ModelCallSummary.from_responses(kora_responses, error_count=error_count)
+    total_requests = len(workload)
+    avoided_model_calls = baseline_summary.model_calls - kora_summary.model_calls
+    avoided_model_call_rate = (
+        avoided_model_calls / baseline_summary.model_calls
+        if baseline_summary.model_calls
+        else 0.0
+    )
+
+    return {
+        "ok": error_count == 0 and validation_fail_count == 0,
+        "mode": "fake_model_call_validation",
+        "offline": True,
+        "adapter": "DeterministicFakeModelCallAdapter",
+        "provider": "fake",
+        "model": "deterministic-fake",
+        "total_requests": total_requests,
+        "baseline_model_calls": baseline_summary.model_calls,
+        "kora_model_calls": kora_summary.model_calls,
+        "avoided_model_calls": avoided_model_calls,
+        "avoided_model_call_rate": avoided_model_call_rate,
+        "deterministic_routes": deterministic_routes,
+        "model_escalations": model_escalations,
+        "validation_pass_count": validation_pass_count,
+        "validation_fail_count": validation_fail_count,
+        "error_count": error_count,
+        "fallback_count": 0,
+        "input_tokens_total": kora_summary.input_tokens_total,
+        "output_tokens_total": kora_summary.output_tokens_total,
+        "baseline_input_tokens_total": baseline_summary.input_tokens_total,
+        "baseline_output_tokens_total": baseline_summary.output_tokens_total,
+        "latency_total_ms": kora_summary.latency_total_ms,
+        "privacy_class": "synthetic",
+        "raw_prompts_emitted": False,
+        "raw_responses_emitted": False,
+        "claim_boundary": CLAIM_BOUNDARY,
+        "notes": [
+            "Synthetic workload only.",
+            "Direct baseline calls the fake adapter for every request.",
+            "KORA-controlled path handles deterministic routes without fake model calls.",
+            "Model-required routes call the fake adapter through the provider-neutral boundary.",
+            "No external APIs, network access, provider credentials, raw prompts, or raw provider responses are used.",
+        ],
+    }
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Run the no-network fake model-call validation example."
+    )
+    parser.add_argument("--offline", action="store_true", help="required; run without network calls")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    if not args.offline:
+        raise SystemExit("real_model_call_validation_fake requires --offline.")
+
+    summary = build_fake_model_call_validation_summary(offline=True)
+    print(json.dumps(summary, indent=2, sort_keys=True))
+    return 0 if summary["ok"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/kora/cli.py
+++ b/kora/cli.py
@@ -31,6 +31,7 @@ def _example_descriptions() -> dict[str, str]:
         "retry_demo": "retry/recovery flow example",
         "direct_vs_kora": "direct call vs KORA-controlled path",
         "real_workload_harness": "benchmark/report flow example",
+        "real_model_call_validation_fake": "no-network fake model-call validation example",
         "runtime_integrated_benchmark": "initial runtime-path benchmark harness",
         "stress_test": "repeated-run stress harness",
     }

--- a/tests/test_real_model_call_validation_fake.py
+++ b/tests/test_real_model_call_validation_fake.py
@@ -1,0 +1,96 @@
+import importlib.util
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+def _load_example_module():
+    script_path = Path("examples/real_model_call_validation_fake/run.py")
+    spec = importlib.util.spec_from_file_location("real_model_call_validation_fake_run", script_path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError("failed to load real_model_call_validation_fake module")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[str(spec.name)] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_fake_model_call_validation_summary_counts() -> None:
+    module = _load_example_module()
+
+    summary = module.build_fake_model_call_validation_summary(offline=True)
+
+    assert summary["ok"] is True
+    assert summary["mode"] == "fake_model_call_validation"
+    assert summary["provider"] == "fake"
+    assert summary["model"] == "deterministic-fake"
+    assert summary["total_requests"] == 10
+    assert summary["baseline_model_calls"] == 10
+    assert summary["kora_model_calls"] == 4
+    assert summary["avoided_model_calls"] == 6
+    assert summary["avoided_model_call_rate"] == 0.6
+    assert summary["deterministic_routes"] == 6
+    assert summary["model_escalations"] == 4
+    assert summary["validation_pass_count"] == 10
+    assert summary["validation_fail_count"] == 0
+    assert summary["error_count"] == 0
+    assert summary["fallback_count"] == 0
+
+
+def test_fake_model_call_validation_does_not_emit_raw_inputs_or_outputs() -> None:
+    module = _load_example_module()
+
+    summary = module.build_fake_model_call_validation_summary(offline=True)
+
+    assert summary["privacy_class"] == "synthetic"
+    assert summary["raw_prompts_emitted"] is False
+    assert summary["raw_responses_emitted"] is False
+    assert "raw provider responses" in summary["notes"][-1]
+
+
+def test_fake_model_call_validation_requires_no_provider_environment(
+    monkeypatch,
+) -> None:
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    module = _load_example_module()
+
+    summary = module.build_fake_model_call_validation_summary(offline=True)
+
+    assert summary["ok"] is True
+    assert "OPENAI_API_KEY" not in os.environ
+    assert "ANTHROPIC_API_KEY" not in os.environ
+
+
+def test_fake_model_call_validation_rejects_non_offline_mode() -> None:
+    module = _load_example_module()
+
+    try:
+        module.build_fake_model_call_validation_summary(offline=False)
+    except ValueError as exc:
+        assert "--offline only" in str(exc)
+    else:
+        raise AssertionError("expected offline-only guard")
+
+
+def test_fake_model_call_validation_cli_runs() -> None:
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "kora",
+            "run",
+            "real_model_call_validation_fake",
+            "--",
+            "--offline",
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert completed.returncode == 0
+    assert '"mode": "fake_model_call_validation"' in completed.stdout
+    assert '"baseline_model_calls": 10' in completed.stdout
+    assert '"kora_model_calls": 4' in completed.stdout


### PR DESCRIPTION
## Summary
- Add a no-network fake model-call validation example using DeterministicFakeModelCallAdapter.
- Compare direct baseline counters against a KORA-controlled path over a synthetic 10-request workload.
- Register the example in the CLI examples list.
- Add tests for summary counters, avoided call rate, no-secret/no-env behavior, offline-only guard, and CLI execution.
- Update validation docs and README/docs index with the new command and claim boundary.

## Expected example output
- total_requests: 10
- baseline_model_calls: 10
- kora_model_calls: 4
- avoided_model_calls: 6
- avoided_model_call_rate: 0.6
- deterministic_routes: 6
- model_escalations: 4
- provider/model: fake / deterministic-fake

## Validation
- git diff --check
- python3 -m pytest
- python3 -m kora --help
- python3 -m kora examples list
- python3 -m kora run real_model_call_validation_fake -- --offline
- python3 -m kora run direct_vs_kora -- --offline
- python3 -m kora run runtime_integrated_benchmark -- --offline

## Claim and safety notes
- No real provider calls implemented.
- No external provider dependencies added.
- No secrets, API keys, raw provider responses, private user data, or proprietary datasets added.
- This is fake/local/no-network validation only and does not claim real provider validation, real API-cost reduction, production validation, production cost reduction, or energy reduction.