### PR TITLE
Add local validation Markdown report generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,8 @@ KORA includes a local no-network validation path that measures model-call routin
 
 Customer-support triage local validation is available as a no-network example.
 
+Local no-network validation examples can generate Markdown reports with `--report-md`.
+
 ## Help Test KORA
 
 Good candidate workloads:

--- a/docs/README.md
+++ b/docs/README.md
@@ -48,6 +48,7 @@ python3 -m kora run runtime_integrated_benchmark -- --offline
 ```
 
 Some example command names are compatibility-preserving. The local validation examples emit public-facing `local_validation` provider labels.
+Use `--report-md /tmp/kora_validation.md` with local validation examples to generate reviewer-facing Markdown reports from aggregate counters.
 
 ## Inspect Evidence
 

--- a/docs/benchmarks/real-model-call-validation-design.md
+++ b/docs/benchmarks/real-model-call-validation-design.md
@@ -272,6 +272,8 @@ This example uses the deterministic local validation adapter with a synthetic 10
 
 The example validates model-call counter plumbing before real local or remote provider adapters are added. It requires no secrets, uses no network, emits aggregate counters only, and does not commit raw prompts or raw provider responses.
 
+The example can generate a reviewer-facing Markdown report from aggregate counters with `--report-md`. Generated reports are evidence packets for local/no-network review before real provider or production validation.
+
 Claim boundary: this is not real provider validation, real API-cost validation, production validation, production cost reduction proof, broad workload superiority proof, or energy reduction evidence.
 
 ## Customer-Support Triage Local Validation Example
@@ -285,6 +287,8 @@ python3 -m kora run customer_support_triage_fake_validation -- --offline
 The command name is preserved for compatibility. The emitted mode/provider/model labels use customer-support local validation terminology.
 
 This extends local/no-network validation from generic counter plumbing to a realistic support triage workload shape. It still uses the deterministic local validation adapter, requires no secrets, makes no network calls, and emits aggregate counters only.
+
+The example can generate a reviewer-facing Markdown report from aggregate counters with `--report-md`.
 
 This is a step before local model or remote provider validation. It is not real provider validation, real API-cost validation, or production validation.
 

--- a/docs/benchmarks/real-model-call-validation-report-template.md
+++ b/docs/benchmarks/real-model-call-validation-report-template.md
@@ -63,6 +63,17 @@ For the customer-support triage local validation example, use:
 
 Do not include API keys, tokens, credentials, private hostnames, private dataset names, or raw provider response IDs unless explicitly approved.
 
+## Generated Local Validation Reports
+
+Local no-network validation examples can generate reviewer-facing Markdown reports from aggregate counters:
+
+```bash
+python3 -m kora run customer_support_triage_fake_validation -- --offline --report-md /tmp/kora_customer_support_validation.md
+python3 -m kora run real_model_call_validation_fake -- --offline --report-md /tmp/kora_local_validation.md
+```
+
+Write generated reports to `/tmp` or another local output path unless the report is intentionally selected for review. Generated reports should not include secrets, raw provider responses, private data, production data, or raw prompts.
+
 ## Commands
 
 ```bash

--- a/examples/customer_support_triage_fake_validation/run.py
+++ b/examples/customer_support_triage_fake_validation/run.py
@@ -13,6 +13,7 @@ from kora.model_call import (
     ModelCallResponse,
     ModelCallSummary,
 )
