### PR TITLE
Add local model adapter design

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,8 @@ Local no-network validation examples can generate Markdown reports with `--repor
 
 Reviewer packet: [local no-network validation](docs/benchmarks/local-validation-reviewer-packet.md).
 
+Local model adapter design: [provider-neutral local runtime path](docs/benchmarks/local-model-adapter-design.md).
+
 ## Help Test KORA
 
 Good candidate workloads:

--- a/docs/README.md
+++ b/docs/README.md
@@ -66,10 +66,11 @@ Use this path for the current `v0.3.0-alpha` prerelease runtime evidence and reg
 10. Real model-call validation design: [`docs/benchmarks/real-model-call-validation-design.md`](benchmarks/real-model-call-validation-design.md)
 11. Real model-call validation report template: [`docs/benchmarks/real-model-call-validation-report-template.md`](benchmarks/real-model-call-validation-report-template.md)
 12. Local validation reviewer packet: [`docs/benchmarks/local-validation-reviewer-packet.md`](benchmarks/local-validation-reviewer-packet.md)
-13. Local no-network model-call validation example: [`examples/real_model_call_validation_fake`](../examples/real_model_call_validation_fake)
-14. Customer-support triage local validation example: [`examples/customer_support_triage_fake_validation`](../examples/customer_support_triage_fake_validation)
-15. Customer-support triage workload spec: [`docs/workloads/customer-support-triage.md`](workloads/customer-support-triage.md)
-16. Claim boundary source: [`docs/claims/kora-claim-registry.md`](claims/kora-claim-registry.md)
+13. Local model adapter design: [`docs/benchmarks/local-model-adapter-design.md`](benchmarks/local-model-adapter-design.md)
+14. Local no-network model-call validation example: [`examples/real_model_call_validation_fake`](../examples/real_model_call_validation_fake)
+15. Customer-support triage local validation example: [`examples/customer_support_triage_fake_validation`](../examples/customer_support_triage_fake_validation)
+16. Customer-support triage workload spec: [`docs/workloads/customer-support-triage.md`](workloads/customer-support-triage.md)
+17. Claim boundary source: [`docs/claims/kora-claim-registry.md`](claims/kora-claim-registry.md)
 
 Current approved public claim:
 

--- a/docs/benchmarks/local-model-adapter-design.md
+++ b/docs/benchmarks/local-model-adapter-design.md
@@ -1,0 +1,206 @@
+# Local Model Adapter Design
+
+## Purpose
+
+This design defines how KORA can later connect to local model runtimes through the provider-neutral `ModelCallAdapter` interface.
+
+The goal is to preserve the same measurement shape used by current local/no-network validation examples while allowing future adapters for local model runtimes. This document is a design contract only. It does not implement Ollama, llama.cpp, vLLM, remote provider calls, or new dependencies.
+
+## Current State
+
+KORA currently supports local/no-network validation with deterministic local validation adapters.
+
+Current properties:
+
+- no external provider calls are required
+- no local model runtime is required
+- no API keys or provider credentials are required
+- examples emit aggregate model-call counters
+- Markdown reports are generated from aggregate counters
+- reviewer-facing guidance is documented in the local validation reviewer packet
+
+This design is the next step toward local model validation. It defines how future local runtime adapters should plug in without changing the public claim boundary.
+
+## Target Local Runtimes
+
+Future adapters may support local runtimes such as:
+
+- Ollama
+- llama.cpp
+- vLLM
+- other local HTTP runtimes
+- subprocess-based local runtimes
+
+KORA should remain provider-neutral. Supporting one local runtime first should not make that runtime the default public measurement standard.
+
+## Adapter Boundary
+
+Future local adapters should implement the same boundary already used by validation harnesses:
+
+- `ModelCallRequest`
+- `ModelCallResponse`
+- `ModelCallAdapter.call(request)`
+
+The adapter input is a prompt/request envelope. The adapter output must include:
+
+- output text
+- measured model-call count
+- latency when available
+- input token count when available
+- output token count when available
+- provider/runtime label
+- model label
+- sanitized metadata
+
+Adapters must not leak raw private prompts or raw model responses into committed artifacts. Runtime outputs should be kept local by default, and public reports should use aggregate counters and sanitized summaries.
+
+## Local Runtime Modes
+
+### 1. Disabled / Blocked Mode
+
+Disabled or blocked mode is the default safe behavior for unconfigured runtime paths.
+
+Properties:
+
+- no runtime required
+- no network required
+- fails closed with a clear error
+- does not silently fall back to a remote provider
+
+### 2. Deterministic Local Validation Mode
+
+Deterministic local validation mode is the current no-network validation path.
+
+Properties:
+
+- uses the deterministic local validation adapter
+- requires no local model runtime
+- is deterministic and suitable for tests and CI
+- measures the model-call counter path before real local adapters are introduced
+
+### 3. Local Runtime Mode
+
+Local runtime mode is a future opt-in mode for adapters such as Ollama, llama.cpp, vLLM, or another local runtime.
+
+Properties:
+
+- requires explicit user opt-in
+- uses a local runtime endpoint or command configured by environment variable or CLI flag
+- normally requires no secrets
+- records measured local model-call counters
+- keeps raw outputs local by default
+- does not commit raw prompts or raw responses by default
+
+## Configuration Principles
+
+Future local adapter configuration should follow these principles:
+
+- no hard-coded endpoints that imply external calls
+- no committed credentials
+- no default remote provider fallback
+- environment variables may be used later for local endpoint selection
+- CLI flags may be used later for explicit adapter selection
+- default behavior remains local/no-network validation or blocked mode unless the user opts in
+
+Potential future environment variable names:
+
+- `KORA_LOCAL_MODEL_RUNTIME`
+- `KORA_LOCAL_MODEL_ENDPOINT`
+- `KORA_LOCAL_MODEL_NAME`
+
+These names are design placeholders only. They are not active requirements unless implemented in a later task.
+
+## Counters To Measure
+
+Future local model adapters should record:
+
+- `model_calls`
+- `latency_ms`
+- `input_tokens` if available
+- `output_tokens` if available
+- provider/runtime label
+- model label
+- `error_count`
+- `fallback_count`
+- `validation_result` where applicable
+
+Token counters may be unavailable or adapter-specific. Reports should distinguish measured token counts from estimates.
+
+## Privacy And Artifacts
+
+Local model validation must preserve the current artifact policy:
+
+- no raw private prompts committed
+- no raw model outputs committed by default
+- no private customer data
+- no proprietary datasets
+- reports contain aggregate counters and sanitized summaries only
+- local generated reports are reviewed before sharing
+
+If a future reviewer needs example outputs, they should use synthetic or sanitized prompts and explicitly reviewed artifacts.
+
+## Failure Handling
+
+Future local adapters should fail clearly and measurably:
+
+- local runtime unavailable -> clear error
+- timeout -> error counter
+- malformed response -> error counter
+- unsupported runtime -> clear error
+- invalid endpoint or command -> clear error
+- no silent fallback to a remote provider
+
+Validation summaries should make failures visible through `error_count`, `fallback_count`, and reviewer-facing notes.
+
+## Claim Boundaries
+
+Local model adapter validation, once implemented, may support measured local model-call validation language.
+
+Allowed future language after implementation and validation:
+
+> KORA reduced measured local model invocations by X% in a runtime-integrated local model validation workload.
+
+Not allowed from this design alone:
+
+- KORA reduces production AI costs
+- KORA reduces real API costs
+- KORA is production-proven
+- KORA reduces energy consumption
+- KORA is validated across broad workloads
+
+This design does not create production cost reduction proof, real API-cost reduction proof, production benchmark proof, full runtime-integrated benchmark evidence, broad workload superiority proof, or energy reduction evidence.
+
+## Implementation Phases
+
+### Phase 1: Design Doc And Configuration Contract
+
+Define the adapter pathway, configuration principles, privacy policy, failure handling, and claim boundary.
+
+### Phase 2: Adapter Selection Interface
+
+Add a small adapter selection boundary that can choose blocked mode, deterministic local validation mode, or a future local runtime adapter.
+
+### Phase 3: Local Runtime Adapter Skeleton With Blocked Behavior
+
+Add a local runtime adapter skeleton that fails closed unless explicitly configured. This phase should still require no local runtime for tests.
+
+### Phase 4: Ollama Or llama.cpp Adapter Behind Explicit Opt-In
+
+Implement one local runtime adapter behind explicit opt-in. The adapter should be skipped or blocked by default in CI unless the runtime is configured.
+
+### Phase 5: Customer-Support Triage Local Model Validation
+
+Run the existing synthetic customer-support triage workload through the local runtime adapter and emit the same aggregate counters and Markdown report structure.
+
+### Phase 6: Claim Review And Docs Update
+
+Review measured counters, privacy handling, reproducibility, and claim language before updating public docs.
+
+## Open Questions
+
+- Which local runtime should be supported first?
+- Should the first adapter use HTTP, subprocess execution, or both?
+- How should token counts be normalized across local runtimes?
+- What timeout defaults are appropriate for reviewer runs and CI?
+- What semantic validation strategy should be used for local model outputs?
+- Where should optional reviewed artifacts live, and what should stay local only?

--- a/docs/benchmarks/local-validation-reviewer-packet.md
+++ b/docs/benchmarks/local-validation-reviewer-packet.md
@@ -147,3 +147,5 @@ Not allowed:
 ## Next Validation Step
 
 The next step after this packet is a local model adapter or remote provider adapter using the same reporting structure, while preserving privacy and claim boundaries.
+
+See the [local model adapter design](local-model-adapter-design.md) for the next local runtime pathway after local/no-network validation.

--- a/docs/benchmarks/real-model-call-validation-design.md
+++ b/docs/benchmarks/real-model-call-validation-design.md
@@ -84,6 +84,8 @@ This mode preserves the current alpha claim boundary. It should not be described
 
 Local model-call mode should run through a local runtime or local provider abstraction, such as Ollama, llama.cpp, vLLM, or a repo-supported local adapter if one is added later.
 
+See the [local model adapter design](local-model-adapter-design.md) for the provider-neutral local runtime pathway and configuration principles.
+
 Properties:
 
 - records measured local model invocation count
@@ -414,6 +416,8 @@ The interface should report:
 ### Phase 3: Local Model-Call Mode
 
 Add local model-call execution with a local runtime or local adapter abstraction.
+
+Use the [local model adapter design](local-model-adapter-design.md) as the configuration and adapter-boundary contract for this phase.
 
 This phase should not require remote provider credentials and should not commit raw model responses.
 


### PR DESCRIPTION
## Summary
- Add a local model adapter design doc for future Ollama, llama.cpp, vLLM, or other local runtime adapters
- Define the provider-neutral ModelCallAdapter boundary for local runtime validation
- Document safe local runtime modes, configuration principles, counters, privacy/artifact handling, failure handling, and claim boundaries
- Link the design from README, docs index, real model-call validation design, and local validation reviewer packet

## Validation
- git diff --check
- python3 -m pytest
- python3 -m kora --help
- python3 -m kora examples list
- python3 -m kora run real_model_call_validation_fake -- --offline
- python3 -m kora run customer_support_triage_fake_validation -- --offline
- python3 -m kora run customer_support_triage_fake_validation -- --offline --report-md /tmp/kora_customer_support_validation.md
- python3 -m kora run direct_vs_kora -- --offline
- python3 -m kora run runtime_integrated_benchmark -- --offline

## Safety
- Documentation-only change
- No code constants added
- No real local runtime calls implemented
- No Ollama, llama.cpp, vLLM, OpenAI, Anthropic, or remote provider dependencies added
- No generated report artifacts committed
- No secrets, private data, raw provider responses, or unsupported production/API-cost/energy claims added