### PR TITLE
Add model-call adapter selection skeleton

### DIFF
--- a/docs/benchmarks/local-model-adapter-design.md
+++ b/docs/benchmarks/local-model-adapter-design.md
@@ -110,6 +110,27 @@ Potential future environment variable names:
 
 These names are design placeholders only. They are not active requirements unless implemented in a later task.
 
+## Adapter Selection Skeleton
+
+KORA now includes a small adapter selection skeleton for local validation and future local runtime work.
+
+Current supported adapter kinds:
+
+- `local_validation`: returns the deterministic local validation adapter used by local/no-network examples.
+- `blocked`: returns a fail-closed adapter for unconfigured model-call paths.
+- `local_runtime_placeholder`: returns fail-closed behavior and documents that local runtime adapters are design-only for now.
+
+The `local_runtime_placeholder` adapter kind does not call Ollama, llama.cpp, vLLM, remote providers, local HTTP endpoints, or subprocess runtimes. It exists so future adapters can plug into the same selection path without changing the validation examples or claim boundaries.
+
+Future adapter kinds should keep the same behavior shape:
+
+- explicit adapter selection
+- clear provider/runtime label
+- clear model label
+- measured counters where available
+- fail-closed behavior when unconfigured
+- no silent fallback to remote providers
+
 ## Counters To Measure
 
 Future local model adapters should record:

--- a/docs/benchmarks/real-model-call-validation-design.md
+++ b/docs/benchmarks/real-model-call-validation-design.md
@@ -254,6 +254,8 @@ Current implementation:
 - `ModelCallAdapter`: protocol for adapters that return measured model-call counters.
 - `DeterministicFakeModelCallAdapter`: deterministic local validation adapter for tests and harness development.
 - `BlockedModelCallAdapter`: fail-closed adapter for cases where real provider use has not been explicitly configured.
+
+The adapter selection skeleton currently supports `local_validation`, `blocked`, and `local_runtime_placeholder` kinds so future local model-call validation can add runtime adapters behind explicit opt-in.
 - `ModelCallSummary`: aggregate counter helper for validation reports.
 
 The deterministic local validation adapter is the only local implementation added at this stage. It requires no credentials, performs no external calls, and records provider/model as `local_validation` / `deterministic-local`.

--- a/examples/customer_support_triage_fake_validation/run.py
+++ b/examples/customer_support_triage_fake_validation/run.py
@@ -9,9 +9,11 @@ from typing import Any
 
 from kora.model_call import (
     DeterministicFakeModelCallAdapter,
+    LOCAL_VALIDATION_ADAPTER,
     ModelCallRequest,
     ModelCallResponse,
     ModelCallSummary,
+    select_model_call_adapter,
 )
 from kora.validation_report import render_local_validation_markdown
 
