### PR TITLE
Add customer-support triage workload spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ For methodology, counters, artifact policy, and reproduction commands, see:
 ## What We Are Testing Next
 
 1. Runtime-integrated benchmark paths with real model calls
-2. Customer-support triage workloads
+2. [Customer-support triage workloads](docs/workloads/customer-support-triage.md)
 3. RAG answer-routing workloads
 4. Agent budget-guard workloads
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -33,6 +33,7 @@ KORA control layer architecture.
 - [Experiments regeneration guide](../experiments/README.md)
 - [Benchmark real app guide](benchmark-real-app.md)
 - [Benchmark overview](benchmark.md)
+- [Customer-support triage workload spec](workloads/customer-support-triage.md)
 - [Good first issue candidates](good_first_issues.md)
 
 Core local commands:
@@ -61,7 +62,8 @@ Use this path for the current `v0.3.0-alpha` prerelease runtime evidence and reg
 10. Real model-call validation design: [`docs/benchmarks/real-model-call-validation-design.md`](benchmarks/real-model-call-validation-design.md)
 11. Real model-call validation report template: [`docs/benchmarks/real-model-call-validation-report-template.md`](benchmarks/real-model-call-validation-report-template.md)
 12. Fake model-call validation example: [`examples/real_model_call_validation_fake`](../examples/real_model_call_validation_fake)
-13. Claim boundary source: [`docs/claims/kora-claim-registry.md`](claims/kora-claim-registry.md)
+13. Customer-support triage workload spec: [`docs/workloads/customer-support-triage.md`](workloads/customer-support-triage.md)
+14. Claim boundary source: [`docs/claims/kora-claim-registry.md`](claims/kora-claim-registry.md)
 
 Current approved public claim:
 

--- a/docs/benchmarks/validation-roadmap.md
+++ b/docs/benchmarks/validation-roadmap.md
@@ -77,6 +77,10 @@ Example workload:
 
 Support tickets that include password reset requests, order-status questions, refund-policy questions, account-risk cases, and ambiguous cases requiring model escalation.
 
+Workload spec:
+
+- [Customer-support triage workload](../workloads/customer-support-triage.md)
+
 Counters to measure:
 
 - total requests

--- a/docs/community/help-test-kora.md
+++ b/docs/community/help-test-kora.md
@@ -37,6 +37,8 @@ How to help test KORA with a real workload.
 - deterministic-heavy backend workflows
 - LLM apps with high repeated request patterns
 
+See the [customer-support triage workload spec](../workloads/customer-support-triage.md) for a synthetic example of deterministic-first routing and conditional model escalation.
+
 Good candidates usually have at least one of these properties:
 
 - some requests can be classified without a model

