### PR TITLE
Wire customer-support triage into fake validation example

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,8 @@ See the [real model-call validation design](docs/benchmarks/real-model-call-vali
 
 A no-network fake model-call validation example is available for testing the measured invocation counter path.
 
+Customer-support triage fake validation is available as a no-network example.
+
 ## Help Test KORA
 
 Good candidate workloads:

--- a/docs/README.md
+++ b/docs/README.md
@@ -41,6 +41,7 @@ Core local commands:
 ```bash
 python3 -m kora --help
 python3 -m kora examples list
+python3 -m kora run customer_support_triage_fake_validation -- --offline
 python3 -m kora run real_model_call_validation_fake -- --offline
 python3 -m kora run direct_vs_kora -- --offline
 python3 -m kora run runtime_integrated_benchmark -- --offline
@@ -62,8 +63,9 @@ Use this path for the current `v0.3.0-alpha` prerelease runtime evidence and reg
 10. Real model-call validation design: [`docs/benchmarks/real-model-call-validation-design.md`](benchmarks/real-model-call-validation-design.md)
 11. Real model-call validation report template: [`docs/benchmarks/real-model-call-validation-report-template.md`](benchmarks/real-model-call-validation-report-template.md)
 12. Fake model-call validation example: [`examples/real_model_call_validation_fake`](../examples/real_model_call_validation_fake)
-13. Customer-support triage workload spec: [`docs/workloads/customer-support-triage.md`](workloads/customer-support-triage.md)
-14. Claim boundary source: [`docs/claims/kora-claim-registry.md`](claims/kora-claim-registry.md)
+13. Customer-support triage fake validation example: [`examples/customer_support_triage_fake_validation`](../examples/customer_support_triage_fake_validation)
+14. Customer-support triage workload spec: [`docs/workloads/customer-support-triage.md`](workloads/customer-support-triage.md)
+15. Claim boundary source: [`docs/claims/kora-claim-registry.md`](claims/kora-claim-registry.md)
 
 Current approved public claim:
 

--- a/docs/benchmarks/real-model-call-validation-design.md
+++ b/docs/benchmarks/real-model-call-validation-design.md
@@ -272,6 +272,18 @@ The example validates model-call counter plumbing before real local or remote pr
 
 Claim boundary: this is not real provider validation, real API-cost validation, production validation, production cost reduction proof, broad workload superiority proof, or energy reduction evidence.
 
+## Customer-Support Triage Fake Validation Example
+
+The first application-oriented fake validation example uses the synthetic customer-support triage workload:
+
+```bash
+python3 -m kora run customer_support_triage_fake_validation -- --offline
+```
+
+This extends fake/local validation from generic counter plumbing to a realistic support triage workload shape. It still uses `DeterministicFakeModelCallAdapter`, requires no secrets, makes no network calls, and emits aggregate counters only.
+
+This is a step before local model or remote provider validation. It is not real provider validation, real API-cost validation, or production validation.
+
 ## Telemetry Output
 
 Real model-call validation should emit sanitized artifacts only.

--- a/docs/benchmarks/real-model-call-validation-report-template.md
+++ b/docs/benchmarks/real-model-call-validation-report-template.md
@@ -53,6 +53,14 @@ For the no-network fake validation example, use:
 - Model: `deterministic-fake`
 - Cost summary: `N/A` unless a real provider with explicit pricing is configured later
 
+For the customer-support triage fake validation example, use:
+
+- Mode: `customer_support_triage_fake_validation`
+- Workload: `customer_support_triage_synthetic_v1`
+- Provider/runtime: `fake`
+- Model: `deterministic-fake`
+- Cost summary: `N/A` unless a real provider with explicit pricing is configured later
+
 Do not include API keys, tokens, credentials, private hostnames, private dataset names, or raw provider response IDs unless explicitly approved.
 
 ## Commands

--- a/docs/workloads/customer-support-triage.md
+++ b/docs/workloads/customer-support-triage.md
@@ -211,6 +211,26 @@ For the 12-request synthetic workload, expected ideal routing is:
 
 These are workload-design expectations, not measured production results.
 
+## Fake Runtime Validation Example
+
+Run the no-network customer-support triage fake validation example:
+
+```bash
+python3 -m kora run customer_support_triage_fake_validation -- --offline
+```
+
+Expected counters for the current synthetic workload:
+
+- `total_requests`: 12
+- `baseline_model_calls`: 12
+- `kora_model_calls`: 4
+- `avoided_model_calls`: 8
+- `avoided_model_call_rate`: 0.6667
+
+This example uses `DeterministicFakeModelCallAdapter` with synthetic data only. It is fake, local, and no-network validation for the routing and model-call counter path.
+
+It does not prove real provider validation, real API-cost reduction, production validation, production cost reduction, broad workload superiority, or energy reduction.
+
 ## Validation Rules
 
 Example validation rules:

--- a/examples/customer_support_triage_fake_validation/run.py
+++ b/examples/customer_support_triage_fake_validation/run.py
@@ -1,0 +1,235 @@
+"""No-network customer-support triage fake validation example."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+from kora.model_call import (
+    DeterministicFakeModelCallAdapter,
+    ModelCallRequest,
+    ModelCallResponse,
+    ModelCallSummary,
+)
+
+DEFAULT_WORKLOAD = Path("experiments/workloads/customer_support_triage_synthetic_v1.json")
+CLAIM_BOUNDARY = (
+    "This customer-support triage validation example uses synthetic data and fake/local "
+    "no-network model calls. It is not real provider validation, real API-cost "
+    "validation, production validation, production cost reduction proof, broad "
+    "workload superiority proof, or energy reduction evidence."
+)
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[2]
+
+
+def _resolve_workload_path(path: Path) -> Path:
+    if path.is_absolute():
+        return path
+    return _repo_root() / path
+
+
+def load_workload(path: Path = DEFAULT_WORKLOAD) -> dict[str, Any]:
+    workload_path = _resolve_workload_path(path)
+    return json.loads(workload_path.read_text(encoding="utf-8"))
+
+
+def _requests(workload: dict[str, Any]) -> list[dict[str, Any]]:
+    requests = workload.get("requests")
+    if not isinstance(requests, list):
+        raise ValueError("customer-support triage workload must contain a requests list")
+    return requests
+
+
+def _model_request(item: dict[str, Any]) -> ModelCallRequest:
+    return ModelCallRequest(
+        request_id=str(item["request_id"]),
+        prompt=str(item["input"]),
+        privacy_class="synthetic",
+        metadata={
+            "route_class": item.get("route_class"),
+            "expected_route": item.get("expected_route"),
+            "validation_rule": item.get("validation_rule"),
+        },
+    )
+
+
+def _run_direct_baseline(
+    requests: list[dict[str, Any]],
+    adapter: DeterministicFakeModelCallAdapter,
+) -> list[ModelCallResponse]:
+    return [adapter.call(_model_request(item)) for item in requests]
+
+
+def _validate_deterministic_route(item: dict[str, Any]) -> bool:
+    return (
+        item.get("expected_route") == "deterministic"
+        and isinstance(item.get("deterministic_handler"), str)
+        and bool(str(item.get("deterministic_handler")).strip())
+        and isinstance(item.get("validation_rule"), str)
+        and isinstance(item.get("expected_response_type"), str)
+    )
+
+
+def _validate_model_required_route(item: dict[str, Any], response: ModelCallResponse) -> bool:
+    return (
+        item.get("expected_route") == "model_required"
+        and item.get("deterministic_handler") is None
+        and response.model_calls == 1
+        and bool(response.output)
+    )
+
+
+def _run_kora_controlled_path(
+    requests: list[dict[str, Any]],
+    adapter: DeterministicFakeModelCallAdapter,
+) -> tuple[list[ModelCallResponse], int, int, int, int, int, int]:
+    model_responses: list[ModelCallResponse] = []
+    deterministic_routes = 0
+    model_escalations = 0
+    validation_pass_count = 0
+    validation_fail_count = 0
+    error_count = 0
+    fallback_count = 0
+
+    for item in requests:
+        try:
+            expected_route = item.get("expected_route")
+            if expected_route == "deterministic":
+                deterministic_routes += 1
+                if _validate_deterministic_route(item):
+                    validation_pass_count += 1
+                else:
+                    validation_fail_count += 1
+                continue
+
+            if expected_route == "model_required":
+                model_escalations += 1
+                response = adapter.call(_model_request(item))
+                model_responses.append(response)
+                if _validate_model_required_route(item, response):
+                    validation_pass_count += 1
+                else:
+                    validation_fail_count += 1
+                continue
+
+            fallback_count += 1
+            validation_fail_count += 1
+        except Exception:
+            error_count += 1
+
+    return (
+        model_responses,
+        deterministic_routes,
+        model_escalations,
+        validation_pass_count,
+        validation_fail_count,
+        error_count,
+        fallback_count,
+    )
+
+
+def build_customer_support_triage_fake_validation_summary(
+    *,
+    offline: bool = True,
+    workload_path: Path = DEFAULT_WORKLOAD,
+) -> dict[str, Any]:
+    if not offline:
+        raise ValueError("customer_support_triage_fake_validation supports --offline only")
+
+    workload = load_workload(workload_path)
+    requests = _requests(workload)
+    baseline_adapter = DeterministicFakeModelCallAdapter()
+    kora_adapter = DeterministicFakeModelCallAdapter()
+
+    baseline_responses = _run_direct_baseline(requests, baseline_adapter)
+    (
+        kora_responses,
+        deterministic_routes,
+        model_escalations,
+        validation_pass_count,
+        validation_fail_count,
+        error_count,
+        fallback_count,
+    ) = _run_kora_controlled_path(requests, kora_adapter)
+
+    baseline_summary = ModelCallSummary.from_responses(baseline_responses)
+    kora_summary = ModelCallSummary.from_responses(kora_responses, error_count=error_count)
+    avoided_model_calls = baseline_summary.model_calls - kora_summary.model_calls
+    avoided_model_call_rate = (
+        avoided_model_calls / baseline_summary.model_calls
+        if baseline_summary.model_calls
+        else 0.0
+    )
+
+    return {
+        "ok": error_count == 0 and validation_fail_count == 0,
+        "mode": "customer_support_triage_fake_validation",
+        "offline": True,
+        "workload_id": workload.get("workload_id"),
+        "workload_path": str(workload_path),
+        "privacy_class": workload.get("privacy_class"),
+        "adapter": "DeterministicFakeModelCallAdapter",
+        "provider": "fake",
+        "model": "deterministic-fake",
+        "total_requests": len(requests),
+        "baseline_model_calls": baseline_summary.model_calls,
+        "kora_model_calls": kora_summary.model_calls,
+        "avoided_model_calls": avoided_model_calls,
+        "avoided_model_call_rate": avoided_model_call_rate,
+        "deterministic_routes": deterministic_routes,
+        "model_escalations": model_escalations,
+        "validation_pass_count": validation_pass_count,
+        "validation_fail_count": validation_fail_count,
+        "error_count": error_count,
+        "fallback_count": fallback_count,
+        "input_tokens_total": kora_summary.input_tokens_total,
+        "output_tokens_total": kora_summary.output_tokens_total,
+        "baseline_input_tokens_total": baseline_summary.input_tokens_total,
+        "baseline_output_tokens_total": baseline_summary.output_tokens_total,
+        "latency_total_ms": kora_summary.latency_total_ms,
+        "raw_prompts_emitted": False,
+        "raw_responses_emitted": False,
+        "claim_boundary": CLAIM_BOUNDARY,
+        "notes": [
+            "Synthetic customer-support triage workload only.",
+            "Direct baseline calls the fake adapter for every request.",
+            "KORA-controlled path validates deterministic routes without fake model calls.",
+            "Model-required routes call the fake adapter through the provider-neutral boundary.",
+            "No external APIs, network access, provider credentials, raw prompts, or raw provider responses are used.",
+        ],
+    }
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Run the no-network customer-support triage fake validation example."
+    )
+    parser.add_argument("--offline", action="store_true", help="required; run without network calls")
+    parser.add_argument(
+        "--workload",
+        default=str(DEFAULT_WORKLOAD),
+        help="Path to customer-support triage workload JSON.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    if not args.offline:
+        raise SystemExit("customer_support_triage_fake_validation requires --offline.")
+
+    summary = build_customer_support_triage_fake_validation_summary(
+        offline=True,
+        workload_path=Path(args.workload),
+    )
+    print(json.dumps(summary, indent=2, sort_keys=True))
+    return 0 if summary["ok"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/kora/cli.py
+++ b/kora/cli.py
@@ -29,6 +29,7 @@ def _example_descriptions() -> dict[str, str]:
     return {
         "hello_kora": "basic deterministic hello-world graph",
         "retry_demo": "retry/recovery flow example",
+        "customer_support_triage_fake_validation": "customer-support triage fake validation example",
         "direct_vs_kora": "direct call vs KORA-controlled path",
         "real_workload_harness": "benchmark/report flow example",
         "real_model_call_validation_fake": "no-network fake model-call validation example",

--- a/tests/test_customer_support_triage_fake_validation.py
+++ b/tests/test_customer_support_triage_fake_validation.py
@@ -1,0 +1,109 @@
+import importlib.util
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+def _load_example_module():
+    script_path = Path("examples/customer_support_triage_fake_validation/run.py")
+    spec = importlib.util.spec_from_file_location(
+        "customer_support_triage_fake_validation_run", script_path
+    )
+    if spec is None or spec.loader is None:
+        raise RuntimeError("failed to load customer_support_triage_fake_validation module")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[str(spec.name)] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_customer_support_triage_fake_validation_loads_workload() -> None:
+    module = _load_example_module()
+
+    workload = module.load_workload()
+
+    assert workload["workload_id"] == "customer_support_triage_synthetic_v1"
+    assert workload["privacy_class"] == "synthetic"
+    assert len(workload["requests"]) == 12
+
+
+def test_customer_support_triage_fake_validation_summary_counts() -> None:
+    module = _load_example_module()
+
+    summary = module.build_customer_support_triage_fake_validation_summary(offline=True)
+
+    assert summary["ok"] is True
+    assert summary["mode"] == "customer_support_triage_fake_validation"
+    assert summary["workload_id"] == "customer_support_triage_synthetic_v1"
+    assert summary["privacy_class"] == "synthetic"
+    assert summary["provider"] == "fake"
+    assert summary["model"] == "deterministic-fake"
+    assert summary["total_requests"] == 12
+    assert summary["baseline_model_calls"] == 12
+    assert summary["kora_model_calls"] == 4
+    assert summary["avoided_model_calls"] == 8
+    assert round(summary["avoided_model_call_rate"], 4) == 0.6667
+    assert summary["deterministic_routes"] == 8
+    assert summary["model_escalations"] == 4
+    assert summary["validation_pass_count"] == 12
+    assert summary["validation_fail_count"] == 0
+    assert summary["error_count"] == 0
+    assert summary["fallback_count"] == 0
+
+
+def test_customer_support_triage_fake_validation_requires_no_provider_environment(
+    monkeypatch,
+) -> None:
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    module = _load_example_module()
+
+    summary = module.build_customer_support_triage_fake_validation_summary(offline=True)
+
+    assert summary["ok"] is True
+    assert "OPENAI_API_KEY" not in os.environ
+    assert "ANTHROPIC_API_KEY" not in os.environ
+
+
+def test_customer_support_triage_fake_validation_does_not_emit_raw_inputs_or_outputs() -> None:
+    module = _load_example_module()
+
+    summary = module.build_customer_support_triage_fake_validation_summary(offline=True)
+
+    assert summary["raw_prompts_emitted"] is False
+    assert summary["raw_responses_emitted"] is False
+    assert "raw provider responses" in summary["notes"][-1]
+
+
+def test_customer_support_triage_fake_validation_rejects_non_offline_mode() -> None:
+    module = _load_example_module()
+
+    try:
+        module.build_customer_support_triage_fake_validation_summary(offline=False)
+    except ValueError as exc:
+        assert "--offline only" in str(exc)
+    else:
+        raise AssertionError("expected offline-only guard")
+
+
+def test_customer_support_triage_fake_validation_cli_runs() -> None:
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "kora",
+            "run",
+            "customer_support_triage_fake_validation",
+            "--",
+            "--offline",
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert completed.returncode == 0
+    assert '"mode": "customer_support_triage_fake_validation"' in completed.stdout
+    assert '"baseline_model_calls": 12' in completed.stdout
+    assert '"kora_model_calls": 4' in completed.stdout


### PR DESCRIPTION
## Summary
- Add a no-network customer-support triage fake validation example.
- Load `experiments/workloads/customer_support_triage_synthetic_v1.json` and compare direct baseline model calls against KORA-controlled routing.
- Use `DeterministicFakeModelCallAdapter` only; no real provider calls, network calls, secrets, or raw benchmark artifacts.
- Add focused tests and docs for expected counters and claim boundaries.

## Expected counters
- total_requests: 12
- baseline_model_calls: 12
- kora_model_calls: 4
- avoided_model_calls: 8
- avoided_model_call_rate: 0.6667
- deterministic_routes: 8
- model_escalations: 4

## Validation
- `git diff --check`
- `python3 -m pytest`
- `python3 -m kora --help`
- `python3 -m kora examples list`
- `python3 -m kora run customer_support_triage_fake_validation -- --offline`
- `python3 -m kora run real_model_call_validation_fake -- --offline`
- `python3 -m kora run direct_vs_kora -- --offline`
- `python3 -m kora run runtime_integrated_benchmark -- --offline`

## Claim safety
This is fake/local/no-network validation only. It does not claim real provider validation, real API-cost reduction, production validation, production cost reduction, or energy reduction.