### PR TITLE
Add opt-in local runtime adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ Customer-support triage local validation is available as a no-network example.
 
 Local no-network validation examples can generate Markdown reports with `--report-md`.
 
-Local no-network validation examples support `--adapter local_validation`.
+Local no-network validation examples support `--adapter local_validation` by default and explicit `--adapter local_runtime` for the deterministic in-process local runtime stub.
 
 Reviewer packet: [local no-network validation](docs/benchmarks/local-validation-reviewer-packet.md).
 

--- a/docs/benchmarks/local-model-adapter-design.md
+++ b/docs/benchmarks/local-model-adapter-design.md
@@ -117,10 +117,13 @@ KORA now includes a small adapter selection skeleton for local validation and fu
 Current supported adapter kinds:
 
 - `local_validation`: returns the deterministic local validation adapter used by local/no-network examples.
+- `local_runtime`: returns an explicit opt-in deterministic in-process local runtime stub for local/no-network validation.
 - `blocked`: returns a fail-closed adapter for unconfigured model-call paths.
 - `local_runtime_placeholder`: returns fail-closed behavior and documents that local runtime adapters are design-only for now.
 
-The local validation examples expose an explicit `--adapter` option for the current safe adapter kinds. Real local runtime adapters remain unimplemented and fail closed through `local_runtime_placeholder`.
+The local validation examples expose an explicit `--adapter` option for the current safe adapter kinds. The `local_runtime` adapter is a concrete local/no-network runtime stub: it runs in process, uses deterministic output, records aggregate counters, and does not call local HTTP endpoints, subprocess runtimes, remote providers, provider APIs, or external model downloads. The default remains `local_validation`.
+
+`local_runtime_placeholder` remains design-only and fail-closed for unsupported runtime paths.
 
 Reviewer-facing reproduction commands, no-network baseline counters, and fail-closed adapter checks are listed in the [local no-network validation reviewer packet](local-validation-reviewer-packet.md).
 
@@ -139,7 +142,7 @@ The skeleton reserves the future local runtime adapter boundary while failing cl
 - does not require any local runtime installation for tests or examples
 - raises a clear error stating that local runtime adapters are not implemented yet and that no provider call was attempted
 
-Current runnable validation remains local/no-network validation through the deterministic local validation adapter. Future local runtime work can replace the fail-closed placeholder with a concrete adapter behind explicit opt-in.
+Current runnable validation remains local/no-network validation through the deterministic local validation adapter by default. The `local_runtime` adapter provides an explicit opt-in local runtime stub for exercising the same boundary without external runtime calls. Future runtime-specific adapters can extend the same selection path without replacing the fail-closed placeholder.
 
 Future adapter kinds should keep the same behavior shape:
 

--- a/docs/benchmarks/local-validation-reviewer-packet.md
+++ b/docs/benchmarks/local-validation-reviewer-packet.md
@@ -58,6 +58,8 @@ python3 -m kora run runtime_integrated_benchmark -- --offline
 
 python3 -m kora run real_model_call_validation_fake -- --offline --adapter local_validation
 python3 -m kora run customer_support_triage_fake_validation -- --offline --adapter local_validation
+python3 -m kora run real_model_call_validation_fake -- --offline --adapter local_runtime
+python3 -m kora run customer_support_triage_fake_validation -- --offline --adapter local_runtime
 
 python3 -m kora run customer_support_triage_fake_validation -- --offline --report-md /tmp/kora_customer_support_validation.md
 ```
@@ -92,6 +94,13 @@ python3 -m kora run real_model_call_validation_fake -- --offline --adapter local
 python3 -m kora run customer_support_triage_fake_validation -- --offline --adapter local_validation
 ```
 
+The `local_runtime` adapter is an explicit opt-in local/no-network runtime stub. It uses deterministic in-process behavior, records the same aggregate counter shape as `local_validation`, and does not call local HTTP endpoints, subprocess runtimes, remote providers, provider APIs, or external model downloads.
+
+```bash
+python3 -m kora run real_model_call_validation_fake -- --offline --adapter local_runtime
+python3 -m kora run customer_support_triage_fake_validation -- --offline --adapter local_runtime
+```
+
 The `blocked` and `local_runtime_placeholder` adapter kinds are fail-closed safety paths. `blocked` represents an unconfigured model-call path. `local_runtime_placeholder` is design-only, makes no runtime calls, and does not contact local HTTP endpoints, subprocess runtimes, remote providers, or provider APIs.
 
 Fail-closed checks:
