### PR TITLE
Add real provider adapter design packet

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,8 @@ The reviewer packet includes the no-network baseline checklist, adapter-selectio
 
 Local model adapter design: [provider-neutral local runtime path](docs/benchmarks/local-model-adapter-design.md).
 
+Real provider adapter design-only packet: [future provider boundary](docs/benchmarks/real-provider-adapter-design.md).
+
 ## Help Test KORA
 
 Good candidate workloads:

--- a/docs/benchmarks/local-model-adapter-design.md
+++ b/docs/benchmarks/local-model-adapter-design.md
@@ -127,6 +127,8 @@ The local validation examples expose an explicit `--adapter` option for the curr
 
 Reviewer-facing reproduction commands, no-network baseline counters, and fail-closed adapter checks are listed in the [local no-network validation reviewer packet](local-validation-reviewer-packet.md).
 
+Future real provider adapters are covered separately in the [real provider adapter design](real-provider-adapter-design.md). That packet is design-only and does not add provider calls, credential handling, network calls, or provider dependencies.
+
 The `local_runtime_placeholder` adapter kind does not call Ollama, llama.cpp, vLLM, remote providers, local HTTP endpoints, or subprocess runtimes. It exists so future adapters can plug into the same selection path without changing the validation examples or claim boundaries.
 
 ## Blocked Local Runtime Adapter Skeleton

--- a/docs/benchmarks/local-validation-reviewer-packet.md
+++ b/docs/benchmarks/local-validation-reviewer-packet.md
@@ -221,8 +221,10 @@ Safe interpretation of this packet:
 
 ## Next Validation Step
 
-The next step after this packet is a local model adapter or remote provider adapter using the same reporting structure, while preserving privacy and claim boundaries.
+The next step after this packet is real provider adapter design, followed later by any implementation behind explicit opt-in, using the same reporting structure while preserving privacy and claim boundaries.
 
-The reviewer packet commands still use local/no-network validation. Local runtime adapters remain design-only and fail-closed until a concrete adapter is implemented and validated.
+The reviewer packet commands still use local/no-network validation. The `local_runtime` adapter is an explicit deterministic in-process local/no-network stub. The `local_runtime_placeholder` adapter remains design-only and fail-closed for unsupported runtime paths.
 
 See the [local model adapter design](local-model-adapter-design.md) for the next local runtime pathway after local/no-network validation.
+
+See the [real provider adapter design](real-provider-adapter-design.md) for the future provider boundary. It is design-only and does not implement provider calls, credential handling, network calls, or provider dependencies.

--- a/docs/benchmarks/real-model-call-validation-design.md
+++ b/docs/benchmarks/real-model-call-validation-design.md
@@ -86,6 +86,8 @@ Local model-call mode should run through a local runtime or local provider abstr
 
 See the [local model adapter design](local-model-adapter-design.md) for the provider-neutral local runtime pathway and configuration principles.
 
+See the [real provider adapter design](real-provider-adapter-design.md) for the design-only future provider boundary. That packet does not implement provider calls, credential handling, network calls, or provider dependencies.
+
 Properties:
 
 - records measured local model invocation count
@@ -253,11 +255,13 @@ Current implementation:
 - `ModelCallResponse`: normalized response with measured model-call count, latency, token counters where available, provider/model labels, and metadata.
 - `ModelCallAdapter`: protocol for adapters that return measured model-call counters.
 - `DeterministicFakeModelCallAdapter`: deterministic local validation adapter for tests and harness development.
+- `DeterministicLocalRuntimeModelCallAdapter`: explicit opt-in deterministic in-process local runtime stub for local/no-network validation.
 - `BlockedModelCallAdapter`: fail-closed adapter for cases where real provider use has not been explicitly configured.
 - `ModelCallSummary`: aggregate counter helper for validation reports.
 
