### PR TITLE
Clarify local no-network validation terminology

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,9 +94,9 @@ See the [KORA validation roadmap](docs/benchmarks/validation-roadmap.md) for the
 
 See the [real model-call validation design](docs/benchmarks/real-model-call-validation-design.md) for the next measurement path.
 
-A no-network fake model-call validation example is available for testing the measured invocation counter path.
+KORA includes a local no-network validation path that measures model-call routing without requiring API keys or external providers.
 
-Customer-support triage fake validation is available as a no-network example.
+Customer-support triage local validation is available as a no-network example.
 
 ## Help Test KORA
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -47,6 +47,8 @@ python3 -m kora run direct_vs_kora -- --offline
 python3 -m kora run runtime_integrated_benchmark -- --offline
 ```
 
+Some example command names are compatibility-preserving. The local validation examples emit public-facing `local_validation` provider labels.
+
 ## Inspect Evidence
 
 Use this path for the current `v0.3.0-alpha` prerelease runtime evidence and regeneration flow:
@@ -62,8 +64,8 @@ Use this path for the current `v0.3.0-alpha` prerelease runtime evidence and reg
 9. Validation roadmap: [`docs/benchmarks/validation-roadmap.md`](benchmarks/validation-roadmap.md)
 10. Real model-call validation design: [`docs/benchmarks/real-model-call-validation-design.md`](benchmarks/real-model-call-validation-design.md)
 11. Real model-call validation report template: [`docs/benchmarks/real-model-call-validation-report-template.md`](benchmarks/real-model-call-validation-report-template.md)
-12. Fake model-call validation example: [`examples/real_model_call_validation_fake`](../examples/real_model_call_validation_fake)
-13. Customer-support triage fake validation example: [`examples/customer_support_triage_fake_validation`](../examples/customer_support_triage_fake_validation)
+12. Local no-network model-call validation example: [`examples/real_model_call_validation_fake`](../examples/real_model_call_validation_fake)
+13. Customer-support triage local validation example: [`examples/customer_support_triage_fake_validation`](../examples/customer_support_triage_fake_validation)
 14. Customer-support triage workload spec: [`docs/workloads/customer-support-triage.md`](workloads/customer-support-triage.md)
 15. Claim boundary source: [`docs/claims/kora-claim-registry.md`](claims/kora-claim-registry.md)
 

--- a/docs/benchmarks/real-model-call-validation-design.md
+++ b/docs/benchmarks/real-model-call-validation-design.md
@@ -250,37 +250,41 @@ Current implementation:
 - `ModelCallRequest`: normalized request with `request_id`, `prompt`, metadata, and privacy class.
 - `ModelCallResponse`: normalized response with measured model-call count, latency, token counters where available, provider/model labels, and metadata.
 - `ModelCallAdapter`: protocol for adapters that return measured model-call counters.
-- `DeterministicFakeModelCallAdapter`: local, deterministic, no-network adapter for tests and harness development.
+- `DeterministicFakeModelCallAdapter`: deterministic local validation adapter for tests and harness development.
 - `BlockedModelCallAdapter`: fail-closed adapter for cases where real provider use has not been explicitly configured.
 - `ModelCallSummary`: aggregate counter helper for validation reports.
 
-The fake deterministic adapter is the only local implementation added at this stage. It requires no credentials, performs no external calls, and records provider/model as `fake` / `deterministic-fake`.
+The deterministic local validation adapter is the only local implementation added at this stage. It requires no credentials, performs no external calls, and records provider/model as `local_validation` / `deterministic-local`.
 
 Future local or remote provider adapters can plug into the same interface. Remote provider calls must use environment variables for configuration and must not commit secrets, raw prompts, raw responses, private user data, or proprietary datasets.
 
-## Fake Model-Call Runtime Example
+## Local No-Network Model-Call Runtime Example
 
-The first runtime validation example is a no-network fake model-call path:
+The first runtime validation example is a local no-network model-call path:
 
 ```bash
 python3 -m kora run real_model_call_validation_fake -- --offline
 ```
 
-This example uses `DeterministicFakeModelCallAdapter` with a synthetic 10-request workload. The direct baseline calls the fake adapter for every request. The KORA-controlled path handles deterministic routes without fake model calls and escalates only model-required routes through the provider-neutral adapter boundary.
+The command name is preserved for compatibility. The emitted mode/provider/model labels use local no-network validation terminology.
+
+This example uses the deterministic local validation adapter with a synthetic 10-request workload. The direct baseline records local validation model-call events for every request. The KORA-controlled path handles deterministic routes without local validation model-call events and escalates only model-required routes through the provider-neutral adapter boundary.
 
 The example validates model-call counter plumbing before real local or remote provider adapters are added. It requires no secrets, uses no network, emits aggregate counters only, and does not commit raw prompts or raw provider responses.
 
 Claim boundary: this is not real provider validation, real API-cost validation, production validation, production cost reduction proof, broad workload superiority proof, or energy reduction evidence.
 
-## Customer-Support Triage Fake Validation Example
+## Customer-Support Triage Local Validation Example
 
-The first application-oriented fake validation example uses the synthetic customer-support triage workload:
+The first application-oriented local validation example uses the synthetic customer-support triage workload:
 
 ```bash
 python3 -m kora run customer_support_triage_fake_validation -- --offline
 ```
 
-This extends fake/local validation from generic counter plumbing to a realistic support triage workload shape. It still uses `DeterministicFakeModelCallAdapter`, requires no secrets, makes no network calls, and emits aggregate counters only.
+The command name is preserved for compatibility. The emitted mode/provider/model labels use customer-support local validation terminology.
+
+This extends local/no-network validation from generic counter plumbing to a realistic support triage workload shape. It still uses the deterministic local validation adapter, requires no secrets, makes no network calls, and emits aggregate counters only.
 
 This is a step before local model or remote provider validation. It is not real provider validation, real API-cost validation, or production validation.
 

--- a/docs/benchmarks/real-model-call-validation-report-template.md
+++ b/docs/benchmarks/real-model-call-validation-report-template.md
@@ -46,19 +46,19 @@ Sanitized environment details:
 - Token counter source:
 - Provider configuration source: environment variables only, if remote provider mode is used
 
-For the no-network fake validation example, use:
+For the local no-network validation example, use:
 
-- Mode: `fake_model_call_validation`
-- Provider/runtime: `fake`
-- Model: `deterministic-fake`
+- Mode: `local_no_network_model_call_validation`
+- Provider/runtime: `local_validation`
+- Model: `deterministic-local`
 - Cost summary: `N/A` unless a real provider with explicit pricing is configured later
 
-For the customer-support triage fake validation example, use:
+For the customer-support triage local validation example, use:
 
-- Mode: `customer_support_triage_fake_validation`
+- Mode: `customer_support_triage_local_validation`
 - Workload: `customer_support_triage_synthetic_v1`
-- Provider/runtime: `fake`
-- Model: `deterministic-fake`
+- Provider/runtime: `local_validation`
+- Model: `deterministic-local`
 - Cost summary: `N/A` unless a real provider with explicit pricing is configured later
 
 Do not include API keys, tokens, credentials, private hostnames, private dataset names, or raw provider response IDs unless explicitly approved.

--- a/docs/workloads/customer-support-triage.md
+++ b/docs/workloads/customer-support-triage.md
@@ -25,7 +25,7 @@ It is:
 - not based on private customer data
 - not a production-cost claim
 - not a real API-cost claim
-- intended for future fake, local, or real model-call validation
+- intended for future local no-network, local model, or real model-call validation
 
 ## Routing Classes
 
@@ -211,9 +211,9 @@ For the 12-request synthetic workload, expected ideal routing is:
 
 These are workload-design expectations, not measured production results.
 
-## Fake Runtime Validation Example
+## Local Runtime Validation Example
 
-Run the no-network customer-support triage fake validation example:
+Run the local no-network customer-support triage validation example:
 
 ```bash
 python3 -m kora run customer_support_triage_fake_validation -- --offline
