### PR TITLE
Add local validation reviewer packet

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,8 @@ Customer-support triage local validation is available as a no-network example.
 
 Local no-network validation examples can generate Markdown reports with `--report-md`.
 
+Reviewer packet: [local no-network validation](docs/benchmarks/local-validation-reviewer-packet.md).
+
 ## Help Test KORA
 
 Good candidate workloads:

--- a/docs/README.md
+++ b/docs/README.md
@@ -65,10 +65,11 @@ Use this path for the current `v0.3.0-alpha` prerelease runtime evidence and reg
 9. Validation roadmap: [`docs/benchmarks/validation-roadmap.md`](benchmarks/validation-roadmap.md)
 10. Real model-call validation design: [`docs/benchmarks/real-model-call-validation-design.md`](benchmarks/real-model-call-validation-design.md)
 11. Real model-call validation report template: [`docs/benchmarks/real-model-call-validation-report-template.md`](benchmarks/real-model-call-validation-report-template.md)
-12. Local no-network model-call validation example: [`examples/real_model_call_validation_fake`](../examples/real_model_call_validation_fake)
-13. Customer-support triage local validation example: [`examples/customer_support_triage_fake_validation`](../examples/customer_support_triage_fake_validation)
-14. Customer-support triage workload spec: [`docs/workloads/customer-support-triage.md`](workloads/customer-support-triage.md)
-15. Claim boundary source: [`docs/claims/kora-claim-registry.md`](claims/kora-claim-registry.md)
+12. Local validation reviewer packet: [`docs/benchmarks/local-validation-reviewer-packet.md`](benchmarks/local-validation-reviewer-packet.md)
+13. Local no-network model-call validation example: [`examples/real_model_call_validation_fake`](../examples/real_model_call_validation_fake)
+14. Customer-support triage local validation example: [`examples/customer_support_triage_fake_validation`](../examples/customer_support_triage_fake_validation)
+15. Customer-support triage workload spec: [`docs/workloads/customer-support-triage.md`](workloads/customer-support-triage.md)
+16. Claim boundary source: [`docs/claims/kora-claim-registry.md`](claims/kora-claim-registry.md)
 
 Current approved public claim:
 

