### PR TITLE
Add explicit adapter selection for local validation examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,8 @@ Customer-support triage local validation is available as a no-network example.
 
 Local no-network validation examples can generate Markdown reports with `--report-md`.
 
+Local no-network validation examples support `--adapter local_validation`.
+
 Reviewer packet: [local no-network validation](docs/benchmarks/local-validation-reviewer-packet.md).
 
 Local model adapter design: [provider-neutral local runtime path](docs/benchmarks/local-model-adapter-design.md).

--- a/docs/benchmarks/local-model-adapter-design.md
+++ b/docs/benchmarks/local-model-adapter-design.md
@@ -120,6 +120,8 @@ Current supported adapter kinds:
 - `blocked`: returns a fail-closed adapter for unconfigured model-call paths.
 - `local_runtime_placeholder`: returns fail-closed behavior and documents that local runtime adapters are design-only for now.
 
+The local validation examples expose an explicit `--adapter` option for the current safe adapter kinds. Real local runtime adapters remain unimplemented and fail closed through `local_runtime_placeholder`.
+
 The `local_runtime_placeholder` adapter kind does not call Ollama, llama.cpp, vLLM, remote providers, local HTTP endpoints, or subprocess runtimes. It exists so future adapters can plug into the same selection path without changing the validation examples or claim boundaries.
 
 ## Blocked Local Runtime Adapter Skeleton

--- a/docs/benchmarks/local-validation-reviewer-packet.md
+++ b/docs/benchmarks/local-validation-reviewer-packet.md
@@ -56,6 +56,17 @@ Reports are written only when `--report-md` is provided. Use `/tmp` or another l
 
 Generated reports are not committed by default. They contain aggregate counters and boundary language. They do not contain raw prompts, raw provider responses, secrets, or private data.
 
+## Adapter Selection
+
+The local validation examples default to the `local_validation` adapter.
+
+```bash
+python3 -m kora run real_model_call_validation_fake -- --offline --adapter local_validation
+python3 -m kora run customer_support_triage_fake_validation -- --offline --adapter local_validation
+```
+
+The `blocked` and `local_runtime_placeholder` adapter kinds are fail-closed safety paths. `blocked` represents an unconfigured model-call path. `local_runtime_placeholder` is design-only, makes no runtime calls, and does not contact local HTTP endpoints, subprocess runtimes, remote providers, or provider APIs.
+
 ## Expected Generic Local Validation Counters
 
 For `real_model_call_validation_fake`, expected counters are:

--- a/docs/benchmarks/real-model-call-validation-design.md
+++ b/docs/benchmarks/real-model-call-validation-design.md
@@ -259,6 +259,8 @@ Current implementation:
 The adapter selection skeleton currently supports `local_validation`, `blocked`, and `local_runtime_placeholder` kinds so future local model-call validation can add runtime adapters behind explicit opt-in.
 The `local_runtime_placeholder` kind is fail-closed until a concrete local runtime adapter is implemented and validated.
 
+The local/no-network validation examples expose explicit `--adapter` selection. `local_validation` preserves the current deterministic validation path, while `blocked` and `local_runtime_placeholder` fail closed before validation runs.
+
 The deterministic local validation adapter is the only local implementation added at this stage. It requires no credentials, performs no external calls, and records provider/model as `local_validation` / `deterministic-local`.
 
 Future local or remote provider adapters can plug into the same interface. Remote provider calls must use environment variables for configuration and must not commit secrets, raw prompts, raw responses, private user data, or proprietary datasets.

--- a/examples/customer_support_triage_fake_validation/run.py
+++ b/examples/customer_support_triage_fake_validation/run.py
@@ -13,6 +13,7 @@ from kora.model_call import (
     ModelCallRequest,
     ModelCallResponse,
     ModelCallSummary,
+    available_model_call_adapters,
     select_model_call_adapter,
 )
 from kora.validation_report import render_local_validation_markdown
@@ -39,6 +40,23 @@ def _resolve_workload_path(path: Path) -> Path:
 def load_workload(path: Path = DEFAULT_WORKLOAD) -> dict[str, Any]:
     workload_path = _resolve_workload_path(path)
     return json.loads(workload_path.read_text(encoding="utf-8"))