@@ -227,7 +227,7 @@ Expected counters for the current synthetic workload:
 - `avoided_model_calls`: 8
 - `avoided_model_call_rate`: 0.6667
 
-This example uses `DeterministicFakeModelCallAdapter` with synthetic data only. It is fake, local, and no-network validation for the routing and model-call counter path.
+This example uses a deterministic local validation adapter with synthetic data only. It is local/no-network validation for the routing and model-call counter path.
 
 It does not prove real provider validation, real API-cost reduction, production validation, production cost reduction, broad workload superiority, or energy reduction.
 
@@ -287,6 +287,6 @@ Not allowed:
 Next implementation work should:
 
 1. Implement the synthetic workload file as a runnable validation path.
-2. Wire the workload into `DeterministicFakeModelCallAdapter`.
+2. Wire the workload into the deterministic local validation adapter.
 3. Compare direct baseline and KORA-controlled routing.
 4. Emit a JSON summary and Markdown report.

--- a/examples/customer_support_triage_fake_validation/run.py
+++ b/examples/customer_support_triage_fake_validation/run.py
@@ -1,4 +1,4 @@
-"""No-network customer-support triage fake validation example."""
+"""Local no-network customer-support triage validation example."""
 
 from __future__ import annotations
 
@@ -16,8 +16,8 @@ from kora.model_call import (
 
 DEFAULT_WORKLOAD = Path("experiments/workloads/customer_support_triage_synthetic_v1.json")
 CLAIM_BOUNDARY = (
-    "This customer-support triage validation example uses synthetic data and fake/local "
-    "no-network model calls. It is not real provider validation, real API-cost "
+    "This customer-support triage validation example uses synthetic data and local/"
+    "no-network model-call events. It is not real provider validation, real API-cost "
     "validation, production validation, production cost reduction proof, broad "
     "workload superiority proof, or energy reduction evidence."
 )
@@ -168,14 +168,14 @@ def build_customer_support_triage_fake_validation_summary(
 
     return {
         "ok": error_count == 0 and validation_fail_count == 0,
-        "mode": "customer_support_triage_fake_validation",
+        "mode": "customer_support_triage_local_validation",
         "offline": True,
         "workload_id": workload.get("workload_id"),
         "workload_path": str(workload_path),
         "privacy_class": workload.get("privacy_class"),
-        "adapter": "DeterministicFakeModelCallAdapter",
-        "provider": "fake",
-        "model": "deterministic-fake",
+        "adapter": "deterministic local validation adapter",
+        "provider": "local_validation",
+        "model": "deterministic-local",
         "total_requests": len(requests),
         "baseline_model_calls": baseline_summary.model_calls,
         "kora_model_calls": kora_summary.model_calls,
@@ -197,9 +197,9 @@ def build_customer_support_triage_fake_validation_summary(
         "claim_boundary": CLAIM_BOUNDARY,
         "notes": [
             "Synthetic customer-support triage workload only.",
-            "Direct baseline calls the fake adapter for every request.",
-            "KORA-controlled path validates deterministic routes without fake model calls.",
-            "Model-required routes call the fake adapter through the provider-neutral boundary.",
+            "Direct baseline records local validation model-call events for every request.",
+            "KORA-controlled path validates deterministic routes without local validation model-call events.",
+            "Model-required routes use the deterministic local validation adapter through the provider-neutral boundary.",
             "No external APIs, network access, provider credentials, raw prompts, or raw provider responses are used.",
         ],
     }
@@ -207,7 +207,7 @@ def build_customer_support_triage_fake_validation_summary(
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(
-        description="Run the no-network customer-support triage fake validation example."
+        description="Run the local no-network customer-support triage validation example."
     )
     parser.add_argument("--offline", action="store_true", help="required; run without network calls")
     parser.add_argument(

--- a/examples/real_model_call_validation_fake/run.py
+++ b/examples/real_model_call_validation_fake/run.py
@@ -1,4 +1,4 @@
-"""No-network fake model-call validation example.
+"""Local no-network model-call validation example.
 
 This example exercises the provider-neutral model-call adapter boundary with
 synthetic data only. It is intended to validate local model-call counters before
@@ -22,7 +22,7 @@ from kora.model_call import (
 Route = Literal["deterministic", "model_required"]
 
 CLAIM_BOUNDARY = (
-    "This fake/local no-network validation example tests the measured model-call "
+    "This local/no-network validation example tests the measured model-call "
     "counter path. It is not real provider validation, real API-cost validation, "
     "production validation, production cost reduction proof, broad workload "
     "superiority proof, or energy reduction evidence."
@@ -199,11 +199,11 @@ def build_fake_model_call_validation_summary(
 
     return {
         "ok": error_count == 0 and validation_fail_count == 0,
-        "mode": "fake_model_call_validation",
+        "mode": "local_no_network_model_call_validation",
         "offline": True,
-        "adapter": "DeterministicFakeModelCallAdapter",
-        "provider": "fake",
-        "model": "deterministic-fake",
+        "adapter": "deterministic local validation adapter",
+        "provider": "local_validation",
+        "model": "deterministic-local",
         "total_requests": total_requests,
         "baseline_model_calls": baseline_summary.model_calls,
         "kora_model_calls": kora_summary.model_calls,
@@ -226,9 +226,9 @@ def build_fake_model_call_validation_summary(
         "claim_boundary": CLAIM_BOUNDARY,
         "notes": [
             "Synthetic workload only.",
-            "Direct baseline calls the fake adapter for every request.",
-            "KORA-controlled path handles deterministic routes without fake model calls.",
-            "Model-required routes call the fake adapter through the provider-neutral boundary.",
+            "Direct baseline records local validation model-call events for every request.",
+            "KORA-controlled path handles deterministic routes without local validation model-call events.",
+            "Model-required routes use the deterministic local validation adapter through the provider-neutral boundary.",
             "No external APIs, network access, provider credentials, raw prompts, or raw provider responses are used.",
         ],
     }
@@ -236,7 +236,7 @@ def build_fake_model_call_validation_summary(
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(
-        description="Run the no-network fake model-call validation example."
+        description="Run the local no-network model-call validation example."
     )
     parser.add_argument("--offline", action="store_true", help="required; run without network calls")
     return parser.parse_args(argv)

--- a/kora/cli.py
+++ b/kora/cli.py
@@ -29,10 +29,10 @@ def _example_descriptions() -> dict[str, str]:
     return {
         "hello_kora": "basic deterministic hello-world graph",
         "retry_demo": "retry/recovery flow example",
-        "customer_support_triage_fake_validation": "customer-support triage fake validation example",
+        "customer_support_triage_fake_validation": "customer-support triage local no-network validation example",
         "direct_vs_kora": "direct call vs KORA-controlled path",
         "real_workload_harness": "benchmark/report flow example",
-        "real_model_call_validation_fake": "no-network fake model-call validation example",
+        "real_model_call_validation_fake": "local no-network model-call validation example",
         "runtime_integrated_benchmark": "initial runtime-path benchmark harness",
         "stress_test": "repeated-run stress harness",
     }

--- a/kora/model_call.py
+++ b/kora/model_call.py
@@ -47,8 +47,8 @@ class ModelCallAdapter(Protocol):
 class DeterministicFakeModelCallAdapter:
     """Local no-network adapter for deterministic validation tests."""
 
-    provider = "fake"
-    model = "deterministic-fake"
+    provider = "local_validation"
+    model = "deterministic-local"
 
     def call(self, request: ModelCallRequest) -> ModelCallResponse:
         start = time.perf_counter()

--- a/tests/test_customer_support_triage_fake_validation.py
+++ b/tests/test_customer_support_triage_fake_validation.py
@@ -34,11 +34,11 @@ def test_customer_support_triage_fake_validation_summary_counts() -> None:
     summary = module.build_customer_support_triage_fake_validation_summary(offline=True)
 
     assert summary["ok"] is True
-    assert summary["mode"] == "customer_support_triage_fake_validation"
+    assert summary["mode"] == "customer_support_triage_local_validation"
     assert summary["workload_id"] == "customer_support_triage_synthetic_v1"
     assert summary["privacy_class"] == "synthetic"
-    assert summary["provider"] == "fake"
-    assert summary["model"] == "deterministic-fake"
+    assert summary["provider"] == "local_validation"
+    assert summary["model"] == "deterministic-local"
     assert summary["total_requests"] == 12
     assert summary["baseline_model_calls"] == 12
     assert summary["kora_model_calls"] == 4
@@ -104,6 +104,6 @@ def test_customer_support_triage_fake_validation_cli_runs() -> None:
     )
 
     assert completed.returncode == 0
-    assert '"mode": "customer_support_triage_fake_validation"' in completed.stdout
+    assert '"mode": "customer_support_triage_local_validation"' in completed.stdout
     assert '"baseline_model_calls": 12' in completed.stdout
     assert '"kora_model_calls": 4' in completed.stdout

--- a/tests/test_model_call.py
+++ b/tests/test_model_call.py
@@ -52,8 +52,8 @@ def test_fake_adapter_provider_model_and_metadata_are_local_safe() -> None:
 
     response = adapter.call(request)
 
-    assert response.provider == "fake"
-    assert response.model == "deterministic-fake"
+    assert response.provider == "local_validation"
+    assert response.model == "deterministic-local"
     assert response.metadata["privacy_class"] == "synthetic"
     assert response.metadata["network"] == "none"
     assert response.metadata["deterministic"] is True

--- a/tests/test_real_model_call_validation_fake.py
+++ b/tests/test_real_model_call_validation_fake.py
@@ -22,9 +22,9 @@ def test_fake_model_call_validation_summary_counts() -> None:
     summary = module.build_fake_model_call_validation_summary(offline=True)
 
     assert summary["ok"] is True
-    assert summary["mode"] == "fake_model_call_validation"
-    assert summary["provider"] == "fake"
-    assert summary["model"] == "deterministic-fake"
+    assert summary["mode"] == "local_no_network_model_call_validation"
+    assert summary["provider"] == "local_validation"
+    assert summary["model"] == "deterministic-local"
     assert summary["total_requests"] == 10
     assert summary["baseline_model_calls"] == 10
     assert summary["kora_model_calls"] == 4
@@ -91,6 +91,6 @@ def test_fake_model_call_validation_cli_runs() -> None:
     )
 
     assert completed.returncode == 0
-    assert '"mode": "fake_model_call_validation"' in completed.stdout
+    assert '"mode": "local_no_network_model_call_validation"' in completed.stdout
     assert '"baseline_model_calls": 10' in completed.stdout
     assert '"kora_model_calls": 4' in completed.stdout


### PR DESCRIPTION
## Summary
- Replace public-facing “fake” wording with local/no-network validation terminology in README and docs.
- Keep compatibility-preserving command names while clarifying emitted mode/provider/model labels.
- Update local validation outputs to report `local_validation` and `deterministic-local`.
- Update tests for the new public-facing labels.

## Validation
- `git diff --check`
- `python3 -m pytest`
- `python3 -m kora --help`
- `python3 -m kora examples list`
- `python3 -m kora run real_model_call_validation_fake -- --offline`
- `python3 -m kora run customer_support_triage_fake_validation -- --offline`
- `python3 -m kora run direct_vs_kora -- --offline`
- `python3 -m kora run runtime_integrated_benchmark -- --offline`

## Claim safety
No real provider calls, secrets, production validation claims, real API-cost reduction claims, production cost-reduction claims, or energy-reduction claims were added.