### PR TITLE
Add KORA validation workstream EOD handoff

### DIFF
--- a/docs/context/KORA_NEXT_CHATGPT_SOD_PROMPT.md
+++ b/docs/context/KORA_NEXT_CHATGPT_SOD_PROMPT.md
@@ -1,0 +1,64 @@
+# KORA Next ChatGPT SOD Prompt
+
+You are helping plan the next KORA public repository task.
+
+Public repository: https://github.com/Krako-Labs/KORA
+
+Current public truth: `origin/main`
+
+Current public HEAD: `7657ddb6ad153ea28c222a4b13b8cefc5d7f54d3`
+
+Active clean repo path: `/Users/albertkim/02_PROJECTS/05_KORA_Project/repo/KORA`
+
+Private internals repo path: `/Users/albertkim/02_PROJECTS/05_KORA_Project/repo/internals`
+
+Treat the private internals repo as a private operational source only. Do not move internal operations content into public docs.
+
+## Completed state
+
+KORA now has:
+
+- README PNG diagram system with SVG sources preserved.
+- Real model-call validation design docs.
+- Provider-neutral model-call adapter interface.
+- Deterministic local validation adapter.
+- Blocked adapter.
+- Model-call summary helper.
+- Local/no-network validation examples.
+- Customer-support triage synthetic workload spec.
+- Customer-support triage local validation path.
+- Markdown validation report generator.
+- Reviewer-facing local validation packet.
+- Local model adapter design.
+- Adapter selection skeleton.
+- Blocked local runtime adapter skeleton.
+
+## Safe public claim
+
+KORA reduced model invocations by 80% in a reproducible deterministic-heavy benchmark workload.
+
+## Local/no-network validation wording
+
+KORA's local no-network validation examples show that KORA can measure avoided model-call events in synthetic workloads.
+
+## Non-claims
+
+- No production cost reduction proof.
+- No real API-cost reduction proof.
+- No production benchmark proof.
+- No full runtime-integrated real-provider benchmark evidence.
+- No broad workload superiority proof.
+- No energy reduction evidence.
+- No formal government validation.
+- No signed partner validation unless actually signed and documented.
+- No guaranteed adoption or funding.
+
+## Recommended task candidates
+
+1. Implement an explicit adapter-selection CLI option.
+2. Design the first concrete local runtime adapter behind explicit opt-in.
+3. Polish the local validation reviewer packet/report flow.
+4. Add a real provider adapter design doc only.
+5. Clean up old worktrees after explicit approval.
+
+Propose one Codex task at a time. Keep the task public-safe, claim-safe, and scoped to the next concrete step.

--- a/docs/context/KORA_NEXT_CODEX_SOD_PROMPT.md
+++ b/docs/context/KORA_NEXT_CODEX_SOD_PROMPT.md
@@ -1,0 +1,73 @@
+# KORA Next Codex SOD Prompt
+
+Task ###
+
+You are working on the KORA public repo.
+
+Public repository: https://github.com/Krako-Labs/KORA
+
+Current public truth: `origin/main`
+
+Current public HEAD: `7657ddb6ad153ea28c222a4b13b8cefc5d7f54d3`
+
+Active clean KORA repo:
+`/Users/albertkim/02_PROJECTS/05_KORA_Project/repo/KORA`
+
+KORA worktree root:
+`/Users/albertkim/02_PROJECTS/05_KORA_Project/worktrees/`
+
+Private internals repo:
+`/Users/albertkim/02_PROJECTS/05_KORA_Project/repo/internals`
+
+Legacy/dirty repo, do not use:
+`/Users/albertkim/02_PROJECTS/05_KORA`
+
+GitHub CLI identity:
+`hkalbertkim`
+
+Before any PR or merge operation, run:
+
+```bash
+gh auth status
+```
+
+The active GitHub CLI identity must be `hkalbertkim`. If another account is active, stop and report.
+
+## Public/private split
+
+Public KORA docs must remain public-safe. Do not expose private internals content, private operations, credentials, personal data, raw provider responses, or proprietary datasets.
+
+Do not create releases, tags, release assets, raw benchmark uploads, package version changes, GitHub issues, project boards, repository settings changes, or collaborator changes unless explicitly requested.
+
+## Current validation commands
+
+```bash
+git diff --check
+python3 -m pytest
+python3 -m kora --help
+python3 -m kora examples list
+python3 -m kora run real_model_call_validation_fake -- --offline
+python3 -m kora run customer_support_triage_fake_validation -- --offline
+python3 -m kora run customer_support_triage_fake_validation -- --offline --report-md /tmp/kora_customer_support_validation.md
+python3 -m kora run direct_vs_kora -- --offline
+python3 -m kora run runtime_integrated_benchmark -- --offline
+```
+
+## Suggested next task
+
+Implement an explicit adapter-selection CLI option for local validation examples.
+
+Constraints:
+
+- Keep default behavior unchanged.
+- Keep current local/no-network validation labels.
+- Allow only safe adapter kinds currently supported by `available_model_call_adapters()`.
+- Ensure `local_runtime_placeholder` remains fail-closed and does not attempt network, HTTP, subprocess, provider, or local runtime calls.
+- Do not add provider dependencies.
+- Do not add unsupported production cost-reduction, real API-cost reduction, production benchmark, or energy-reduction claims.
+
+The final completion report must start and end with:
+
+```text
+Task ### Implemented
+```