@@ -144,8 +146,8 @@ def build_customer_support_triage_fake_validation_summary(
 
     workload = load_workload(workload_path)
     requests = _requests(workload)
-    baseline_adapter = DeterministicFakeModelCallAdapter()
-    kora_adapter = DeterministicFakeModelCallAdapter()
+    baseline_adapter = select_model_call_adapter(LOCAL_VALIDATION_ADAPTER)
+    kora_adapter = select_model_call_adapter(LOCAL_VALIDATION_ADAPTER)
 
     baseline_responses = _run_direct_baseline(requests, baseline_adapter)
     (

--- a/examples/real_model_call_validation_fake/run.py
+++ b/examples/real_model_call_validation_fake/run.py
@@ -15,9 +15,11 @@ from typing import Any, Literal
 
 from kora.model_call import (
     DeterministicFakeModelCallAdapter,
+    LOCAL_VALIDATION_ADAPTER,
     ModelCallRequest,
     ModelCallResponse,
     ModelCallSummary,
+    select_model_call_adapter,
 )
 from kora.validation_report import render_local_validation_markdown
 
@@ -176,8 +178,8 @@ def build_fake_model_call_validation_summary(
     if not offline:
         raise ValueError("real_model_call_validation_fake supports --offline only")
 
-    baseline_adapter = DeterministicFakeModelCallAdapter()
-    kora_adapter = DeterministicFakeModelCallAdapter()
+    baseline_adapter = select_model_call_adapter(LOCAL_VALIDATION_ADAPTER)
+    kora_adapter = select_model_call_adapter(LOCAL_VALIDATION_ADAPTER)
 
     baseline_responses = _run_direct_baseline(workload, baseline_adapter)
     (

--- a/kora/model_call.py
+++ b/kora/model_call.py
@@ -6,6 +6,16 @@ import time
 from dataclasses import dataclass, field
 from typing import Any, Protocol
 
+LOCAL_VALIDATION_ADAPTER = "local_validation"
+BLOCKED_ADAPTER = "blocked"
+LOCAL_RUNTIME_PLACEHOLDER_ADAPTER = "local_runtime_placeholder"
+
+SUPPORTED_MODEL_CALL_ADAPTERS = (
+    LOCAL_VALIDATION_ADAPTER,
+    BLOCKED_ADAPTER,
+    LOCAL_RUNTIME_PLACEHOLDER_ADAPTER,
+)
+
 
 def _estimate_tokens(text: str) -> int:
     """Return a stable, conservative token estimate for local validation."""
@@ -47,7 +57,7 @@ class ModelCallAdapter(Protocol):
 class DeterministicFakeModelCallAdapter:
     """Local no-network adapter for deterministic validation tests."""
 
-    provider = "local_validation"
+    provider = LOCAL_VALIDATION_ADAPTER
     model = "deterministic-local"
 
     def call(self, request: ModelCallRequest) -> ModelCallResponse:
@@ -75,12 +85,44 @@ class DeterministicFakeModelCallAdapter:
 class BlockedModelCallAdapter:
     """Adapter that fails closed when real provider use is not configured."""
 
-    def call(self, request: ModelCallRequest) -> ModelCallResponse:
-        del request
-        raise RuntimeError(
+    def __init__(self, message: str | None = None) -> None:
+        self.message = message or (
             "Real model-call adapter is not configured. Use an explicit local "
             "or remote adapter in a validation harness."
         )
+
+    def call(self, request: ModelCallRequest) -> ModelCallResponse:
+        del request
+        raise RuntimeError(self.message)
+
+
+def available_model_call_adapters() -> list[str]:
+    """Return adapter kind labels supported by the selector."""
+
+    return list(SUPPORTED_MODEL_CALL_ADAPTERS)
+
+
+def select_model_call_adapter(kind: str | None = None) -> ModelCallAdapter:
+    """Select a provider-neutral model-call adapter by kind.
+
+    The current implemented runtime path is local no-network validation. Local
+    runtime adapters are intentionally fail-closed until explicitly implemented.
+    """
+
+    selected_kind = kind or LOCAL_VALIDATION_ADAPTER
+    if selected_kind == LOCAL_VALIDATION_ADAPTER:
+        return DeterministicFakeModelCallAdapter()
+    if selected_kind == BLOCKED_ADAPTER:
+        return BlockedModelCallAdapter()
+    if selected_kind == LOCAL_RUNTIME_PLACEHOLDER_ADAPTER:
+        return BlockedModelCallAdapter(
+            "Local runtime adapters are design-only and not implemented yet. "
+            "Use local_validation for local no-network validation; no provider "
+            "calls are attempted."
+        )
+
+    supported = ", ".join(SUPPORTED_MODEL_CALL_ADAPTERS)
+    raise ValueError(f"Unsupported model-call adapter kind {selected_kind!r}. Supported: {supported}")
 
 
 @dataclass(frozen=True)

--- a/tests/test_model_call.py
+++ b/tests/test_model_call.py
@@ -3,10 +3,15 @@ import os
 import pytest
 
 from kora.model_call import (
+    BLOCKED_ADAPTER,
     BlockedModelCallAdapter,
     DeterministicFakeModelCallAdapter,
+    LOCAL_RUNTIME_PLACEHOLDER_ADAPTER,
+    LOCAL_VALIDATION_ADAPTER,
     ModelCallRequest,
     ModelCallSummary,
+    available_model_call_adapters,
+    select_model_call_adapter,
 )
 
 
@@ -115,3 +120,67 @@ def test_blocked_adapter_fails_closed() -> None:
 
     with pytest.raises(RuntimeError, match="Real model-call adapter is not configured"):
         adapter.call(ModelCallRequest(request_id="req-9", prompt="blocked"))
+
+
+def test_select_model_call_adapter_defaults_to_local_validation() -> None:
+    adapter = select_model_call_adapter()
+
+    assert isinstance(adapter, DeterministicFakeModelCallAdapter)
+
+
+def test_select_model_call_adapter_returns_local_validation_adapter() -> None:
+    adapter = select_model_call_adapter(LOCAL_VALIDATION_ADAPTER)
+
+    assert isinstance(adapter, DeterministicFakeModelCallAdapter)
+    response = adapter.call(ModelCallRequest(request_id="req-10", prompt="local validation"))
+    assert response.provider == "local_validation"
+    assert response.model == "deterministic-local"
+
+
+def test_select_model_call_adapter_returns_blocked_adapter() -> None:
+    adapter = select_model_call_adapter(BLOCKED_ADAPTER)
+
+    assert isinstance(adapter, BlockedModelCallAdapter)
+    with pytest.raises(RuntimeError, match="Real model-call adapter is not configured"):
+        adapter.call(ModelCallRequest(request_id="req-11", prompt="blocked"))
+
+
+def test_select_model_call_adapter_local_runtime_placeholder_fails_closed() -> None:
+    adapter = select_model_call_adapter(LOCAL_RUNTIME_PLACEHOLDER_ADAPTER)
+
+    assert isinstance(adapter, BlockedModelCallAdapter)
+    with pytest.raises(RuntimeError, match="Local runtime adapters are design-only"):
+        adapter.call(ModelCallRequest(request_id="req-12", prompt="placeholder"))
+
+
+def test_select_model_call_adapter_unknown_kind_raises_value_error() -> None:
+    with pytest.raises(ValueError, match="Unsupported model-call adapter kind"):
+        select_model_call_adapter("remote_provider")
+
+
+def test_available_model_call_adapters_lists_safe_kinds() -> None:
+    adapters = available_model_call_adapters()
+
+    assert LOCAL_VALIDATION_ADAPTER in adapters
+    assert BLOCKED_ADAPTER in adapters
+    assert LOCAL_RUNTIME_PLACEHOLDER_ADAPTER in adapters
+
+
+def test_select_model_call_adapter_requires_no_secrets_or_local_runtime(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    monkeypatch.delenv("KORA_LOCAL_MODEL_RUNTIME", raising=False)
+    monkeypatch.delenv("KORA_LOCAL_MODEL_ENDPOINT", raising=False)
+    monkeypatch.delenv("KORA_LOCAL_MODEL_NAME", raising=False)
+
+    adapter = select_model_call_adapter(LOCAL_VALIDATION_ADAPTER)
+    response = adapter.call(ModelCallRequest(request_id="req-13", prompt="no runtime"))
+
+    assert response.model_calls == 1
+    assert "OPENAI_API_KEY" not in os.environ
+    assert "ANTHROPIC_API_KEY" not in os.environ
+    assert "KORA_LOCAL_MODEL_RUNTIME" not in os.environ
+    assert "KORA_LOCAL_MODEL_ENDPOINT" not in os.environ
+    assert "KORA_LOCAL_MODEL_NAME" not in os.environ


### PR DESCRIPTION
## Summary
- Add a model-call adapter selection skeleton for provider-neutral validation
- Support local_validation, blocked, and local_runtime_placeholder adapter kinds
- Keep local runtime placeholder fail-closed with no runtime or provider calls
- Route local/no-network validation examples through the selector while preserving commands and JSON labels
- Add tests for selector behavior, supported kinds, blocked placeholder behavior, and secret-free execution
- Update local model adapter design docs and real model-call validation design docs

## Validation
- git diff --check
- python3 -m pytest
- python3 -m kora --help
- python3 -m kora examples list
- python3 -m kora run real_model_call_validation_fake -- --offline
- python3 -m kora run customer_support_triage_fake_validation -- --offline
- python3 -m kora run customer_support_triage_fake_validation -- --offline --report-md /tmp/kora_customer_support_validation.md
- python3 -m kora run direct_vs_kora -- --offline
- python3 -m kora run runtime_integrated_benchmark -- --offline

## Safety
- No real local runtime calls implemented
- No provider dependencies added
- No generated report artifacts committed
- No secrets, private data, raw provider responses, or unsupported production/API-cost/energy claims added