+from kora.validation_report import render_local_validation_markdown
 
 DEFAULT_WORKLOAD = Path("experiments/workloads/customer_support_triage_synthetic_v1.json")
 CLAIM_BOUNDARY = (
@@ -194,6 +195,7 @@ def build_customer_support_triage_fake_validation_summary(
         "latency_total_ms": kora_summary.latency_total_ms,
         "raw_prompts_emitted": False,
         "raw_responses_emitted": False,
+        "command": "python3 -m kora run customer_support_triage_fake_validation -- --offline",
         "claim_boundary": CLAIM_BOUNDARY,
         "notes": [
             "Synthetic customer-support triage workload only.",
@@ -215,6 +217,11 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         default=str(DEFAULT_WORKLOAD),
         help="Path to customer-support triage workload JSON.",
     )
+    parser.add_argument(
+        "--report-md",
+        default=None,
+        help="Optional path for a generated Markdown report.",
+    )
     return parser.parse_args(argv)
 
 
@@ -227,6 +234,10 @@ def main(argv: list[str] | None = None) -> int:
         offline=True,
         workload_path=Path(args.workload),
     )
+    if args.report_md:
+        report_path = Path(args.report_md)
+        report_path.parent.mkdir(parents=True, exist_ok=True)
+        report_path.write_text(render_local_validation_markdown(summary), encoding="utf-8")
     print(json.dumps(summary, indent=2, sort_keys=True))
     return 0 if summary["ok"] else 1
 

--- a/examples/real_model_call_validation_fake/run.py
+++ b/examples/real_model_call_validation_fake/run.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import argparse
 import json
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Any, Literal
 
 from kora.model_call import (
@@ -18,6 +19,7 @@ from kora.model_call import (
     ModelCallResponse,
     ModelCallSummary,
 )
+from kora.validation_report import render_local_validation_markdown
 
 Route = Literal["deterministic", "model_required"]
 
@@ -223,6 +225,7 @@ def build_fake_model_call_validation_summary(
         "privacy_class": "synthetic",
         "raw_prompts_emitted": False,
         "raw_responses_emitted": False,
+        "command": "python3 -m kora run real_model_call_validation_fake -- --offline",
         "claim_boundary": CLAIM_BOUNDARY,
         "notes": [
             "Synthetic workload only.",
@@ -239,6 +242,11 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         description="Run the local no-network model-call validation example."
     )
     parser.add_argument("--offline", action="store_true", help="required; run without network calls")
+    parser.add_argument(
+        "--report-md",
+        default=None,
+        help="Optional path for a generated Markdown report.",
+    )
     return parser.parse_args(argv)
 
 
@@ -248,6 +256,10 @@ def main(argv: list[str] | None = None) -> int:
         raise SystemExit("real_model_call_validation_fake requires --offline.")
 
     summary = build_fake_model_call_validation_summary(offline=True)
+    if args.report_md:
+        report_path = Path(args.report_md)
+        report_path.parent.mkdir(parents=True, exist_ok=True)
+        report_path.write_text(render_local_validation_markdown(summary), encoding="utf-8")
     print(json.dumps(summary, indent=2, sort_keys=True))
     return 0 if summary["ok"] else 1
 

--- a/kora/validation_report.py
+++ b/kora/validation_report.py
@@ -1,0 +1,108 @@
+"""Markdown reports for local no-network validation summaries."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+BOUNDARY_TEXT = (
+    "This report describes local no-network validation using a deterministic "
+    "local validation adapter. It is not real provider validation, real "
+    "API-cost reduction evidence, production validation, production "
+    "cost-reduction proof, or energy-reduction evidence."
+)
+
+COUNTER_KEYS = (
+    "total_requests",
+    "baseline_model_calls",
+    "kora_model_calls",
+    "avoided_model_calls",
+    "avoided_model_call_rate",
+    "deterministic_routes",
+    "model_escalations",
+    "validation_pass_count",
+    "validation_fail_count",
+    "error_count",
+    "fallback_count",
+    "input_tokens_total",
+    "output_tokens_total",
+)
+
+
+def _display(value: Any) -> str:
+    if value is None:
+        return "N/A"
+    if isinstance(value, float):
+        return f"{value:.4f}" if value == value else "N/A"
+    return str(value)
+
+
+def _summary_line(label: str, value: Any) -> str:
+    return f"- {label}: `{_display(value)}`"
+
+
+def render_local_validation_markdown(summary: dict[str, Any]) -> str:
+    """Render a claim-safe Markdown report from local validation counters."""
+
+    workload = summary.get("workload_id") or summary.get("workload_path") or "synthetic local workload"
+    command = summary.get("command")
+    notes = summary.get("notes")
+
+    lines = [
+        "# Local No-Network Validation Report",
+        "",
+        "## Summary",
+        "",
+        _summary_line("Workload", workload),
+        _summary_line("Mode", summary.get("mode")),
+        _summary_line("Provider", summary.get("provider")),
+        _summary_line("Model", summary.get("model")),
+        _summary_line("Privacy class", summary.get("privacy_class")),
+        _summary_line("Total requests", summary.get("total_requests")),
+        _summary_line("Baseline model calls", summary.get("baseline_model_calls")),
+        _summary_line("KORA-controlled model calls", summary.get("kora_model_calls")),
+        _summary_line("Avoided model calls", summary.get("avoided_model_calls")),
+        _summary_line("Avoided model-call rate", summary.get("avoided_model_call_rate")),
+        _summary_line("Deterministic routes", summary.get("deterministic_routes")),
+        _summary_line("Model escalations", summary.get("model_escalations")),
+        _summary_line("Validation pass count", summary.get("validation_pass_count")),
+        _summary_line("Validation fail count", summary.get("validation_fail_count")),
+        _summary_line("Error count", summary.get("error_count")),
+        _summary_line("Fallback count", summary.get("fallback_count")),
+        "",
+        "## Counters",
+        "",
+        "| Counter | Value |",
+        "|---|---:|",
+    ]
+
+    for key in COUNTER_KEYS:
+        if key in summary:
+            lines.append(f"| `{key}` | {_display(summary.get(key))} |")
+
+    lines.extend(
+        [
+            "",
+            "## Boundary",
+            "",
+            BOUNDARY_TEXT,
+            "",
+            "This report must not include raw prompts, raw provider responses, secrets, or private user data.",
+            "",
+            "## Reproduction",
+            "",
+        ]
+    )
+
+    if command:
+        lines.extend(["```bash", str(command), "```"])
+    else:
+        lines.append("- Command: `N/A`")
+
+    lines.extend(["", "## Notes", ""])
+    if isinstance(notes, list) and notes:
+        lines.extend(f"- {note}" for note in notes)
+    else:
+        lines.append("- No additional notes provided.")
+
+    return "\n".join(lines).rstrip() + "\n"

--- a/tests/test_validation_report.py
+++ b/tests/test_validation_report.py
@@ -1,0 +1,134 @@
+import subprocess
+import sys
+from pathlib import Path
+
+from kora.validation_report import render_local_validation_markdown
+
+
+def _summary() -> dict[str, object]:
+    return {
+        "mode": "customer_support_triage_local_validation",
+        "workload_id": "customer_support_triage_synthetic_v1",
+        "provider": "local_validation",
+        "model": "deterministic-local",
+        "privacy_class": "synthetic",
+        "total_requests": 12,
+        "baseline_model_calls": 12,
+        "kora_model_calls": 4,
+        "avoided_model_calls": 8,
+        "avoided_model_call_rate": 2 / 3,
+        "deterministic_routes": 8,
+        "model_escalations": 4,
+        "validation_pass_count": 12,
+        "validation_fail_count": 0,
+        "error_count": 0,
+        "fallback_count": 0,
+        "input_tokens_total": 50,
+        "output_tokens_total": 50,
+        "command": "python3 -m kora run customer_support_triage_fake_validation -- --offline",
+        "notes": ["Synthetic workload only."],
+    }
+
+
+def test_render_local_validation_markdown_includes_core_sections() -> None:
+    markdown = render_local_validation_markdown(_summary())
+
+    assert "# Local No-Network Validation Report" in markdown
+    assert "## Summary" in markdown
+    assert "## Counters" in markdown
+    assert "## Boundary" in markdown
+    assert "## Reproduction" in markdown
+    assert "## Notes" in markdown
+
+
+def test_render_local_validation_markdown_includes_required_counters() -> None:
+    markdown = render_local_validation_markdown(_summary())
+
+    assert "| `total_requests` | 12 |" in markdown
+    assert "| `baseline_model_calls` | 12 |" in markdown
+    assert "| `kora_model_calls` | 4 |" in markdown
+    assert "| `avoided_model_calls` | 8 |" in markdown
+    assert "| `avoided_model_call_rate` | 0.6667 |" in markdown
+    assert "| `input_tokens_total` | 50 |" in markdown
+    assert "| `output_tokens_total` | 50 |" in markdown
+
+
+def test_render_local_validation_markdown_is_claim_safe() -> None:
+    markdown = render_local_validation_markdown(_summary())
+
+    assert "local no-network validation" in markdown
+    assert "deterministic local validation adapter" in markdown
+    assert "not real provider validation" in markdown
+    assert "real API-cost reduction evidence" in markdown
+    assert "production validation" in markdown
+    assert "energy-reduction evidence" in markdown
+    assert "raw prompts" in markdown
+    assert "raw provider responses" in markdown
+    assert "private user data" in markdown
+
+
+def test_render_local_validation_markdown_does_not_emit_raw_payloads() -> None:
+    markdown = render_local_validation_markdown(_summary())
+
+    assert "raw_prompt" not in markdown
+    assert "raw_response" not in markdown
+    assert "OPENAI_API_KEY" not in markdown
+    assert "ANTHROPIC_API_KEY" not in markdown
+
+
+def test_customer_support_example_writes_markdown_report(tmp_path: Path) -> None:
+    report_path = tmp_path / "customer_support_validation.md"
+
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "kora",
+            "run",
+            "customer_support_triage_fake_validation",
+            "--",
+            "--offline",
+            "--report-md",
+            str(report_path),
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert completed.returncode == 0
+    report = report_path.read_text(encoding="utf-8")
+    assert "# Local No-Network Validation Report" in report
+    assert "| `total_requests` | 12 |" in report
+    assert "| `kora_model_calls` | 4 |" in report
+    assert "customer_support_triage_local_validation" in report
+    assert "local_validation" in report
+
+
+def test_real_model_call_example_writes_markdown_report(tmp_path: Path) -> None:
+    report_path = tmp_path / "local_validation.md"
+
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "kora",
+            "run",
+            "real_model_call_validation_fake",
+            "--",
+            "--offline",
+            "--report-md",
+            str(report_path),
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert completed.returncode == 0
+    report = report_path.read_text(encoding="utf-8")
+    assert "# Local No-Network Validation Report" in report
+    assert "| `total_requests` | 10 |" in report
+    assert "| `kora_model_calls` | 4 |" in report
+    assert "local_no_network_model_call_validation" in report
+    assert "deterministic-local" in report


### PR DESCRIPTION
## Summary
- Add `render_local_validation_markdown` for reviewer-facing local/no-network validation reports.
- Add `--report-md PATH` support to both local validation examples.
- Keep JSON stdout unchanged and do not write reports by default.
- Add tests for report rendering, claim-safe boundary language, and file output.
- Update docs with `/tmp` report generation examples.

## Validation
- `git diff --check`
- `python3 -m pytest`
- `python3 -m kora --help`
- `python3 -m kora examples list`
- `python3 -m kora run customer_support_triage_fake_validation -- --offline`
- `python3 -m kora run customer_support_triage_fake_validation -- --offline --report-md /tmp/kora_customer_support_validation.md`
- `test -f /tmp/kora_customer_support_validation.md`
- `python3 -m kora run real_model_call_validation_fake -- --offline --report-md /tmp/kora_local_validation.md`
- `test -f /tmp/kora_local_validation.md`
- `python3 -m kora run direct_vs_kora -- --offline`
- `python3 -m kora run runtime_integrated_benchmark -- --offline`

## Claim safety
Reports are aggregate-only local/no-network validation evidence. No real provider calls, secrets, raw provider responses, production validation claims, real API-cost reduction claims, production cost-reduction claims, or energy-reduction claims were added. Generated reports were written to `/tmp` and not committed.