--- a/docs/workloads/customer-support-triage.md
+++ b/docs/workloads/customer-support-triage.md
@@ -1,0 +1,272 @@
+# Customer-Support Triage Workload
+
+## Purpose
+
+This is the first application-oriented validation workload spec for KORA. It uses synthetic customer-support requests to test deterministic-first routing and conditional model escalation.
+
+The goal is to define how KORA can route repetitive support requests through structured execution paths before inference.
+
+## Why Customer Support
+
+Customer-support queues often contain repeated requests that follow known policies, structured flows, or lookup patterns.
+
+Many requests can be handled by deterministic routing, policy checks, templates, or validated lookup placeholders. Ambiguous, novel, multi-intent, or policy-sensitive requests should escalate to a model only when needed.
+
+That makes customer-support triage a practical first workload for KORA execution-control validation.
+
+## Workload Status
+
+This document defines a synthetic workload spec.
+
+It is:
+
+- synthetic workload design
+- not production traffic
+- not based on private customer data
+- not a production-cost claim
+- not a real API-cost claim
+- intended for future fake, local, or real model-call validation
+
+## Routing Classes
+
+### 1. `deterministic_faq`
+
+Examples:
+
+- password reset
+- refund policy link
+- shipping status instructions
+- account email change instructions
+
+Expected route: `deterministic`
+
+Model call should be avoided when the request matches a known FAQ intent.
+
+Validation rule concept: confirm the response type and required help-center link or instruction key.
+
+Escalation rule concept: escalate if intent confidence is low, the request includes multiple intents, or the user asks for a policy exception.
+
+### 2. `deterministic_policy`
+
+Examples:
+
+- standard return window
+- warranty eligibility rule
+- cancellation deadline rule
+
+Expected route: `deterministic`
+
+Model call should be avoided when the request maps to an explicit policy table or rule.
+
+Validation rule concept: confirm the returned policy value matches the documented policy key.
+
+Escalation rule concept: escalate if the request asks for an exception, includes missing facts, or conflicts with a policy boundary.
+
+### 3. `structured_lookup`
+
+Examples:
+
+- order status lookup placeholder
+- invoice lookup placeholder
+- subscription plan lookup placeholder
+
+Expected route: `deterministic`
+
+Model call should be avoided when the request can be routed to a structured lookup placeholder or known backend path.
+
+Validation rule concept: confirm the lookup placeholder or route key is present.
+
+Escalation rule concept: escalate if the lookup fails, the account context is missing, or the request contains policy-sensitive follow-up content.
+
+### 4. `model_required`
+
+Examples:
+
+- ambiguous complaint
+- unusual edge case
+- sensitive escalation
+- missing information
+- multi-intent request
+
+Expected route: `model_required`
+
+Model call should not be avoided when deterministic rules cannot safely resolve the request.
+
+Validation rule concept: confirm an escalation reason is present and the response is marked for review or model handling.
+
+Escalation rule concept: escalate when the request is ambiguous, policy-sensitive, missing required information, or asks for a nuanced response.
+
+## Synthetic Request Schema
+
+Each synthetic request should use this conceptual schema:
+
+- `request_id`
+- `input`
+- `route_class`
+- `expected_route`: `deterministic` or `model_required`
+- `deterministic_handler`
+- `validation_rule`
+- `expected_response_type`
+- `privacy_class`: `synthetic`
+- `notes`
+
+Example:
+
+```json
+[
+  {
+    "request_id": "cst-001",
+    "input": "I need help resetting my password.",
+    "route_class": "deterministic_faq",
+    "expected_route": "deterministic",
+    "deterministic_handler": "faq.password_reset",
+    "validation_rule": "required_link_present",
+    "expected_response_type": "faq_instruction",
+    "privacy_class": "synthetic",
+    "notes": "Known FAQ intent."
+  },
+  {
+    "request_id": "cst-002",
+    "input": "Can I return an unopened item after 20 days?",
+    "route_class": "deterministic_policy",
+    "expected_route": "deterministic",
+    "deterministic_handler": "policy.standard_return_window",
+    "validation_rule": "policy_value_matches",
+    "expected_response_type": "policy_answer",
+    "privacy_class": "synthetic",
+    "notes": "Explicit policy table route."
+  },
+  {
+    "request_id": "cst-003",
+    "input": "Please check order ORDER-EXAMPLE-001.",
+    "route_class": "structured_lookup",
+    "expected_route": "deterministic",
+    "deterministic_handler": "lookup.order_status_placeholder",
+    "validation_rule": "lookup_placeholder_present",
+    "expected_response_type": "lookup_placeholder",
+    "privacy_class": "synthetic",
+    "notes": "Synthetic lookup placeholder only."
+  },
+  {
+    "request_id": "cst-004",
+    "input": "I was charged twice and I am upset. I also need to change my plan.",
+    "route_class": "model_required",
+    "expected_route": "model_required",
+    "deterministic_handler": null,
+    "validation_rule": "escalation_reason_present",
+    "expected_response_type": "model_escalation",
+    "privacy_class": "synthetic",
+    "notes": "Multi-intent complaint requiring model escalation."
+  }
+]
+```
+
+## Example Synthetic Workload
+
+| request_id | input summary | route_class | expected_route | deterministic_handler or escalation reason | validation_rule |
+|---|---|---|---|---|---|
+| `cst-001` | Password reset instructions | `deterministic_faq` | `deterministic` | `faq.password_reset` | `required_link_present` |
+| `cst-002` | Refund policy link request | `deterministic_faq` | `deterministic` | `faq.refund_policy_link` | `required_link_present` |
+| `cst-003` | Shipping status instructions | `deterministic_faq` | `deterministic` | `faq.shipping_status_instructions` | `response_type_matches` |
+| `cst-004` | Account email change instructions | `deterministic_faq` | `deterministic` | `faq.account_email_change` | `response_type_matches` |
+| `cst-005` | Standard return window | `deterministic_policy` | `deterministic` | `policy.standard_return_window` | `policy_value_matches` |
+| `cst-006` | Warranty eligibility rule | `deterministic_policy` | `deterministic` | `policy.warranty_eligibility` | `policy_value_matches` |
+| `cst-007` | Order status placeholder | `structured_lookup` | `deterministic` | `lookup.order_status_placeholder` | `lookup_placeholder_present` |
+| `cst-008` | Invoice lookup placeholder | `structured_lookup` | `deterministic` | `lookup.invoice_placeholder` | `lookup_placeholder_present` |
+| `cst-009` | Ambiguous complaint | `model_required` | `model_required` | ambiguous complaint needs nuanced response | `escalation_reason_present` |
+| `cst-010` | Unusual policy edge case | `model_required` | `model_required` | policy exception request | `escalation_reason_present` |
+| `cst-011` | Sensitive escalation | `model_required` | `model_required` | sensitive customer escalation | `escalation_reason_present` |
+| `cst-012` | Missing information and multi-intent request | `model_required` | `model_required` | missing facts and multi-intent routing | `escalation_reason_present` |
+
+## Direct Baseline
+
+A naive direct baseline sends every support request to the model.
+
+For this 12-request synthetic workload, the direct baseline would use 12 model calls.
+
+## KORA-Controlled Path
+
+KORA routes:
+
+```text
+request -> task graph -> deterministic handler or model escalation -> validation -> telemetry
+```
+
+For this workload design, deterministic FAQ, policy, and structured lookup requests should use deterministic handlers. Ambiguous, unusual, sensitive, or incomplete requests should use model escalation.
+
+## Expected Counters
+
+For the 12-request synthetic workload, expected ideal routing is:
+
+- `total_requests`: 12
+- `baseline_model_calls`: 12
+- `kora_model_calls`: 4
+- `avoided_model_calls`: 8
+- `avoided_model_call_rate`: 0.6667
+- `deterministic_routes`: 8
+- `model_escalations`: 4
+- `validation_pass_count`: TBD until implemented
+- `validation_fail_count`: TBD until implemented
+- `error_count`: TBD until implemented
+
+These are workload-design expectations, not measured production results.
+
+## Validation Rules
+
+Example validation rules:
+
+- `response_type_matches`
+- `required_link_present`
+- `policy_value_matches`
+- `lookup_placeholder_present`
+- `escalation_reason_present`
+- `no_private_data_emitted`
+
+## Telemetry Fields
+
+Expected telemetry fields:
+
+- `route_class`
+- `selected_route`
+- `model_call_used`
+- `validation_result`
+- `escalation_reason`
+- `deterministic_handler`
+- `latency_ms`
+- `error`
+- `fallback_used`
+
+## Privacy and Safety
+
+This workload must use:
+
+- no private customer data
+- no real tickets
+- no credentials
+- no raw production logs
+- no proprietary datasets
+- sanitized or synthetic data only
+
+## Claim Boundaries
+
+This workload can support future measured model-invocation reduction claims only after implementation and validation.
+
+Allowed future language after validation:
+
+> KORA reduced measured model invocations by X% in a synthetic customer-support triage validation workload.
+
+Not allowed:
+
+- KORA reduces customer-support costs by X%.
+- KORA reduces production support API costs by X%.
+- KORA is production-proven for customer support.
+- KORA replaces human support agents.
+
+## Next Implementation Step
+
+Next implementation work should:
+
+1. Implement the synthetic workload file as a runnable validation path.
+2. Wire the workload into `DeterministicFakeModelCallAdapter`.
+3. Compare direct baseline and KORA-controlled routing.
+4. Emit a JSON summary and Markdown report.

