### PR TITLE
Add blocked local runtime adapter skeleton

### DIFF
--- a/docs/benchmarks/local-model-adapter-design.md
+++ b/docs/benchmarks/local-model-adapter-design.md
@@ -122,6 +122,21 @@ Current supported adapter kinds:
 
 The `local_runtime_placeholder` adapter kind does not call Ollama, llama.cpp, vLLM, remote providers, local HTTP endpoints, or subprocess runtimes. It exists so future adapters can plug into the same selection path without changing the validation examples or claim boundaries.
 
+## Blocked Local Runtime Adapter Skeleton
+
+KORA includes an explicit blocked local runtime adapter skeleton for the `local_runtime_placeholder` kind.
+
+The skeleton reserves the future local runtime adapter boundary while failing closed by design. It:
+
+- accepts an inert local runtime configuration object for future runtime, model, endpoint, command, timeout, and metadata fields
+- does not read environment variables automatically
+- does not validate configuration by contacting a runtime
+- does not call Ollama, llama.cpp, vLLM, local HTTP endpoints, subprocess runtimes, or remote providers
+- does not require any local runtime installation for tests or examples
+- raises a clear error stating that local runtime adapters are not implemented yet and that no provider call was attempted
+
+Current runnable validation remains local/no-network validation through the deterministic local validation adapter. Future local runtime work can replace the fail-closed placeholder with a concrete adapter behind explicit opt-in.
+
 Future adapter kinds should keep the same behavior shape:
 
 - explicit adapter selection

--- a/docs/benchmarks/local-validation-reviewer-packet.md
+++ b/docs/benchmarks/local-validation-reviewer-packet.md
@@ -148,4 +148,6 @@ Not allowed:
 
 The next step after this packet is a local model adapter or remote provider adapter using the same reporting structure, while preserving privacy and claim boundaries.
 
+The reviewer packet commands still use local/no-network validation. Local runtime adapters remain design-only and fail-closed until a concrete adapter is implemented and validated.
+
 See the [local model adapter design](local-model-adapter-design.md) for the next local runtime pathway after local/no-network validation.

--- a/docs/benchmarks/real-model-call-validation-design.md
+++ b/docs/benchmarks/real-model-call-validation-design.md
@@ -254,9 +254,10 @@ Current implementation:
 - `ModelCallAdapter`: protocol for adapters that return measured model-call counters.
 - `DeterministicFakeModelCallAdapter`: deterministic local validation adapter for tests and harness development.
 - `BlockedModelCallAdapter`: fail-closed adapter for cases where real provider use has not been explicitly configured.
+- `ModelCallSummary`: aggregate counter helper for validation reports.
 
 The adapter selection skeleton currently supports `local_validation`, `blocked`, and `local_runtime_placeholder` kinds so future local model-call validation can add runtime adapters behind explicit opt-in.
-- `ModelCallSummary`: aggregate counter helper for validation reports.
+The `local_runtime_placeholder` kind is fail-closed until a concrete local runtime adapter is implemented and validated.
 
 The deterministic local validation adapter is the only local implementation added at this stage. It requires no credentials, performs no external calls, and records provider/model as `local_validation` / `deterministic-local`.
 

--- a/kora/model_call.py
+++ b/kora/model_call.py
@@ -9,6 +9,7 @@ from typing import Any, Protocol
 LOCAL_VALIDATION_ADAPTER = "local_validation"
 BLOCKED_ADAPTER = "blocked"
 LOCAL_RUNTIME_PLACEHOLDER_ADAPTER = "local_runtime_placeholder"