--- a/docs/benchmarks/local-validation-reviewer-packet.md
+++ b/docs/benchmarks/local-validation-reviewer-packet.md
@@ -1,0 +1,149 @@
+# Local No-Network Validation Reviewer Packet
+
+## Purpose
+
+This packet helps reviewers reproduce KORA's local/no-network validation path without API keys, external providers, private data, or network calls.
+
+It is intended for technical review of the current validation plumbing: routing decisions, aggregate model-call counters, and Markdown report generation from synthetic workloads.
+
+## What This Packet Shows
+
+- A direct baseline records deterministic local validation adapter events for every request.
+- A KORA-controlled path avoids model-call events for deterministic routes.
+- The customer-support triage workload demonstrates an application-shaped synthetic workload.
+- Markdown reports are generated from aggregate counters.
+
+## What This Packet Does Not Show
+
+This packet is not real provider validation, not real API-cost reduction evidence, not production validation, not production cost-reduction proof, not energy-reduction evidence, and not broad workload superiority proof.
+
+This packet is not:
+
+- real provider validation
+- real API-cost reduction evidence
+- production validation
+- production cost-reduction proof
+- energy-reduction evidence
+- broad workload superiority proof
+
+## Prerequisites
+
+- A Python environment that can run the KORA test suite and CLI.
+- An editable install or local package setup if your environment does not already resolve `python3 -m kora`.
+- No API keys required.
+- No provider credentials required.
+- No network access required for these validation examples.
+
+## Quick Start Commands
+
+```bash
+python3 -m kora --help
+python3 -m kora examples list
+
+python3 -m kora run real_model_call_validation_fake -- --offline
+python3 -m kora run customer_support_triage_fake_validation -- --offline
+```
+
+## Generate Reviewer Reports
+
+```bash
+python3 -m kora run real_model_call_validation_fake -- --offline --report-md /tmp/kora_local_validation.md
+
+python3 -m kora run customer_support_triage_fake_validation -- --offline --report-md /tmp/kora_customer_support_validation.md
+```
+
+Reports are written only when `--report-md` is provided. Use `/tmp` or another local output path for generated artifacts unless a report is intentionally selected for review.
+
+Generated reports are not committed by default. They contain aggregate counters and boundary language. They do not contain raw prompts, raw provider responses, secrets, or private data.
+
+## Expected Generic Local Validation Counters
+
+For `real_model_call_validation_fake`, expected counters are:
+
+| Counter | Expected value |
+|---|---:|
+| `total_requests` | 10 |
+| `baseline_model_calls` | 10 |
+| `kora_model_calls` | 4 |
+| `avoided_model_calls` | 6 |
+| `avoided_model_call_rate` | 0.6 |
+| `deterministic_routes` | 6 |
+| `model_escalations` | 4 |
+
+Expected labels:
+
+- `provider`: `local_validation`
+- `model`: `deterministic-local`
+
+## Expected Customer-Support Triage Counters
+
+For `customer_support_triage_fake_validation`, expected counters are:
+
+| Counter | Expected value |
+|---|---:|
+| `total_requests` | 12 |
+| `baseline_model_calls` | 12 |
+| `kora_model_calls` | 4 |
+| `avoided_model_calls` | 8 |
+| `avoided_model_call_rate` | 0.6667 |
+| `deterministic_routes` | 8 |
+| `model_escalations` | 4 |
+
+Expected labels:
+
+- `provider`: `local_validation`
+- `model`: `deterministic-local`
+
+## How To Read The Counters
+
+- `baseline_model_calls`: model-call events recorded by the direct baseline path.
+- `kora_model_calls`: model-call events recorded by the KORA-controlled path.
+- `avoided_model_calls`: `baseline_model_calls - kora_model_calls`.
+- `avoided_model_call_rate`: `avoided_model_calls / baseline_model_calls`.
+- `deterministic_routes`: requests handled through deterministic routing.
+- `model_escalations`: requests routed to the deterministic local validation adapter.
+- `validation_pass_count`: route or response checks that passed.
+- `validation_fail_count`: route or response checks that failed.
+- `error_count`: runtime errors counted during the example.
+- `fallback_count`: requests that fell back because the route was unsupported or unresolved.
+
+## Privacy And Artifact Handling
+
+- Do not include secrets.
+- Do not include API keys.
+- Do not include private data.
+- Do not include raw provider responses.
+- Do not use real customer data.
+- Do not use proprietary datasets.
+- Review generated local reports before sharing them.
+
+## Claim-Safe Language
+
+Allowed:
+
+> KORA's local no-network validation examples show that KORA can measure avoided model-call events in synthetic workloads.
+
+Allowed:
+
+> In the customer-support triage synthetic workload, the local validation path records 8 avoided model-call events out of 12 requests.
+
+Not allowed:
+
+- KORA reduces production AI costs by 66.7%.
+- KORA reduces real API costs by 66.7%.
+- KORA is production-proven for customer support.
+- KORA reduces energy consumption.
+- KORA has real provider validation from this packet.
+
+## Troubleshooting
+
+- Command not found: confirm you are in the KORA repository and the package is importable with `python3 -m kora --help`.
+- Editable install missing: install the project in editable mode if your environment does not resolve local modules.
+- Example not listed: run `python3 -m kora examples list` from a fresh checkout of `origin/main`.
+- Report path not writable: use `/tmp` or another writable local directory.
+- Stale checkout: run `git fetch origin` and confirm your local branch is current.
+- Expected counters differ: confirm you are running with `--offline` and have not modified the synthetic workload files.
+
+## Next Validation Step
+
+The next step after this packet is a local model adapter or remote provider adapter using the same reporting structure, while preserving privacy and claim boundaries.

--- a/docs/benchmarks/real-model-call-validation-design.md
+++ b/docs/benchmarks/real-model-call-validation-design.md
@@ -274,6 +274,8 @@ The example validates model-call counter plumbing before real local or remote pr
 
 The example can generate a reviewer-facing Markdown report from aggregate counters with `--report-md`. Generated reports are evidence packets for local/no-network review before real provider or production validation.
 