--- a/experiments/workloads/customer_support_triage_synthetic_v1.json
+++ b/experiments/workloads/customer_support_triage_synthetic_v1.json
@@ -1,0 +1,128 @@
+{
+  "workload_id": "customer_support_triage_synthetic_v1",
+  "description": "Synthetic customer-support triage workload draft for deterministic-first routing and conditional model escalation validation.",
+  "version": 1,
+  "privacy_class": "synthetic",
+  "requests": [
+    {
+      "request_id": "cst-001",
+      "input": "I need help resetting my password.",
+      "route_class": "deterministic_faq",
+      "expected_route": "deterministic",
+      "deterministic_handler": "faq.password_reset",
+      "validation_rule": "required_link_present",
+      "expected_response_type": "faq_instruction",
+      "notes": "Known FAQ intent."
+    },
+    {
+      "request_id": "cst-002",
+      "input": "Where can I read the refund policy?",
+      "route_class": "deterministic_faq",
+      "expected_route": "deterministic",
+      "deterministic_handler": "faq.refund_policy_link",
+      "validation_rule": "required_link_present",
+      "expected_response_type": "faq_link",
+      "notes": "Known policy-link request."
+    },
+    {
+      "request_id": "cst-003",
+      "input": "How do I check shipping status for ORDER-EXAMPLE-001?",
+      "route_class": "deterministic_faq",
+      "expected_route": "deterministic",
+      "deterministic_handler": "faq.shipping_status_instructions",
+      "validation_rule": "response_type_matches",
+      "expected_response_type": "faq_instruction",
+      "notes": "Synthetic order placeholder only."
+    },
+    {
+      "request_id": "cst-004",
+      "input": "How do I update the email address on my account?",
+      "route_class": "deterministic_faq",
+      "expected_route": "deterministic",
+      "deterministic_handler": "faq.account_email_change",
+      "validation_rule": "response_type_matches",
+      "expected_response_type": "faq_instruction",
+      "notes": "Known account settings flow."
+    },
+    {
+      "request_id": "cst-005",
+      "input": "Can I return an unopened item after 20 days?",
+      "route_class": "deterministic_policy",
+      "expected_route": "deterministic",
+      "deterministic_handler": "policy.standard_return_window",
+      "validation_rule": "policy_value_matches",
+      "expected_response_type": "policy_answer",
+      "notes": "Explicit policy table route."
+    },
+    {
+      "request_id": "cst-006",
+      "input": "Is a device covered by the standard warranty after 8 months?",
+      "route_class": "deterministic_policy",
+      "expected_route": "deterministic",
+      "deterministic_handler": "policy.warranty_eligibility",
+      "validation_rule": "policy_value_matches",
+      "expected_response_type": "policy_answer",
+      "notes": "Synthetic warranty rule example."
+    },
+    {
+      "request_id": "cst-007",
+      "input": "Please check order ORDER-EXAMPLE-002.",
+      "route_class": "structured_lookup",
+      "expected_route": "deterministic",
+      "deterministic_handler": "lookup.order_status_placeholder",
+      "validation_rule": "lookup_placeholder_present",
+      "expected_response_type": "lookup_placeholder",
+      "notes": "Lookup placeholder, not a real order."
+    },
+    {
+      "request_id": "cst-008",
+      "input": "Please find invoice INVOICE-EXAMPLE-003.",
+      "route_class": "structured_lookup",
+      "expected_route": "deterministic",
+      "deterministic_handler": "lookup.invoice_placeholder",
+      "validation_rule": "lookup_placeholder_present",
+      "expected_response_type": "lookup_placeholder",
+      "notes": "Lookup placeholder, not a real invoice."
+    },
+    {
+      "request_id": "cst-009",
+      "input": "I am upset about a delayed shipment and need a thoughtful response.",
+      "route_class": "model_required",
+      "expected_route": "model_required",
+      "deterministic_handler": null,
+      "validation_rule": "escalation_reason_present",
+      "expected_response_type": "model_escalation",
+      "notes": "Ambiguous complaint requiring nuanced response."
+    },
+    {
+      "request_id": "cst-010",
+      "input": "Can you make an exception to the return policy for a special situation?",
+      "route_class": "model_required",
+      "expected_route": "model_required",
+      "deterministic_handler": null,
+      "validation_rule": "escalation_reason_present",
+      "expected_response_type": "model_escalation",
+      "notes": "Policy exception request."
+    },
+    {
+      "request_id": "cst-011",
+      "input": "A customer is angry and asks to escalate a sensitive billing dispute.",
+      "route_class": "model_required",
+      "expected_route": "model_required",
+      "deterministic_handler": null,
+      "validation_rule": "escalation_reason_present",
+      "expected_response_type": "model_escalation",
+      "notes": "Sensitive escalation."
+    },
+    {
+      "request_id": "cst-012",
+      "input": "I need to cancel, change my plan, and ask about a missing package.",
+      "route_class": "model_required",
+      "expected_route": "model_required",
+      "deterministic_handler": null,
+      "validation_rule": "escalation_reason_present",
+      "expected_response_type": "model_escalation",
+      "notes": "Missing information and multi-intent request."
+    }
+  ]
+}