+
+
+def _select_validation_adapter(kind: str) -> DeterministicFakeModelCallAdapter:
+    adapter = select_model_call_adapter(kind)
+    if kind != LOCAL_VALIDATION_ADAPTER:
+        adapter.call(
+            ModelCallRequest(
+                request_id="adapter-selection-check",
+                prompt="",
+                privacy_class="synthetic",
+                metadata={"purpose": "adapter_selection_check"},
+            )
+        )
+    if not isinstance(adapter, DeterministicFakeModelCallAdapter):
+        supported = ", ".join(available_model_call_adapters())
+        raise ValueError(f"Unsupported validation adapter {kind!r}. Supported: {supported}")
+    return adapter
 
 
 def _requests(workload: dict[str, Any]) -> list[dict[str, Any]]:
@@ -139,6 +157,7 @@ def _run_kora_controlled_path(
 def build_customer_support_triage_fake_validation_summary(
     *,
     offline: bool = True,
+    adapter_kind: str = LOCAL_VALIDATION_ADAPTER,
     workload_path: Path = DEFAULT_WORKLOAD,
 ) -> dict[str, Any]:
     if not offline:
@@ -146,8 +165,8 @@ def build_customer_support_triage_fake_validation_summary(
 
     workload = load_workload(workload_path)
     requests = _requests(workload)
-    baseline_adapter = select_model_call_adapter(LOCAL_VALIDATION_ADAPTER)
-    kora_adapter = select_model_call_adapter(LOCAL_VALIDATION_ADAPTER)
+    baseline_adapter = _select_validation_adapter(adapter_kind)
+    kora_adapter = _select_validation_adapter(adapter_kind)
 
     baseline_responses = _run_direct_baseline(requests, baseline_adapter)
     (
@@ -224,6 +243,12 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         default=None,
         help="Optional path for a generated Markdown report.",
     )
+    parser.add_argument(
+        "--adapter",
+        default=LOCAL_VALIDATION_ADAPTER,
+        choices=available_model_call_adapters(),
+        help="Model-call adapter kind for local validation.",
+    )
     return parser.parse_args(argv)
 
 
@@ -232,10 +257,14 @@ def main(argv: list[str] | None = None) -> int:
     if not args.offline:
         raise SystemExit("customer_support_triage_fake_validation requires --offline.")
 
-    summary = build_customer_support_triage_fake_validation_summary(
-        offline=True,
-        workload_path=Path(args.workload),
-    )
+    try:
+        summary = build_customer_support_triage_fake_validation_summary(
+            offline=True,
+            adapter_kind=args.adapter,
+            workload_path=Path(args.workload),
+        )
+    except (RuntimeError, ValueError) as exc:
+        raise SystemExit(str(exc)) from exc
     if args.report_md:
         report_path = Path(args.report_md)
         report_path.parent.mkdir(parents=True, exist_ok=True)

--- a/examples/real_model_call_validation_fake/run.py
+++ b/examples/real_model_call_validation_fake/run.py
@@ -19,6 +19,7 @@ from kora.model_call import (
     ModelCallRequest,
     ModelCallResponse,
     ModelCallSummary,
+    available_model_call_adapters,
     select_model_call_adapter,
 )
 from kora.validation_report import render_local_validation_markdown
@@ -106,6 +107,23 @@ WORKLOAD: tuple[SyntheticRequest, ...] = (
 )
 
 
+def _select_validation_adapter(kind: str) -> DeterministicFakeModelCallAdapter:
+    adapter = select_model_call_adapter(kind)
+    if kind != LOCAL_VALIDATION_ADAPTER:
+        adapter.call(
+            ModelCallRequest(
+                request_id="adapter-selection-check",
+                prompt="",
+                privacy_class="synthetic",
+                metadata={"purpose": "adapter_selection_check"},
+            )
+        )
+    if not isinstance(adapter, DeterministicFakeModelCallAdapter):
+        supported = ", ".join(available_model_call_adapters())
+        raise ValueError(f"Unsupported validation adapter {kind!r}. Supported: {supported}")
+    return adapter
+
+
 def _model_request(item: SyntheticRequest) -> ModelCallRequest:
     return ModelCallRequest(
         request_id=item.request_id,
@@ -173,13 +191,14 @@ def _run_kora_controlled_path(
 def build_fake_model_call_validation_summary(
     *,
     offline: bool = True,
+    adapter_kind: str = LOCAL_VALIDATION_ADAPTER,
     workload: tuple[SyntheticRequest, ...] = WORKLOAD,
 ) -> dict[str, Any]:
     if not offline:
         raise ValueError("real_model_call_validation_fake supports --offline only")
 
-    baseline_adapter = select_model_call_adapter(LOCAL_VALIDATION_ADAPTER)
-    kora_adapter = select_model_call_adapter(LOCAL_VALIDATION_ADAPTER)
+    baseline_adapter = _select_validation_adapter(adapter_kind)
+    kora_adapter = _select_validation_adapter(adapter_kind)
 
     baseline_responses = _run_direct_baseline(workload, baseline_adapter)
     (
@@ -249,6 +268,12 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         default=None,
         help="Optional path for a generated Markdown report.",
     )
+    parser.add_argument(
+        "--adapter",
+        default=LOCAL_VALIDATION_ADAPTER,
+        choices=available_model_call_adapters(),
+        help="Model-call adapter kind for local validation.",
+    )
     return parser.parse_args(argv)
 
 
@@ -257,7 +282,10 @@ def main(argv: list[str] | None = None) -> int:
     if not args.offline:
         raise SystemExit("real_model_call_validation_fake requires --offline.")
 
-    summary = build_fake_model_call_validation_summary(offline=True)
+    try:
+        summary = build_fake_model_call_validation_summary(offline=True, adapter_kind=args.adapter)
+    except (RuntimeError, ValueError) as exc:
+        raise SystemExit(str(exc)) from exc
     if args.report_md:
         report_path = Path(args.report_md)
         report_path.parent.mkdir(parents=True, exist_ok=True)

--- a/tests/test_customer_support_triage_fake_validation.py
+++ b/tests/test_customer_support_triage_fake_validation.py
@@ -52,6 +52,21 @@ def test_customer_support_triage_fake_validation_summary_counts() -> None:
     assert summary["fallback_count"] == 0
 
 
+def test_customer_support_triage_fake_validation_explicit_local_validation_counts() -> None:
+    module = _load_example_module()
+
+    summary = module.build_customer_support_triage_fake_validation_summary(
+        offline=True,
+        adapter_kind="local_validation",
+    )
+
+    assert summary["provider"] == "local_validation"
+    assert summary["model"] == "deterministic-local"
+    assert summary["baseline_model_calls"] == 12
+    assert summary["kora_model_calls"] == 4
+    assert summary["avoided_model_calls"] == 8
+
+
 def test_customer_support_triage_fake_validation_requires_no_provider_environment(
     monkeypatch,
 ) -> None:
@@ -107,3 +122,167 @@ def test_customer_support_triage_fake_validation_cli_runs() -> None:
     assert '"mode": "customer_support_triage_local_validation"' in completed.stdout
     assert '"baseline_model_calls": 12' in completed.stdout
     assert '"kora_model_calls": 4' in completed.stdout
+
+
+def test_customer_support_triage_fake_validation_cli_explicit_local_validation_runs() -> None:
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "kora",
+            "run",
+            "customer_support_triage_fake_validation",
+            "--",
+            "--offline",
+            "--adapter",
+            "local_validation",
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert completed.returncode == 0
+    assert '"provider": "local_validation"' in completed.stdout
+    assert '"baseline_model_calls": 12' in completed.stdout
+    assert '"kora_model_calls": 4' in completed.stdout
+
+
+def test_customer_support_triage_fake_validation_report_with_explicit_adapter(
+    tmp_path: Path,
+) -> None:
+    report_path = tmp_path / "customer_support_validation.md"
+
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "kora",
+            "run",
+            "customer_support_triage_fake_validation",
+            "--",
+            "--offline",
+            "--adapter",
+            "local_validation",
+            "--report-md",
+            str(report_path),
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert completed.returncode == 0
+    assert report_path.exists()
+    report = report_path.read_text(encoding="utf-8")
+    assert "customer_support_triage_local_validation" in report
+    assert "local_validation" in report
+
+
+def test_customer_support_triage_fake_validation_blocked_adapter_fails_closed(
+    tmp_path: Path,
+) -> None:
+    report_path = tmp_path / "blocked.md"
+
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "kora",
+            "run",
+            "customer_support_triage_fake_validation",
+            "--",
+            "--offline",
+            "--adapter",
+            "blocked",
+            "--report-md",
+            str(report_path),
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert completed.returncode != 0
+    assert "Real model-call adapter is not configured" in completed.stderr
+    assert "customer-support triage workload" not in completed.stderr
+    assert not report_path.exists()
+
+
+def test_customer_support_triage_fake_validation_local_runtime_placeholder_fails_closed(
+    tmp_path: Path,
+) -> None:
+    report_path = tmp_path / "placeholder.md"
+
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "kora",
+            "run",
+            "customer_support_triage_fake_validation",
+            "--",
+            "--offline",
+            "--adapter",
+            "local_runtime_placeholder",
+            "--report-md",
+            str(report_path),
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert completed.returncode != 0
+    assert "Local runtime adapters are not implemented yet" in completed.stderr
+    assert "No provider call was attempted" in completed.stderr
+    assert "customer-support triage workload" not in completed.stderr
+    assert not report_path.exists()
+
+
+def test_customer_support_triage_fake_validation_unknown_adapter_lists_available_kinds() -> None:
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "kora",
+            "run",
+            "customer_support_triage_fake_validation",
+            "--",
+            "--offline",
+            "--adapter",
+            "remote_provider",
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert completed.returncode != 0
+    assert "invalid choice" in completed.stderr
+    assert "local_validation" in completed.stderr
+    assert "blocked" in completed.stderr
+    assert "local_runtime_placeholder" in completed.stderr
+
+
+def test_customer_support_triage_fake_validation_help_lists_available_adapter_kinds() -> None:
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "kora",
+            "run",
+            "customer_support_triage_fake_validation",
+            "--",
+            "--help",
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert completed.returncode == 0
+    assert "--adapter" in completed.stdout
+    assert "local_validation" in completed.stdout
+    assert "blocked" in completed.stdout
+    assert "local_runtime_placeholder" in completed.stdout

--- a/tests/test_real_model_call_validation_fake.py
+++ b/tests/test_real_model_call_validation_fake.py
@@ -38,6 +38,21 @@ def test_fake_model_call_validation_summary_counts() -> None:
     assert summary["fallback_count"] == 0
 
 
+def test_fake_model_call_validation_explicit_local_validation_counts() -> None:
+    module = _load_example_module()
+
+    summary = module.build_fake_model_call_validation_summary(
+        offline=True,
+        adapter_kind="local_validation",
+    )
+
+    assert summary["provider"] == "local_validation"
+    assert summary["model"] == "deterministic-local"
+    assert summary["baseline_model_calls"] == 10
+    assert summary["kora_model_calls"] == 4
+    assert summary["avoided_model_calls"] == 6
+
+
 def test_fake_model_call_validation_does_not_emit_raw_inputs_or_outputs() -> None:
     module = _load_example_module()
 
@@ -94,3 +109,134 @@ def test_fake_model_call_validation_cli_runs() -> None:
     assert '"mode": "local_no_network_model_call_validation"' in completed.stdout
     assert '"baseline_model_calls": 10' in completed.stdout
     assert '"kora_model_calls": 4' in completed.stdout
+
+
+def test_fake_model_call_validation_cli_explicit_local_validation_runs() -> None:
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "kora",
+            "run",
+            "real_model_call_validation_fake",
+            "--",
+            "--offline",
+            "--adapter",
+            "local_validation",
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert completed.returncode == 0
+    assert '"provider": "local_validation"' in completed.stdout
+    assert '"baseline_model_calls": 10' in completed.stdout
+    assert '"kora_model_calls": 4' in completed.stdout
+
+
+def test_fake_model_call_validation_blocked_adapter_fails_closed(tmp_path: Path) -> None:
+    report_path = tmp_path / "blocked.md"
+
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "kora",
+            "run",
+            "real_model_call_validation_fake",
+            "--",
+            "--offline",
+            "--adapter",
+            "blocked",
+            "--report-md",
+            str(report_path),
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert completed.returncode != 0
+    assert "Real model-call adapter is not configured" in completed.stderr
+    assert "Return the current order status" not in completed.stderr
+    assert not report_path.exists()
+
+
+def test_fake_model_call_validation_local_runtime_placeholder_fails_closed(
+    tmp_path: Path,
+) -> None:
+    report_path = tmp_path / "placeholder.md"
+
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "kora",
+            "run",
+            "real_model_call_validation_fake",
+            "--",
+            "--offline",
+            "--adapter",
+            "local_runtime_placeholder",
+            "--report-md",
+            str(report_path),
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert completed.returncode != 0
+    assert "Local runtime adapters are not implemented yet" in completed.stderr
+    assert "No provider call was attempted" in completed.stderr
+    assert "Return the current order status" not in completed.stderr
+    assert not report_path.exists()
+
+
+def test_fake_model_call_validation_unknown_adapter_lists_available_kinds() -> None:
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "kora",
+            "run",
+            "real_model_call_validation_fake",
+            "--",
+            "--offline",
+            "--adapter",
+            "remote_provider",
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert completed.returncode != 0
+    assert "invalid choice" in completed.stderr
+    assert "local_validation" in completed.stderr
+    assert "blocked" in completed.stderr
+    assert "local_runtime_placeholder" in completed.stderr
+
+
+def test_fake_model_call_validation_help_lists_available_adapter_kinds() -> None:
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "kora",
+            "run",
+            "real_model_call_validation_fake",
+            "--",
+            "--help",
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert completed.returncode == 0
+    assert "--adapter" in completed.stdout
+    assert "local_validation" in completed.stdout
+    assert "blocked" in completed.stdout
+    assert "local_runtime_placeholder" in completed.stdout


### PR DESCRIPTION
## Summary
- Adds `--adapter KIND` to local/no-network validation examples.
- Keeps `local_validation` as the default deterministic no-network path.
- Adds fail-closed `blocked` and `local_runtime_placeholder` choices.
- Documents adapter-selection boundaries in README and benchmark docs.

## Safety
- No real provider API calls.
- No network/runtime calls.
- No external model dependencies.
- No production cost, real API-cost, or energy-reduction claims.

## Validation
- `gh auth status` -> active account `hkalbertkim`
- `gh api user --jq .login` -> `hkalbertkim`
- `git status --short --branch` -> clean branch
- `git log --oneline -5` -> Task 253 commit at branch tip
- `git diff --check` -> passed
- `python3 -m pytest` -> 111 passed
- `python3 -m kora --help` -> passed
- `python3 -m kora examples list` -> passed
- `python3 -m kora run real_model_call_validation_fake -- --offline` -> passed
- `python3 -m kora run real_model_call_validation_fake -- --offline --adapter local_validation` -> passed
- `python3 -m kora run customer_support_triage_fake_validation -- --offline` -> passed
- `python3 -m kora run customer_support_triage_fake_validation -- --offline --adapter local_validation` -> passed
- `python3 -m kora run customer_support_triage_fake_validation -- --offline --report-md /tmp/kora_customer_support_validation.md` -> passed
- `python3 -m kora run direct_vs_kora -- --offline` -> passed
- `python3 -m kora run runtime_integrated_benchmark -- --offline` -> passed
- `python3 -m kora run real_model_call_validation_fake -- --offline --adapter blocked` -> exited 1 fail-closed
- `python3 -m kora run real_model_call_validation_fake -- --offline --adapter local_runtime_placeholder` -> exited 1 fail-closed, no provider call attempted
- `python3 -m kora run customer_support_triage_fake_validation -- --offline --adapter blocked` -> exited 1 fail-closed
- `python3 -m kora run customer_support_triage_fake_validation -- --offline --adapter local_runtime_placeholder` -> exited 1 fail-closed, no provider call attempted