@@ -124,6 +133,11 @@ Expected labels:
 - `provider`: `local_validation`
 - `model`: `deterministic-local`
 
+With explicit `--adapter local_runtime`, the expected counters are the same and the labels are:
+
+- `provider`: `local_runtime`
+- `model`: `deterministic-local-runtime`
+
 ## Expected Customer-Support Triage Counters
 
 For `customer_support_triage_fake_validation`, expected counters are:
@@ -142,6 +156,11 @@ Expected labels:
 
 - `provider`: `local_validation`
 - `model`: `deterministic-local`
+
+With explicit `--adapter local_runtime`, the expected counters are the same and the labels are:
+
+- `provider`: `local_runtime`
+- `model`: `deterministic-local-runtime`
 
 ## How To Read The Counters
 

--- a/docs/benchmarks/real-model-call-validation-design.md
+++ b/docs/benchmarks/real-model-call-validation-design.md
@@ -285,6 +285,8 @@ For a reviewer-facing walkthrough, see the [local no-network validation reviewer
 
 The reviewer packet includes adapter-selection commands, no-network baseline counters, fail-closed adapter checks, and the local Markdown report generation path for synthetic workloads.
 
+The local validation examples also support explicit `--adapter local_runtime` selection. That adapter is a deterministic in-process local/no-network runtime stub; it is not a real provider integration and does not call local HTTP endpoints, subprocess runtimes, remote providers, provider APIs, or external model downloads.
+
 Claim boundary: this is not real provider validation, real API-cost validation, production validation, production cost reduction proof, broad workload superiority proof, or energy reduction evidence.
 
 ## Customer-Support Triage Local Validation Example

--- a/examples/customer_support_triage_fake_validation/run.py
+++ b/examples/customer_support_triage_fake_validation/run.py
@@ -9,9 +9,11 @@ from typing import Any
 
 from kora.model_call import (
     DeterministicFakeModelCallAdapter,
+    DeterministicLocalRuntimeModelCallAdapter,
     LOCAL_VALIDATION_ADAPTER,
     ModelCallRequest,
     ModelCallResponse,
+    ModelCallAdapter,
     ModelCallSummary,
     available_model_call_adapters,
     select_model_call_adapter,
@@ -42,7 +44,7 @@ def load_workload(path: Path = DEFAULT_WORKLOAD) -> dict[str, Any]:
     return json.loads(workload_path.read_text(encoding="utf-8"))
 
 
-def _select_validation_adapter(kind: str) -> DeterministicFakeModelCallAdapter:
+def _select_validation_adapter(kind: str) -> ModelCallAdapter:
     adapter = select_model_call_adapter(kind)
     if kind != LOCAL_VALIDATION_ADAPTER:
         adapter.call(
@@ -53,7 +55,10 @@ def _select_validation_adapter(kind: str) -> DeterministicFakeModelCallAdapter:
                 metadata={"purpose": "adapter_selection_check"},
             )
         )
-    if not isinstance(adapter, DeterministicFakeModelCallAdapter):
+    if not isinstance(
+        adapter,
+        (DeterministicFakeModelCallAdapter, DeterministicLocalRuntimeModelCallAdapter),
+    ):
         supported = ", ".join(available_model_call_adapters())
         raise ValueError(f"Unsupported validation adapter {kind!r}. Supported: {supported}")
     return adapter
@@ -81,7 +86,7 @@ def _model_request(item: dict[str, Any]) -> ModelCallRequest:
 
 def _run_direct_baseline(
     requests: list[dict[str, Any]],
-    adapter: DeterministicFakeModelCallAdapter,
+    adapter: ModelCallAdapter,
 ) -> list[ModelCallResponse]:
     return [adapter.call(_model_request(item)) for item in requests]
 
@@ -107,7 +112,7 @@ def _validate_model_required_route(item: dict[str, Any], response: ModelCallResp
 
 def _run_kora_controlled_path(
     requests: list[dict[str, Any]],
-    adapter: DeterministicFakeModelCallAdapter,
+    adapter: ModelCallAdapter,
 ) -> tuple[list[ModelCallResponse], int, int, int, int, int, int]:
     model_responses: list[ModelCallResponse] = []
     deterministic_routes = 0
@@ -195,9 +200,9 @@ def build_customer_support_triage_fake_validation_summary(
         "workload_id": workload.get("workload_id"),
         "workload_path": str(workload_path),
         "privacy_class": workload.get("privacy_class"),
-        "adapter": "deterministic local validation adapter",
-        "provider": "local_validation",
-        "model": "deterministic-local",
+        "adapter": baseline_responses[0].metadata.get("adapter", adapter_kind),
+        "provider": baseline_responses[0].provider,
+        "model": baseline_responses[0].model,
         "total_requests": len(requests),
         "baseline_model_calls": baseline_summary.model_calls,
         "kora_model_calls": kora_summary.model_calls,
@@ -220,9 +225,9 @@ def build_customer_support_triage_fake_validation_summary(
         "claim_boundary": CLAIM_BOUNDARY,
         "notes": [
             "Synthetic customer-support triage workload only.",
-            "Direct baseline records local validation model-call events for every request.",
-            "KORA-controlled path validates deterministic routes without local validation model-call events.",
-            "Model-required routes use the deterministic local validation adapter through the provider-neutral boundary.",
+            "Direct baseline records selected local adapter model-call events for every request.",
+            "KORA-controlled path validates deterministic routes without selected local adapter model-call events.",
+            "Model-required routes use the selected local adapter through the provider-neutral boundary.",
             "No external APIs, network access, provider credentials, raw prompts, or raw provider responses are used.",
         ],
     }

--- a/examples/real_model_call_validation_fake/run.py
+++ b/examples/real_model_call_validation_fake/run.py
@@ -15,9 +15,11 @@ from typing import Any, Literal
 
 from kora.model_call import (
     DeterministicFakeModelCallAdapter,
+    DeterministicLocalRuntimeModelCallAdapter,
     LOCAL_VALIDATION_ADAPTER,
     ModelCallRequest,
     ModelCallResponse,
+    ModelCallAdapter,
     ModelCallSummary,
     available_model_call_adapters,
     select_model_call_adapter,
@@ -107,7 +109,7 @@ WORKLOAD: tuple[SyntheticRequest, ...] = (
 )
 
 
-def _select_validation_adapter(kind: str) -> DeterministicFakeModelCallAdapter:
+def _select_validation_adapter(kind: str) -> ModelCallAdapter:
     adapter = select_model_call_adapter(kind)
     if kind != LOCAL_VALIDATION_ADAPTER:
         adapter.call(
@@ -118,7 +120,10 @@ def _select_validation_adapter(kind: str) -> DeterministicFakeModelCallAdapter:
                 metadata={"purpose": "adapter_selection_check"},
             )
         )
-    if not isinstance(adapter, DeterministicFakeModelCallAdapter):
+    if not isinstance(
+        adapter,
+        (DeterministicFakeModelCallAdapter, DeterministicLocalRuntimeModelCallAdapter),
+    ):
         supported = ", ".join(available_model_call_adapters())
         raise ValueError(f"Unsupported validation adapter {kind!r}. Supported: {supported}")
     return adapter
@@ -135,7 +140,7 @@ def _model_request(item: SyntheticRequest) -> ModelCallRequest:
 
 def _run_direct_baseline(
     workload: tuple[SyntheticRequest, ...],
-    adapter: DeterministicFakeModelCallAdapter,
+    adapter: ModelCallAdapter,
 ) -> list[ModelCallResponse]:
     return [adapter.call(_model_request(item)) for item in workload]
 
@@ -148,7 +153,7 @@ def _run_deterministic_handler(item: SyntheticRequest) -> str:
 
 def _run_kora_controlled_path(
     workload: tuple[SyntheticRequest, ...],
-    adapter: DeterministicFakeModelCallAdapter,
+    adapter: ModelCallAdapter,
 ) -> tuple[list[ModelCallResponse], int, int, int, int, int]:
     model_responses: list[ModelCallResponse] = []
     deterministic_routes = 0
@@ -224,9 +229,9 @@ def build_fake_model_call_validation_summary(
         "ok": error_count == 0 and validation_fail_count == 0,
         "mode": "local_no_network_model_call_validation",
         "offline": True,
-        "adapter": "deterministic local validation adapter",
-        "provider": "local_validation",
-        "model": "deterministic-local",
+        "adapter": baseline_responses[0].metadata.get("adapter", adapter_kind),
+        "provider": baseline_responses[0].provider,
+        "model": baseline_responses[0].model,
         "total_requests": total_requests,
         "baseline_model_calls": baseline_summary.model_calls,
         "kora_model_calls": kora_summary.model_calls,
@@ -250,9 +255,9 @@ def build_fake_model_call_validation_summary(
         "claim_boundary": CLAIM_BOUNDARY,
         "notes": [
             "Synthetic workload only.",
-            "Direct baseline records local validation model-call events for every request.",
-            "KORA-controlled path handles deterministic routes without local validation model-call events.",
-            "Model-required routes use the deterministic local validation adapter through the provider-neutral boundary.",
+            "Direct baseline records selected local adapter model-call events for every request.",
+            "KORA-controlled path handles deterministic routes without selected local adapter model-call events.",
+            "Model-required routes use the selected local adapter through the provider-neutral boundary.",
             "No external APIs, network access, provider credentials, raw prompts, or raw provider responses are used.",
         ],
     }

--- a/kora/model_call.py
+++ b/kora/model_call.py
@@ -7,12 +7,14 @@ from dataclasses import dataclass, field
 from typing import Any, Protocol
 
 LOCAL_VALIDATION_ADAPTER = "local_validation"
+LOCAL_RUNTIME_ADAPTER = "local_runtime"
 BLOCKED_ADAPTER = "blocked"
 LOCAL_RUNTIME_PLACEHOLDER_ADAPTER = "local_runtime_placeholder"
 LOCAL_RUNTIME_NOT_CONFIGURED_MODEL = "local-runtime-not-configured"
 
 SUPPORTED_MODEL_CALL_ADAPTERS = (
     LOCAL_VALIDATION_ADAPTER,
+    LOCAL_RUNTIME_ADAPTER,
     BLOCKED_ADAPTER,
     LOCAL_RUNTIME_PLACEHOLDER_ADAPTER,
 )
@@ -95,6 +97,35 @@ class DeterministicFakeModelCallAdapter:
         )
 
 
+class DeterministicLocalRuntimeModelCallAdapter:
+    """Explicit opt-in local runtime stub with deterministic in-process behavior."""
+
+    provider = LOCAL_RUNTIME_ADAPTER
+    model = "deterministic-local-runtime"
+
+    def call(self, request: ModelCallRequest) -> ModelCallResponse:
+        start = time.perf_counter()
+        output = f"local_runtime:{request.request_id}:{request.prompt.strip()[:80]}"
+        latency_ms = (time.perf_counter() - start) * 1000.0
+        return ModelCallResponse(
+            request_id=request.request_id,
+            output=output,
+            model_calls=1,
+            latency_ms=latency_ms,
+            input_tokens=_estimate_tokens(request.prompt),
+            output_tokens=_estimate_tokens(output),
+            provider=self.provider,
+            model=self.model,
+            metadata={
+                "privacy_class": request.privacy_class,
+                "adapter": self.provider,
+                "network": "none",
+                "runtime": "in_process_stub",
+                "deterministic": True,
+            },
+        )
+
+
 class BlockedModelCallAdapter:
     """Adapter that fails closed when real provider use is not configured."""
 
@@ -140,13 +171,15 @@ def available_model_call_adapters() -> list[str]:
 def select_model_call_adapter(kind: str | None = None) -> ModelCallAdapter:
     """Select a provider-neutral model-call adapter by kind.
 
-    The current implemented runtime path is local no-network validation. Local
-    runtime adapters are intentionally fail-closed until explicitly implemented.
+    The default path is local no-network validation. The concrete local runtime
+    path is an explicit opt-in deterministic in-process adapter.
     """
 
     selected_kind = kind or LOCAL_VALIDATION_ADAPTER
     if selected_kind == LOCAL_VALIDATION_ADAPTER:
         return DeterministicFakeModelCallAdapter()
+    if selected_kind == LOCAL_RUNTIME_ADAPTER:
+        return DeterministicLocalRuntimeModelCallAdapter()
     if selected_kind == BLOCKED_ADAPTER:
         return BlockedModelCallAdapter()
     if selected_kind == LOCAL_RUNTIME_PLACEHOLDER_ADAPTER:

--- a/tests/test_customer_support_triage_fake_validation.py
+++ b/tests/test_customer_support_triage_fake_validation.py
@@ -67,6 +67,22 @@ def test_customer_support_triage_fake_validation_explicit_local_validation_count
     assert summary["avoided_model_calls"] == 8
 
 
+def test_customer_support_triage_fake_validation_explicit_local_runtime_counts() -> None:
+    module = _load_example_module()
+
+    summary = module.build_customer_support_triage_fake_validation_summary(
+        offline=True,
+        adapter_kind="local_runtime",
+    )
+
+    assert summary["provider"] == "local_runtime"
+    assert summary["model"] == "deterministic-local-runtime"
+    assert summary["baseline_model_calls"] == 12
+    assert summary["kora_model_calls"] == 4
+    assert summary["avoided_model_calls"] == 8
+    assert summary["validation_pass_count"] == 12
+
+
 def test_customer_support_triage_fake_validation_requires_no_provider_environment(
     monkeypatch,
 ) -> None:
@@ -179,6 +195,37 @@ def test_customer_support_triage_fake_validation_report_with_explicit_adapter(
     assert "local_validation" in report
 
 
+def test_customer_support_triage_fake_validation_report_with_local_runtime_adapter(
+    tmp_path: Path,
+) -> None:
+    report_path = tmp_path / "customer_support_local_runtime.md"
+
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "kora",
+            "run",
+            "customer_support_triage_fake_validation",
+            "--",
+            "--offline",
+            "--adapter",
+            "local_runtime",
+            "--report-md",
+            str(report_path),
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert completed.returncode == 0
+    assert report_path.exists()
+    report = report_path.read_text(encoding="utf-8")
+    assert "customer_support_triage_local_validation" in report
+    assert "local_runtime" in report
+
+
 def test_customer_support_triage_fake_validation_blocked_adapter_fails_closed(
     tmp_path: Path,
 ) -> None:
@@ -261,6 +308,7 @@ def test_customer_support_triage_fake_validation_unknown_adapter_lists_available
     assert completed.returncode != 0
     assert "invalid choice" in completed.stderr
     assert "local_validation" in completed.stderr
+    assert "local_runtime" in completed.stderr
     assert "blocked" in completed.stderr
     assert "local_runtime_placeholder" in completed.stderr
 
@@ -284,5 +332,6 @@ def test_customer_support_triage_fake_validation_help_lists_available_adapter_ki
     assert completed.returncode == 0
     assert "--adapter" in completed.stdout
     assert "local_validation" in completed.stdout
+    assert "local_runtime" in completed.stdout
     assert "blocked" in completed.stdout
     assert "local_runtime_placeholder" in completed.stdout

--- a/tests/test_model_call.py
+++ b/tests/test_model_call.py
@@ -7,6 +7,8 @@ from kora.model_call import (
     BlockedLocalRuntimeModelCallAdapter,
     BlockedModelCallAdapter,
     DeterministicFakeModelCallAdapter,
+    DeterministicLocalRuntimeModelCallAdapter,
+    LOCAL_RUNTIME_ADAPTER,
     LOCAL_RUNTIME_PLACEHOLDER_ADAPTER,
     LOCAL_VALIDATION_ADAPTER,
     LocalRuntimeAdapterConfig,
@@ -77,6 +79,45 @@ def test_fake_adapter_requires_no_secrets_or_environment(monkeypatch: pytest.Mon
     assert response.model_calls == 1
     assert "OPENAI_API_KEY" not in os.environ
     assert "ANTHROPIC_API_KEY" not in os.environ
+
+
+def test_local_runtime_adapter_returns_deterministic_response() -> None:
+    adapter = DeterministicLocalRuntimeModelCallAdapter()
+    request = ModelCallRequest(request_id="req-local-1", prompt="Classify this request")
+
+    first = adapter.call(request)
+    second = adapter.call(request)
+
+    assert first.output == second.output
+    assert first.output == "local_runtime:req-local-1:Classify this request"
+    assert first.model_calls == 1
+    assert first.provider == LOCAL_RUNTIME_ADAPTER
+    assert first.model == "deterministic-local-runtime"
+    assert first.metadata["network"] == "none"
+    assert first.metadata["runtime"] == "in_process_stub"
+    assert first.metadata["deterministic"] is True
+
+
+def test_local_runtime_adapter_requires_no_secrets_or_environment(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    monkeypatch.delenv("KORA_LOCAL_MODEL_RUNTIME", raising=False)
+    monkeypatch.delenv("KORA_LOCAL_MODEL_ENDPOINT", raising=False)
+    monkeypatch.delenv("KORA_LOCAL_MODEL_NAME", raising=False)
+
+    response = DeterministicLocalRuntimeModelCallAdapter().call(
+        ModelCallRequest(request_id="req-local-2", prompt="local runtime only")
+    )
+
+    assert response.model_calls == 1
+    assert response.provider == LOCAL_RUNTIME_ADAPTER
+    assert "OPENAI_API_KEY" not in os.environ
+    assert "ANTHROPIC_API_KEY" not in os.environ
+    assert "KORA_LOCAL_MODEL_RUNTIME" not in os.environ
+    assert "KORA_LOCAL_MODEL_ENDPOINT" not in os.environ
+    assert "KORA_LOCAL_MODEL_NAME" not in os.environ
 
 
 def test_model_call_summary_aggregates_counters() -> None:
@@ -191,6 +232,15 @@ def test_select_model_call_adapter_returns_local_validation_adapter() -> None:
     assert response.model == "deterministic-local"
 
 
+def test_select_model_call_adapter_returns_local_runtime_adapter() -> None:
+    adapter = select_model_call_adapter(LOCAL_RUNTIME_ADAPTER)
+
+    assert isinstance(adapter, DeterministicLocalRuntimeModelCallAdapter)
+    response = adapter.call(ModelCallRequest(request_id="req-local-3", prompt="local runtime"))
+    assert response.provider == LOCAL_RUNTIME_ADAPTER
+    assert response.model == "deterministic-local-runtime"
+
+
 def test_select_model_call_adapter_returns_blocked_adapter() -> None:
     adapter = select_model_call_adapter(BLOCKED_ADAPTER)
 
@@ -216,6 +266,7 @@ def test_available_model_call_adapters_lists_safe_kinds() -> None:
     adapters = available_model_call_adapters()
 
     assert LOCAL_VALIDATION_ADAPTER in adapters
+    assert LOCAL_RUNTIME_ADAPTER in adapters
     assert BLOCKED_ADAPTER in adapters
     assert LOCAL_RUNTIME_PLACEHOLDER_ADAPTER in adapters
 
@@ -233,6 +284,27 @@ def test_select_model_call_adapter_requires_no_secrets_or_local_runtime(
     response = adapter.call(ModelCallRequest(request_id="req-13", prompt="no runtime"))
 
     assert response.model_calls == 1
+    assert "OPENAI_API_KEY" not in os.environ
+    assert "ANTHROPIC_API_KEY" not in os.environ
+    assert "KORA_LOCAL_MODEL_RUNTIME" not in os.environ
+    assert "KORA_LOCAL_MODEL_ENDPOINT" not in os.environ
+    assert "KORA_LOCAL_MODEL_NAME" not in os.environ
+
+
+def test_local_runtime_adapter_requires_no_secrets_or_local_runtime(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    monkeypatch.delenv("KORA_LOCAL_MODEL_RUNTIME", raising=False)
+    monkeypatch.delenv("KORA_LOCAL_MODEL_ENDPOINT", raising=False)
+    monkeypatch.delenv("KORA_LOCAL_MODEL_NAME", raising=False)
+
+    adapter = select_model_call_adapter(LOCAL_RUNTIME_ADAPTER)
+    response = adapter.call(ModelCallRequest(request_id="req-local-4", prompt="no runtime"))
+
+    assert response.model_calls == 1
+    assert response.metadata["runtime"] == "in_process_stub"
     assert "OPENAI_API_KEY" not in os.environ
     assert "ANTHROPIC_API_KEY" not in os.environ
     assert "KORA_LOCAL_MODEL_RUNTIME" not in os.environ

--- a/tests/test_real_model_call_validation_fake.py
+++ b/tests/test_real_model_call_validation_fake.py
@@ -53,6 +53,22 @@ def test_fake_model_call_validation_explicit_local_validation_counts() -> None:
     assert summary["avoided_model_calls"] == 6
 
 
+def test_fake_model_call_validation_explicit_local_runtime_counts() -> None:
+    module = _load_example_module()
+
+    summary = module.build_fake_model_call_validation_summary(
+        offline=True,
+        adapter_kind="local_runtime",
+    )
+
+    assert summary["provider"] == "local_runtime"
+    assert summary["model"] == "deterministic-local-runtime"
+    assert summary["baseline_model_calls"] == 10
+    assert summary["kora_model_calls"] == 4
+    assert summary["avoided_model_calls"] == 6
+    assert summary["validation_pass_count"] == 10
+
+
 def test_fake_model_call_validation_does_not_emit_raw_inputs_or_outputs() -> None:
     module = _load_example_module()
 
@@ -131,6 +147,31 @@ def test_fake_model_call_validation_cli_explicit_local_validation_runs() -> None
 
     assert completed.returncode == 0
     assert '"provider": "local_validation"' in completed.stdout
+    assert '"baseline_model_calls": 10' in completed.stdout
+    assert '"kora_model_calls": 4' in completed.stdout
+
+
+def test_fake_model_call_validation_cli_explicit_local_runtime_runs() -> None:
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "kora",
+            "run",
+            "real_model_call_validation_fake",
+            "--",
+            "--offline",
+            "--adapter",
+            "local_runtime",
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert completed.returncode == 0
+    assert '"provider": "local_runtime"' in completed.stdout
+    assert '"model": "deterministic-local-runtime"' in completed.stdout
     assert '"baseline_model_calls": 10' in completed.stdout
     assert '"kora_model_calls": 4' in completed.stdout
 
@@ -215,6 +256,7 @@ def test_fake_model_call_validation_unknown_adapter_lists_available_kinds() -> N
     assert completed.returncode != 0
     assert "invalid choice" in completed.stderr
     assert "local_validation" in completed.stderr
+    assert "local_runtime" in completed.stderr
     assert "blocked" in completed.stderr
     assert "local_runtime_placeholder" in completed.stderr
 
@@ -238,5 +280,6 @@ def test_fake_model_call_validation_help_lists_available_adapter_kinds() -> None
     assert completed.returncode == 0
     assert "--adapter" in completed.stdout
     assert "local_validation" in completed.stdout
+    assert "local_runtime" in completed.stdout
     assert "blocked" in completed.stdout
     assert "local_runtime_placeholder" in completed.stdout


### PR DESCRIPTION
## Summary
- Adds a concrete local/no-network runtime adapter behind explicit `--adapter local_runtime`.
- Keeps `local_validation` as the default path.
- Preserves fail-closed behavior for `blocked` and `local_runtime_placeholder` adapters.
- Updates tests and reviewer-facing docs.

## Validation
- `git diff --check`
- `python3 -m pytest` -> `119 passed`
- `python3 -m kora --help`
- `python3 -m kora examples list`
- `python3 -m kora run real_model_call_validation_fake -- --offline`
- `python3 -m kora run real_model_call_validation_fake -- --offline --adapter local_validation`
- `python3 -m kora run customer_support_triage_fake_validation -- --offline`
- `python3 -m kora run customer_support_triage_fake_validation -- --offline --adapter local_validation`
- `python3 -m kora run real_model_call_validation_fake -- --offline --adapter local_runtime`
- `python3 -m kora run customer_support_triage_fake_validation -- --offline --adapter local_runtime`
- `python3 -m kora run customer_support_triage_fake_validation -- --offline --adapter local_runtime --report-md /tmp/kora_task266_customer_support_local_runtime.md`
- `python3 -m kora run direct_vs_kora -- --offline`
- `python3 -m kora run runtime_integrated_benchmark -- --offline`
- Fail-closed adapter checks for `blocked` and `local_runtime_placeholder`
- Public exposure scan
- Claim safety scan
- Network/provider safety scan

## Safety
- No real provider API calls.
- No network calls.
- No external model downloads.
- No local runtime subprocess or HTTP calls.
- No raw benchmark artifacts committed.
- No release/tag/package changes.
- No claim expansion.
