### PR TITLE
Polish local validation reviewer packet

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,8 @@ Local no-network validation examples support `--adapter local_validation`.
 
 Reviewer packet: [local no-network validation](docs/benchmarks/local-validation-reviewer-packet.md).
 
+The reviewer packet includes the no-network baseline checklist, adapter-selection commands, fail-closed safety checks, and local Markdown report generation examples.
+
 Local model adapter design: [provider-neutral local runtime path](docs/benchmarks/local-model-adapter-design.md).
 
 ## Help Test KORA

--- a/docs/benchmarks/local-model-adapter-design.md
+++ b/docs/benchmarks/local-model-adapter-design.md
@@ -122,6 +122,8 @@ Current supported adapter kinds:
 
 The local validation examples expose an explicit `--adapter` option for the current safe adapter kinds. Real local runtime adapters remain unimplemented and fail closed through `local_runtime_placeholder`.
 
+Reviewer-facing reproduction commands, no-network baseline counters, and fail-closed adapter checks are listed in the [local no-network validation reviewer packet](local-validation-reviewer-packet.md).
+
 The `local_runtime_placeholder` adapter kind does not call Ollama, llama.cpp, vLLM, remote providers, local HTTP endpoints, or subprocess runtimes. It exists so future adapters can plug into the same selection path without changing the validation examples or claim boundaries.
 
 ## Blocked Local Runtime Adapter Skeleton

--- a/docs/benchmarks/local-validation-reviewer-packet.md
+++ b/docs/benchmarks/local-validation-reviewer-packet.md
@@ -44,6 +44,33 @@ python3 -m kora run real_model_call_validation_fake -- --offline
 python3 -m kora run customer_support_triage_fake_validation -- --offline
 ```
 
+## No-Network Baseline Checklist
+
+Run these commands from a fresh checkout of `origin/main` to reproduce the current local/no-network baseline pass:
+
+```bash
+python3 -m pytest
+python3 -m kora --help
+python3 -m kora examples list
+
+python3 -m kora run direct_vs_kora -- --offline
+python3 -m kora run runtime_integrated_benchmark -- --offline
+
+python3 -m kora run real_model_call_validation_fake -- --offline --adapter local_validation
+python3 -m kora run customer_support_triage_fake_validation -- --offline --adapter local_validation
+
+python3 -m kora run customer_support_triage_fake_validation -- --offline --report-md /tmp/kora_customer_support_validation.md
+```
+
+Observed local/no-network baseline examples from the current reviewer pass:
+
+| Command | Expected reviewer result |
+|---|---:|
+| `direct_vs_kora --offline` | direct calls `2`, KORA calls `1` |
+| `runtime_integrated_benchmark --offline` | avoided simulated invocations `80/100` |
+| `real_model_call_validation_fake --offline --adapter local_validation` | baseline `10`, KORA `4`, avoided `6` |
+| `customer_support_triage_fake_validation --offline --adapter local_validation` | baseline `12`, KORA `4`, avoided `8` |
+
 ## Generate Reviewer Reports
 
 ```bash
@@ -66,6 +93,17 @@ python3 -m kora run customer_support_triage_fake_validation -- --offline --adapt
 ```
 
 The `blocked` and `local_runtime_placeholder` adapter kinds are fail-closed safety paths. `blocked` represents an unconfigured model-call path. `local_runtime_placeholder` is design-only, makes no runtime calls, and does not contact local HTTP endpoints, subprocess runtimes, remote providers, or provider APIs.
+
+Fail-closed checks:
+
+```bash
+python3 -m kora run real_model_call_validation_fake -- --offline --adapter blocked
+python3 -m kora run real_model_call_validation_fake -- --offline --adapter local_runtime_placeholder
+python3 -m kora run customer_support_triage_fake_validation -- --offline --adapter blocked
+python3 -m kora run customer_support_triage_fake_validation -- --offline --adapter local_runtime_placeholder
+```
+
+These commands are expected to exit non-zero. The `local_runtime_placeholder` path reports that no provider call was attempted. Reviewers should treat this as a safety check, not as a validation failure.
 
 ## Expected Generic Local Validation Counters
 
@@ -145,6 +183,13 @@ Not allowed:
 - KORA is production-proven for customer support.
 - KORA reduces energy consumption.
 - KORA has real provider validation from this packet.
+
+Safe interpretation of this packet:
+
+- The examples use synthetic workloads.
+- The examples run local/no-network validation paths.
+- The counters are model-call events or simulated invocations, depending on the command.
+- The Markdown report path is a local review artifact unless explicitly selected for public review.
 
 ## Troubleshooting
 

--- a/docs/benchmarks/real-model-call-validation-design.md
+++ b/docs/benchmarks/real-model-call-validation-design.md
@@ -283,6 +283,8 @@ The example can generate a reviewer-facing Markdown report from aggregate counte
 
 For a reviewer-facing walkthrough, see the [local no-network validation reviewer packet](local-validation-reviewer-packet.md).
 
+The reviewer packet includes adapter-selection commands, no-network baseline counters, fail-closed adapter checks, and the local Markdown report generation path for synthetic workloads.
+
 Claim boundary: this is not real provider validation, real API-cost validation, production validation, production cost reduction proof, broad workload superiority proof, or energy reduction evidence.
 
 ## Customer-Support Triage Local Validation Example


### PR DESCRIPTION
## Summary
- Clarifies no-network adapter-selection validation commands.
- Adds reviewer-facing baseline result examples from local synthetic workloads.
- Documents fail-closed adapter behavior.
- Keeps claim boundaries explicit.

## Validation
- `git diff --check` -> passed
- `python3 -m pytest` -> 111 passed
- `python3 -m kora --help` -> passed
- `python3 -m kora examples list` -> passed
- `python3 -m kora run real_model_call_validation_fake -- --offline --adapter local_validation` -> passed
- `python3 -m kora run customer_support_triage_fake_validation -- --offline --adapter local_validation` -> passed
- `python3 -m kora run customer_support_triage_fake_validation -- --offline --report-md /tmp/kora_task263_customer_support_validation.md` -> passed
- `python3 -m kora run runtime_integrated_benchmark -- --offline` -> passed
- Fail-closed adapter checks -> exited 1 as expected; placeholder confirmed no provider call was attempted
- Public exposure scan -> no matches
- Claim safety scan -> only explicit non-claim/prohibited-boundary wording

## Safety
- No real provider calls.
- No network calls.
- No raw benchmark artifacts committed.
- No release/tag/package changes.
- No claim expansion.