--- a/tests/test_customer_support_triage_workload.py
+++ b/tests/test_customer_support_triage_workload.py
@@ -1,0 +1,69 @@
+import json
+import re
+from pathlib import Path
+
+
+WORKLOAD_PATH = Path("experiments/workloads/customer_support_triage_synthetic_v1.json")
+
+
+def _load_workload() -> dict:
+    return json.loads(WORKLOAD_PATH.read_text(encoding="utf-8"))
+
+
+def test_customer_support_triage_workload_is_valid_json() -> None:
+    workload = _load_workload()
+
+    assert workload["workload_id"] == "customer_support_triage_synthetic_v1"
+    assert workload["version"] == 1
+    assert workload["privacy_class"] == "synthetic"
+    assert isinstance(workload["requests"], list)
+
+
+def test_customer_support_triage_workload_route_counts() -> None:
+    requests = _load_workload()["requests"]
+
+    deterministic_count = sum(
+        request["expected_route"] == "deterministic" for request in requests
+    )
+    model_required_count = sum(
+        request["expected_route"] == "model_required" for request in requests
+    )
+
+    assert len(requests) == 12
+    assert deterministic_count == 8
+    assert model_required_count == 4
+
+
+def test_customer_support_triage_workload_required_fields() -> None:
+    required_fields = {
+        "request_id",
+        "input",
+        "route_class",
+        "expected_route",
+        "deterministic_handler",
+        "validation_rule",
+        "expected_response_type",
+        "notes",
+    }
+
+    for request in _load_workload()["requests"]:
+        assert set(request) == required_fields
+        assert request["request_id"].startswith("cst-")
+        assert request["route_class"] in {
+            "deterministic_faq",
+            "deterministic_policy",
+            "structured_lookup",
+            "model_required",
+        }
+        assert request["expected_route"] in {"deterministic", "model_required"}
+
+
+def test_customer_support_triage_workload_has_no_obvious_private_data() -> None:
+    text = WORKLOAD_PATH.read_text(encoding="utf-8")
+    email_pattern = re.compile(r"[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}")
+    phone_pattern = re.compile(r"(?:\+?\d[\d .-]{8,}\d)")
+
+    assert not email_pattern.search(text)
+    assert not phone_pattern.search(text)
+    assert "ORDER-EXAMPLE-" in text
+    assert "INVOICE-EXAMPLE-" in text


### PR DESCRIPTION
## Summary
- Add a public synthetic customer-support triage workload spec.
- Add a machine-readable synthetic workload draft with 12 requests: 8 deterministic and 4 model-required.
- Define route classes, expected counters, validation rules, telemetry fields, privacy rules, and claim boundaries.
- Link the workload from README, docs index, validation roadmap, and help-test guidance.
- Add a focused JSON sanity test for route counts, required fields, synthetic privacy class, and obvious private-data patterns.

## Expected routing counters
- total_requests: 12
- baseline_model_calls: 12
- kora_model_calls: 4
- avoided_model_calls: 8
- avoided_model_call_rate: 0.6667
- deterministic_routes: 8
- model_escalations: 4

## Validation
- git diff --check
- python3 -m pytest
- python3 -m kora --help
- python3 -m kora examples list
- python3 -m kora run real_model_call_validation_fake -- --offline
- python3 -m kora run direct_vs_kora -- --offline
- python3 -m kora run runtime_integrated_benchmark -- --offline

## Safety and claim notes
- Synthetic workload only; no real customer data, tickets, emails, phone numbers, credentials, or proprietary datasets.
- No runtime provider calls implemented.
- No production validation, production cost-reduction, real API-cost reduction, or energy-reduction claims added.