--- a/docs/eod/kora_eod_2026_05_09_validation_workstream.md
+++ b/docs/eod/kora_eod_2026_05_09_validation_workstream.md
@@ -1,0 +1,166 @@
+# KORA EOD Report — Validation Workstream
+
+## Date
+
+2026-05-09
+
+## Public repo
+
+https://github.com/Krako-Labs/KORA
+
+## Public HEAD
+
+`7657ddb6ad153ea28c222a4b13b8cefc5d7f54d3`
+
+## Private internals repo
+
+https://github.com/Krako-Labs/internals
+
+## Internals HEAD
+
+`869216eb7dd34bf8f50750d2348f3d6508e5108b`
+
+## GitHub CLI identity
+
+`gh auth status` confirmed the active GitHub CLI account as `hkalbertkim`.
+
+## Summary
+
+The validation workstream moved KORA from deterministic-heavy alpha benchmark evidence toward a safer, reviewer-facing validation path for measured model-call routing. The public repository now includes local/no-network validation examples, customer-support triage synthetic workload materials, Markdown validation reports, a reviewer packet, local model adapter design, adapter selection, and a blocked local runtime adapter skeleton.
+
+This work remains claim-safe. It does not implement real provider calls, real local runtime calls, production validation, or real API-cost evidence.
+
+## Completed public PRs/tasks
+
+- Public/private messaging split and claim boundary cleanup.
+- README image system finalized with PNG displayed diagrams and preserved SVG sources.
+- Real model-call validation design docs added.
+- Provider-neutral model-call adapter interface added.
+- Deterministic local validation adapter added.
+- Blocked adapter added.
+- Model-call summary helper added.
+- Local/no-network validation examples added.
+- Customer-support triage synthetic workload spec added.
+- Customer-support triage local validation path added.
+- Markdown validation report generator added.
+- Reviewer-facing local validation packet added.
+- Local model adapter design added.
+- Adapter selection skeleton added.
+- Blocked local runtime adapter skeleton added.
+
+## Completed private internals work
+
+- Internals repository structure and detailed internal operations docs were added.
+- Internal claim tracker was updated for the real model-call validation workstream.
+- Internal messaging notes now preserve the public/private boundary.
+
+## Current public README/image state
+
+The README displays PNG diagrams:
+
+- `docs/assets/kora-execution-control-overview.png`
+- `docs/assets/kora-benchmark-evidence-card.png`
+- `docs/assets/kora-validation-roadmap.png`
+- `docs/assets/kora-help-test-flow.png`
+
+SVG source/reference files remain preserved in `docs/assets/`.
+
+## Current validation capability
+
+KORA can run local/no-network validation examples that measure avoided model-call events in synthetic workloads:
+
+- `python3 -m kora run real_model_call_validation_fake -- --offline`
+- `python3 -m kora run customer_support_triage_fake_validation -- --offline`
+
+Customer-support local validation counters:
+
+- `total_requests`: 12
+- `baseline_model_calls`: 12
+- `kora_model_calls`: 4
+- `avoided_model_calls`: 8
+- `avoided_model_call_rate`: 0.6667
+- `deterministic_routes`: 8
+- `model_escalations`: 4
+
+## Current adapter capability
+
+The model-call adapter layer includes:
+
+- `ModelCallRequest`
+- `ModelCallResponse`
+- `ModelCallAdapter`
+- deterministic local validation adapter
+- blocked adapter
+- model-call summary helper
+- adapter selection for `local_validation`, `blocked`, and `local_runtime_placeholder`
+- blocked local runtime adapter skeleton for future local runtime work
+
+The blocked local runtime adapter skeleton fails closed and does not call Ollama, llama.cpp, vLLM, HTTP endpoints, subprocess runtimes, remote providers, or other external runtimes.
+
+## Current reviewer packet/report capability
+
+KORA can generate local Markdown validation reports from aggregate counters:
+
+```bash
+python3 -m kora run customer_support_triage_fake_validation -- --offline --report-md /tmp/kora_customer_support_validation.md
+python3 -m kora run real_model_call_validation_fake -- --offline --report-md /tmp/kora_local_validation.md
+```
+
+Reviewer guidance is available at:
+
+- `docs/benchmarks/local-validation-reviewer-packet.md`
+- `docs/benchmarks/real-model-call-validation-report-template.md`
+
+Generated reports should remain local unless intentionally reviewed. They should not include secrets, raw provider responses, private data, or production data.
+
+## Current safe public claim
+
+KORA reduced model invocations by 80% in a reproducible deterministic-heavy benchmark workload.
+
+## Explicit non-claims
+
+- No production cost reduction proof.
+- No real API-cost reduction proof.
+- No production benchmark proof.
+- No full runtime-integrated real-provider benchmark evidence.
+- No broad workload superiority proof.
+- No energy reduction evidence.
+- No formal government validation.
+- No signed partner validation unless actually signed and documented.
+- No guaranteed adoption or funding.
+
+## Validation commands
+
+```bash
+python3 -m pytest
+python3 -m kora --help
+python3 -m kora examples list
+python3 -m kora run real_model_call_validation_fake -- --offline
+python3 -m kora run customer_support_triage_fake_validation -- --offline
+python3 -m kora run customer_support_triage_fake_validation -- --offline --report-md /tmp/kora_customer_support_validation.md
+python3 -m kora run direct_vs_kora -- --offline
+python3 -m kora run runtime_integrated_benchmark -- --offline
+```
+
+## Remaining TODOs
+
+- Krako 2.0: TBD.
+- Canonical GitHub Discussions/contact route TODO.
+- Decide next technical path:
+  1. explicit adapter-selection CLI option
+  2. first concrete local runtime adapter behind explicit opt-in
+  3. local validation report packet polish
+  4. real provider adapter design only
+  5. cleanup old worktrees after explicit approval
+
+## Recommended next technical work
+
+Implement an explicit adapter-selection CLI option for local validation examples, keeping the default local/no-network path unchanged and keeping local runtime placeholders fail-closed.
+
+## Next ChatGPT SOD prompt
+
+Use `docs/context/KORA_NEXT_CHATGPT_SOD_PROMPT.md` as the next planning handoff. Ask for one Codex task at a time and preserve the public claim boundary.
+
+## Next Codex SOD prompt
+
+Use `docs/context/KORA_NEXT_CODEX_SOD_PROMPT.md` as the next implementation handoff. The suggested next task is an explicit adapter-selection CLI option.


### PR DESCRIPTION
## Summary
- add the 2026-05-09 validation workstream EOD report
- add public-safe next-session ChatGPT and Codex SOD handoff prompts
- refresh local-only ChatGPT/Codex context outside the public repo

## Validation
- git diff --check
- python3 -m pytest
- python3 -m kora --help
- python3 -m kora examples list
- python3 -m kora run real_model_call_validation_fake -- --offline
- python3 -m kora run customer_support_triage_fake_validation -- --offline
- python3 -m kora run customer_support_triage_fake_validation -- --offline --report-md /tmp/kora_customer_support_validation.md
- python3 -m kora run direct_vs_kora -- --offline
- python3 -m kora run runtime_integrated_benchmark -- --offline

## Boundary
- no generated validation report artifacts committed
- no local ChatGPT context files committed
- no releases, tags, assets, raw benchmark uploads, package version changes, issues, project boards, settings, or collaborator changes
- no real provider API calls or new claims added