+LOCAL_RUNTIME_NOT_CONFIGURED_MODEL = "local-runtime-not-configured"
 
 SUPPORTED_MODEL_CALL_ADAPTERS = (
     LOCAL_VALIDATION_ADAPTER,
@@ -44,6 +45,18 @@ class ModelCallResponse:
     output_tokens: int | None
     provider: str | None
     model: str | None
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class LocalRuntimeAdapterConfig:
+    """Inert future local runtime configuration for fail-closed adapters."""
+
+    runtime: str = ""
+    model: str | None = None
+    endpoint: str | None = None
+    command: str | None = None
+    timeout_s: float | None = None
     metadata: dict[str, Any] = field(default_factory=dict)
 
 
@@ -96,6 +109,28 @@ class BlockedModelCallAdapter:
         raise RuntimeError(self.message)
 
 
+class BlockedLocalRuntimeModelCallAdapter:
+    """Fail-closed skeleton for future local runtime adapters."""
+
+    provider = LOCAL_RUNTIME_PLACEHOLDER_ADAPTER
+    model = LOCAL_RUNTIME_NOT_CONFIGURED_MODEL
+
+    def __init__(
+        self,
+        config: LocalRuntimeAdapterConfig | None = None,
+        message: str | None = None,
+    ) -> None:
+        self.config = config or LocalRuntimeAdapterConfig()
+        self.message = message or (
+            "Local runtime adapters are not implemented yet. No provider call "
+            "was attempted. Use local_validation for local/no-network validation."
+        )
+
+    def call(self, request: ModelCallRequest) -> ModelCallResponse:
+        del request
+        raise RuntimeError(self.message)
+
+
 def available_model_call_adapters() -> list[str]:
     """Return adapter kind labels supported by the selector."""
 
@@ -115,11 +150,7 @@ def select_model_call_adapter(kind: str | None = None) -> ModelCallAdapter:
     if selected_kind == BLOCKED_ADAPTER:
         return BlockedModelCallAdapter()
     if selected_kind == LOCAL_RUNTIME_PLACEHOLDER_ADAPTER:
-        return BlockedModelCallAdapter(
-            "Local runtime adapters are design-only and not implemented yet. "
-            "Use local_validation for local no-network validation; no provider "
-            "calls are attempted."
-        )
+        return BlockedLocalRuntimeModelCallAdapter()
 
     supported = ", ".join(SUPPORTED_MODEL_CALL_ADAPTERS)
     raise ValueError(f"Unsupported model-call adapter kind {selected_kind!r}. Supported: {supported}")

--- a/tests/test_model_call.py
+++ b/tests/test_model_call.py
@@ -4,10 +4,12 @@ import pytest
 
 from kora.model_call import (
     BLOCKED_ADAPTER,
+    BlockedLocalRuntimeModelCallAdapter,
     BlockedModelCallAdapter,
     DeterministicFakeModelCallAdapter,
     LOCAL_RUNTIME_PLACEHOLDER_ADAPTER,
     LOCAL_VALIDATION_ADAPTER,
+    LocalRuntimeAdapterConfig,
     ModelCallRequest,
     ModelCallSummary,
     available_model_call_adapters,
@@ -122,6 +124,58 @@ def test_blocked_adapter_fails_closed() -> None:
         adapter.call(ModelCallRequest(request_id="req-9", prompt="blocked"))
 
 
+def test_local_runtime_config_can_be_created_with_defaults() -> None:
+    config = LocalRuntimeAdapterConfig()
+
+    assert config.runtime == ""
+    assert config.model is None
+    assert config.endpoint is None
+    assert config.command is None
+    assert config.timeout_s is None
+    assert config.metadata == {}
+
+
+def test_local_runtime_config_metadata_default_is_not_shared() -> None:
+    first = LocalRuntimeAdapterConfig()
+    second = LocalRuntimeAdapterConfig()
+
+    first.metadata["runtime"] = "example"
+
+    assert second.metadata == {}
+
+
+def test_blocked_local_runtime_adapter_fails_closed_without_prompt_leak() -> None:
+    adapter = BlockedLocalRuntimeModelCallAdapter()
+    raw_prompt = "do not include this raw synthetic prompt"
+
+    with pytest.raises(RuntimeError) as exc_info:
+        adapter.call(ModelCallRequest(request_id="req-local-runtime", prompt=raw_prompt))
+
+    message = str(exc_info.value)
+    assert "Local runtime adapters are not implemented yet" in message
+    assert "No provider call was attempted" in message
+    assert "local_validation" in message
+    assert raw_prompt not in message
+
+
+def test_blocked_local_runtime_adapter_accepts_inert_config() -> None:
+    config = LocalRuntimeAdapterConfig(
+        runtime="ollama",
+        model="example-local-model",
+        endpoint="http://127.0.0.1:11434",
+        command="example-local-runtime",
+        timeout_s=5.0,
+        metadata={"purpose": "test-only placeholder"},
+    )
+    adapter = BlockedLocalRuntimeModelCallAdapter(config=config)
+
+    assert adapter.config == config
+    assert adapter.provider == LOCAL_RUNTIME_PLACEHOLDER_ADAPTER
+    assert adapter.model == "local-runtime-not-configured"
+    with pytest.raises(RuntimeError, match="No provider call was attempted"):
+        adapter.call(ModelCallRequest(request_id="req-local-runtime-config", prompt="blocked"))
+
+
 def test_select_model_call_adapter_defaults_to_local_validation() -> None:
     adapter = select_model_call_adapter()
 
@@ -148,8 +202,8 @@ def test_select_model_call_adapter_returns_blocked_adapter() -> None:
 def test_select_model_call_adapter_local_runtime_placeholder_fails_closed() -> None:
     adapter = select_model_call_adapter(LOCAL_RUNTIME_PLACEHOLDER_ADAPTER)
 
-    assert isinstance(adapter, BlockedModelCallAdapter)
-    with pytest.raises(RuntimeError, match="Local runtime adapters are design-only"):
+    assert isinstance(adapter, BlockedLocalRuntimeModelCallAdapter)
+    with pytest.raises(RuntimeError, match="Local runtime adapters are not implemented yet"):
         adapter.call(ModelCallRequest(request_id="req-12", prompt="placeholder"))
 
 
@@ -179,6 +233,25 @@ def test_select_model_call_adapter_requires_no_secrets_or_local_runtime(
     response = adapter.call(ModelCallRequest(request_id="req-13", prompt="no runtime"))
 
     assert response.model_calls == 1
+    assert "OPENAI_API_KEY" not in os.environ
+    assert "ANTHROPIC_API_KEY" not in os.environ
+    assert "KORA_LOCAL_MODEL_RUNTIME" not in os.environ
+    assert "KORA_LOCAL_MODEL_ENDPOINT" not in os.environ
+    assert "KORA_LOCAL_MODEL_NAME" not in os.environ
+
+
+def test_local_runtime_placeholder_requires_no_secrets_or_local_runtime(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    monkeypatch.delenv("KORA_LOCAL_MODEL_RUNTIME", raising=False)
+    monkeypatch.delenv("KORA_LOCAL_MODEL_ENDPOINT", raising=False)
+    monkeypatch.delenv("KORA_LOCAL_MODEL_NAME", raising=False)
+
+    adapter = select_model_call_adapter(LOCAL_RUNTIME_PLACEHOLDER_ADAPTER)
+
+    assert isinstance(adapter, BlockedLocalRuntimeModelCallAdapter)
     assert "OPENAI_API_KEY" not in os.environ
     assert "ANTHROPIC_API_KEY" not in os.environ
     assert "KORA_LOCAL_MODEL_RUNTIME" not in os.environ


### PR DESCRIPTION
## Summary
- add an explicit blocked local runtime adapter skeleton and inert local runtime config placeholder
- wire local_runtime_placeholder through the selector to fail closed with a clear no-provider-call message
- add tests for config defaults, prompt non-leakage, selector behavior, and no env/runtime requirements
- update local model validation docs with the fail-closed skeleton boundary

## Validation
- git diff --check
- python3 -m pytest
- python3 -m kora --help
- python3 -m kora examples list
- python3 -m kora run real_model_call_validation_fake -- --offline
- python3 -m kora run customer_support_triage_fake_validation -- --offline
- python3 -m kora run customer_support_triage_fake_validation -- --offline --report-md /tmp/kora_customer_support_validation.md
- python3 -m kora run direct_vs_kora -- --offline
- python3 -m kora run runtime_integrated_benchmark -- --offline

## Claim safety
- no real local runtime calls implemented
- no HTTP, subprocess, remote provider, Ollama, llama.cpp, vLLM, OpenAI, or Anthropic dependencies added
- no secrets required
- no raw benchmark artifacts or generated report artifacts committed
- no production cost-reduction, real API-cost reduction, production validation, or energy-reduction claims added