+For a reviewer-facing walkthrough, see the [local no-network validation reviewer packet](local-validation-reviewer-packet.md).
+
 Claim boundary: this is not real provider validation, real API-cost validation, production validation, production cost reduction proof, broad workload superiority proof, or energy reduction evidence.
 
 ## Customer-Support Triage Local Validation Example

--- a/docs/benchmarks/real-model-call-validation-report-template.md
+++ b/docs/benchmarks/real-model-call-validation-report-template.md
@@ -74,6 +74,8 @@ python3 -m kora run real_model_call_validation_fake -- --offline --report-md /tm
 
 Write generated reports to `/tmp` or another local output path unless the report is intentionally selected for review. Generated reports should not include secrets, raw provider responses, private data, production data, or raw prompts.
 
+For the recommended reviewer-facing walkthrough, see the [local no-network validation reviewer packet](local-validation-reviewer-packet.md).
+
 ## Commands
 
 ```bash

--- a/tests/test_local_validation_reviewer_packet.py
+++ b/tests/test_local_validation_reviewer_packet.py
@@ -1,0 +1,40 @@
+from pathlib import Path
+
+
+PACKET_PATH = Path("docs/benchmarks/local-validation-reviewer-packet.md")
+
+
+def test_local_validation_reviewer_packet_exists_and_has_report_commands() -> None:
+    content = PACKET_PATH.read_text(encoding="utf-8")
+
+    assert "# Local No-Network Validation Reviewer Packet" in content
+    assert "python3 -m kora run real_model_call_validation_fake -- --offline --report-md" in content
+    assert (
+        "python3 -m kora run customer_support_triage_fake_validation -- --offline --report-md"
+        in content
+    )
+
+
+def test_local_validation_reviewer_packet_documents_expected_counters() -> None:
+    content = PACKET_PATH.read_text(encoding="utf-8")
+
+    assert "| `total_requests` | 10 |" in content
+    assert "| `baseline_model_calls` | 10 |" in content
+    assert "| `kora_model_calls` | 4 |" in content
+    assert "| `avoided_model_calls` | 6 |" in content
+    assert "| `total_requests` | 12 |" in content
+    assert "| `baseline_model_calls` | 12 |" in content
+    assert "| `avoided_model_calls` | 8 |" in content
+    assert "`provider`: `local_validation`" in content
+    assert "`model`: `deterministic-local`" in content
+
+
+def test_local_validation_reviewer_packet_preserves_claim_boundaries() -> None:
+    content = PACKET_PATH.read_text(encoding="utf-8")
+
+    assert "not real provider validation" in content
+    assert "not real API-cost reduction evidence" in content
+    assert "not production validation" in content
+    assert "not production cost-reduction proof" in content
+    assert "not energy-reduction evidence" in content
+    assert "KORA has real provider validation from this packet." in content


### PR DESCRIPTION
## Summary
- Add a reviewer-facing local/no-network validation packet guide
- Document report generation commands and expected counters for both local validation examples
- Clarify privacy/artifact handling and claim-safe language
- Link the packet from README, docs index, validation design, and report template docs
- Add a focused docs test for packet existence, report commands, expected counters, and claim boundaries

## Validation
- git diff --check
- python3 -m pytest
- python3 -m kora --help
- python3 -m kora examples list
- python3 -m kora run real_model_call_validation_fake -- --offline
- python3 -m kora run real_model_call_validation_fake -- --offline --report-md /tmp/kora_local_validation.md
- test -f /tmp/kora_local_validation.md
- python3 -m kora run customer_support_triage_fake_validation -- --offline
- python3 -m kora run customer_support_triage_fake_validation -- --offline --report-md /tmp/kora_customer_support_validation.md
- test -f /tmp/kora_customer_support_validation.md
- python3 -m kora run direct_vs_kora -- --offline
- python3 -m kora run runtime_integrated_benchmark -- --offline

## Claim and artifact safety
- No generated report artifacts committed
- No real provider calls added
- No secrets or private data added
- No unsupported production cost, real API-cost, production validation, or energy claims added