-The adapter selection skeleton currently supports `local_validation`, `blocked`, and `local_runtime_placeholder` kinds so future local model-call validation can add runtime adapters behind explicit opt-in.
-The `local_runtime_placeholder` kind is fail-closed until a concrete local runtime adapter is implemented and validated.
+The adapter selection skeleton currently supports `local_validation`, `local_runtime`, `blocked`, and `local_runtime_placeholder` kinds so future validation can add provider adapters behind explicit opt-in.
+The `local_runtime` kind is a deterministic in-process local/no-network stub. The `local_runtime_placeholder` kind remains fail-closed for unsupported runtime paths.
+Future real provider adapters are design-only and should follow the [real provider adapter design](real-provider-adapter-design.md) before implementation.
 
 The local/no-network validation examples expose explicit `--adapter` selection. `local_validation` preserves the current deterministic validation path, while `blocked` and `local_runtime_placeholder` fail closed before validation runs.
 

--- a/docs/benchmarks/real-provider-adapter-design.md
+++ b/docs/benchmarks/real-provider-adapter-design.md
@@ -1,0 +1,174 @@
+# Real Provider Adapter Design
+
+## Purpose
+
+This packet defines how future real provider adapters may integrate with KORA's provider-neutral model-call measurement boundary.
+
+This is a design-only document. It does not implement real provider calls, network calls, HTTP clients, provider credential handling, subprocess runtimes, external model downloads, provider dependencies, or benchmark artifacts.
+
+## Current Default
+
+KORA's current validation paths remain local/no-network by default.
+
+Current safe adapter kinds:
+
+- `local_validation`: default deterministic local validation adapter.
+- `local_runtime`: explicit opt-in deterministic in-process local runtime stub.
+- `blocked`: fail-closed adapter for unconfigured model-call paths.
+- `local_runtime_placeholder`: fail-closed design-only placeholder for unsupported runtime paths.
+
+Future real provider adapters must not become the default path. They must require explicit selection and configuration.
+
+## Non-Goals
+
+This design does not provide:
+
+- production cost reduction proof
+- real API-cost reduction proof
+- production benchmark proof
+- full runtime-integrated real-provider benchmark evidence
+- broad workload superiority proof
+- energy reduction evidence
+- formal government validation
+- signed partner validation
+- guaranteed adoption or funding
+
+This design also does not add provider SDKs, provider-specific runtime clients, provider credentials, HTTP calls, subprocess calls, or external model downloads.
+
+## Provider Adapter Lifecycle
+
+A future real provider adapter should follow a fail-closed lifecycle:
+
+1. Adapter unavailable by default.
+2. User explicitly selects a provider adapter.
+3. Adapter performs local preflight validation of required configuration.
+4. Missing or invalid configuration fails before any provider request is constructed.
+5. Request envelope is normalized through `ModelCallRequest`.
+6. Provider execution occurs only in a future implementation after explicit opt-in and preflight success.
+7. Provider response is normalized through `ModelCallResponse`.
+8. Aggregate counters are recorded through `ModelCallSummary` or an equivalent reporting boundary.
+9. Reports include only aggregate counters and sanitized summaries by default.
+
+Every failure before explicit provider execution should produce a clear error and should not silently fall back to another provider or local runtime.
+
+## Explicit Opt-In Requirement
+
+Future real provider adapters must require explicit user action. A provider adapter should not run because a credential happens to exist in the environment, a default model name is available, or a workload includes a prompt-like field.
+
+Required opt-in properties:
+
+- explicit adapter selection
+- explicit provider configuration
+- clear provider and model labels in output
+- no default remote provider fallback
+- no implicit network call during help, example listing, import, test discovery, or report rendering
+
+The local/no-network validation examples should continue to work without provider configuration.
+
+## Fail-Closed Behavior
+
+Future provider adapters should fail closed for:
+
+- missing provider configuration
+- missing provider credential
+- invalid provider model selection
+- unsupported adapter kind
+- unsupported workload privacy class
+- disabled artifact policy
+- attempted raw prompt or raw response persistence
+- provider timeout or malformed response
+
+Failures should be visible through the command exit status, reviewer-facing error text, and aggregate error counters where a report is intentionally produced.
+
+## Provider Credential Boundary
+
+Provider credentials are future runtime configuration, not repository content.
+
+Future implementations must preserve these boundaries:
+
+- no provider credentials committed to the repository
+- no provider credentials in examples, docs, reports, tests, or fixtures
+- no provider credential values in logs, errors, telemetry, Markdown reports, or JSON summaries
+- missing credentials fail closed before provider execution
+- provider credential source may be described generically, but secret values must never be emitted
+
+This packet does not implement credential loading, validation, storage, or redaction logic.
+
+## Telemetry And Counter Requirements
+
+Future real provider adapters should preserve the existing measurement shape while adding provider-specific fields only when they are safe and available.
+
+Required aggregate fields:
+
+- total requests
+- baseline model calls
+- KORA model calls
+- avoided model calls
+- avoided model-call rate
+- deterministic routes
+- model escalations
+- validation pass count
+- validation fail count
+- error count
+- fallback count
+- adapter kind
+- provider label
+- model label
+
+Optional fields, when safely available:
+
+- latency totals and percentiles
+- input token counts
+- output token counts
+- provider request identifiers after review and redaction
+- provider error classes without raw provider payloads
+
+Cost fields must remain absent unless pricing, billing data, workload, baseline, and claim language are separately reviewed. Estimated cost and measured cost should be clearly distinguished if they are ever added later.
+
+## Report Artifact Requirements
+
+Future provider reports should be conservative by default:
+
+- aggregate counters only
+- sanitized summaries only
+- no raw prompts
+- no raw provider responses
+- no provider credentials
+- no private user data
+- no proprietary datasets
+- no raw benchmark artifacts committed by default
+
+Generated reports should use local output paths, such as `/tmp`, unless a report is intentionally reviewed and selected for publication.
+
+## Security And Privacy Boundaries
+
+Future provider validation should use synthetic or sanitized workloads first. Workloads containing private data must not be committed and must not be used for public evidence without a separate privacy review.
+
+Provider adapters should treat request text, provider responses, request identifiers, and error payloads as potentially sensitive. Public documentation and reports should describe methodology, counters, and sanitized results rather than raw provider exchanges.
+
+## Future Test Plan
+
+Before any real provider implementation is added, the test plan should cover:
+
+- default behavior remains local/no-network
+- provider adapter is unavailable unless explicitly selected
+- missing provider configuration fails closed before provider execution
+- unsupported provider configuration fails clearly
+- help and example listing make no provider calls
+- tests do not require provider credentials
+- report generation excludes secrets, raw prompts, and raw provider responses
+- fail-closed paths do not write misleading success reports
+- provider-specific tests are skipped unless explicitly enabled in a controlled environment
+- safety scans detect newly introduced network, subprocess, provider SDK, or credential-handling code
+
+## Evidence Boundary
+
+Current public evidence remains local/no-network or deterministic-heavy:
+
+> KORA reduced model invocations by 80% in a reproducible deterministic-heavy benchmark workload.
+
+KORA's local no-network validation examples show that KORA can measure avoided model-call events in synthetic workloads.
+
+Future provider evidence would differ from the current synthetic/no-network evidence because it would include explicitly configured provider execution, provider/model labels, measured provider invocation counters, and a reviewed workload methodology. That future evidence would still not imply production cost reduction, real API-cost reduction, production benchmark proof, broad workload superiority, or energy reduction unless those claims are separately supported and reviewed.
+
+This design packet alone creates no new performance, cost, production, or energy claim.


### PR DESCRIPTION
Summary:
- Adds a design-only packet for future real provider adapters.
- Documents explicit opt-in, fail-closed behavior, telemetry/reporting expectations, and claim boundaries.
- Keeps current execution local/no-network only.

Validation:
- git diff --check
- python3 -m pytest
- python3 -m kora --help
- python3 -m kora examples list
- local_validation and local_runtime examples
- runtime_integrated_benchmark --offline
- fail-closed adapter checks
- public exposure scan
- claim safety scan
- network/provider safety scan

Safety:
- No real provider calls.
- No network calls.
- No provider dependencies.
- No API key handling implementation.
- No raw benchmark artifacts committed.
- No release/tag/package changes.
- No claim expansion.