### PR TITLE
Add provider fixture dry-run contract

### DIFF
--- a/docs/benchmarks/real-provider-adapter-design.md
+++ b/docs/benchmarks/real-provider-adapter-design.md
@@ -6,7 +6,7 @@ This packet defines how future real provider adapters may integrate with KORA's 
 
 This is a design-only document. It does not implement real provider calls, network calls, HTTP clients, provider credential handling, subprocess runtimes, external model downloads, provider dependencies, or benchmark artifacts.
 
-For the dry-run-first validation contract that should precede any future real provider implementation, see the [real provider test harness design](real-provider-test-harness-design.md).
+For the dry-run-first validation contract that should precede any future real provider implementation, see the [real provider test harness design](real-provider-test-harness-design.md). KORA also includes `kora/provider_fixture.py`, a local non-executing fixture validator for dry-run metadata. It validates safety flags and counters only; it does not construct provider requests, load credentials, call providers, call network endpoints, invoke subprocess runtimes, or download models.
 
 ## Current Default
 
@@ -163,7 +163,7 @@ Before any real provider implementation is added, the test plan should cover:
 - provider-specific tests are skipped unless explicitly enabled in a controlled environment
 - safety scans detect newly introduced network, subprocess, provider SDK, or credential-handling code
 
-The [real provider test harness design](real-provider-test-harness-design.md) defines a dry-run fixture and reporting contract for this pre-implementation stage.
+The [real provider test harness design](real-provider-test-harness-design.md) defines a dry-run fixture and reporting contract for this pre-implementation stage. The current `kora/provider_fixture.py` validator enforces the no-network, no-provider-call, no-secret-material, no-customer-data, and no-real-provider-response contract for documentation-safe fixture metadata.
 
 ## Evidence Boundary
 

--- a/docs/benchmarks/real-provider-test-harness-design.md
+++ b/docs/benchmarks/real-provider-test-harness-design.md
@@ -8,6 +8,8 @@ The harness exists to test provider adapter boundaries, fixture rules, reporting
 
 This document does not implement provider calls, network calls, HTTP clients, subprocess runtimes, provider credential handling, external model downloads, provider dependencies, or raw benchmark artifacts.
 
+KORA includes a small schema validator for dry-run fixture metadata in `kora/provider_fixture.py`. The validator is local and non-executing: it checks fixture shape, counters, and safety flags, but it does not construct provider requests, load credentials, call providers, call network endpoints, invoke subprocess runtimes, or download models.
+
 ## Non-Goals
 
 This packet does not provide:
@@ -44,19 +46,57 @@ Dry-run mode should never construct, send, replay, or simulate a raw provider re
 
 Dry-run fixtures should describe metadata and expected counter behavior, not provider payloads.
 
-Recommended fixture fields:
+Supported dry-run contract fields:
 
-- `fixture_id`
 - `fixture_version`
-- `mode`: `provider_dry_run`
 - `provider_label`: fake provider name only
 - `model_label`: fake model name only
+- `mode`: `dry_run` or `fixture`
+- `request_id`
+- `baseline_candidate_events`
+- `kora_routed_events`
+- `avoided_model_call_events`
+- `provider_attempted_events`
+- `provider_blocked_events`
+- `no_network`: must be `true`
+- `no_provider_call`: must be `true`
+- `contains_real_provider_response`: must be `false`
+- `contains_customer_data`: must be `false`
+- `contains_secret_material`: must be `false`
+- `notes`: safe explanatory strings only
+
+Design-only harnesses may wrap this per-request contract in a larger fixture envelope with fields such as:
+
+- `fixture_id`
 - `workload_id`
 - `privacy_class`: `synthetic` or `sanitized`
 - `requests`
 - `expected_counters`
 - `claim_boundary`
 - `artifact_policy`
+
+Minimal validator input example:
+
+```json
+{
+  "fixture_version": "0.1",
+  "provider_label": "example-provider",
+  "model_label": "example-model",
+  "mode": "dry_run",
+  "request_id": "dry_run_request_001",
+  "baseline_candidate_events": 2,
+  "kora_routed_events": 1,
+  "avoided_model_call_events": 1,
+  "provider_attempted_events": 0,
+  "provider_blocked_events": 2,
+  "no_network": true,
+  "no_provider_call": true,
+  "contains_real_provider_response": false,
+  "contains_customer_data": false,
+  "contains_secret_material": false,
+  "notes": ["Synthetic metadata only."]
+}
+```
 
 Recommended request fields:
 
@@ -90,7 +130,7 @@ This example is illustrative only. It is not a runnable fixture and it contains 
 {
   "fixture_id": "provider_dry_run_synthetic_example_v1",
   "fixture_version": "0.1",
-  "mode": "provider_dry_run",
+  "mode": "dry_run",
   "provider_label": "example-provider",
   "model_label": "example-model",
   "workload_id": "synthetic_provider_dry_run_v1",
@@ -141,6 +181,21 @@ This example is illustrative only. It is not a runnable fixture and it contains 
 ## Fixture Safety Rules
 
 Fixtures must be safe for public review by default.
+
+The current schema validator enforces these fail-closed rules:
+
+- `mode` must be `dry_run` or `fixture`
+- `no_network` must be `true`
+- `no_provider_call` must be `true`
+- `contains_real_provider_response` must be `false`
+- `contains_customer_data` must be `false`
+- `contains_secret_material` must be `false`
+- `provider_attempted_events` must be `0`
+- `provider_blocked_events` must be zero or greater
+- `avoided_model_call_events` must be zero or greater
+- all counter fields must be integers and non-negative
+
+Invalid fixtures raise a clear validation error before any report generation or future provider boundary is reached.
 
 Required rules:
 
@@ -246,8 +301,13 @@ Reports should not include cost fields in dry-run mode. If cost fields are added
 Future CI tests can validate the dry-run contract without provider access:
 
 - fixture schema accepts safe synthetic metadata
+- fixture schema rejects `no_network=false`
+- fixture schema rejects `no_provider_call=false`
 - fixture schema rejects secret-like values
 - fixture schema rejects raw provider responses
+- fixture schema rejects customer data flags
+- fixture schema rejects negative counters
+- fixture schema rejects unknown modes
 - dry-run mode keeps `provider_attempted_events` at `0`
 - provider-required routes increment `provider_blocked_events`
 - deterministic routes reduce `kora_routed_events`

--- a/kora/provider_fixture.py
+++ b/kora/provider_fixture.py
@@ -1,0 +1,187 @@
+"""Dry-run provider fixture validation.
+
+This module validates documentation-safe provider fixture metadata for future
+real-provider validation planning. It does not construct provider requests,
+load credentials, call network APIs, or execute local runtimes.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Mapping
+
+SAFE_PROVIDER_FIXTURE_MODES = ("dry_run", "fixture")
+
+_COUNTER_FIELDS = (
+    "baseline_candidate_events",
+    "kora_routed_events",
+    "avoided_model_call_events",
+    "provider_attempted_events",
+    "provider_blocked_events",
+)
+
+
+class ProviderFixtureValidationError(ValueError):
+    """Raised when a provider fixture violates the dry-run contract."""
+
+
+@dataclass(frozen=True)
+class ProviderFixtureDryRunContract:
+    """Validated provider fixture metadata for dry-run-only checks."""
+
+    fixture_version: str
+    provider_label: str
+    model_label: str
+    mode: str
+    request_id: str
+    baseline_candidate_events: int
+    kora_routed_events: int
+    avoided_model_call_events: int
+    provider_attempted_events: int
+    provider_blocked_events: int
+    no_network: bool
+    no_provider_call: bool
+    contains_real_provider_response: bool
+    contains_customer_data: bool
+    contains_secret_material: bool
+    notes: list[str] = field(default_factory=list)
+
+    @classmethod
+    def from_mapping(cls, fixture: Mapping[str, Any]) -> "ProviderFixtureDryRunContract":
+        """Validate fixture metadata and return a dry-run contract object."""
+
+        return validate_provider_fixture(fixture)
+
+    def report_fields(self) -> dict[str, Any]:
+        """Return aggregate report fields safe for reviewer-facing summaries."""
+
+        return {
+            "fixture_version": self.fixture_version,
+            "provider_label": self.provider_label,
+            "model_label": self.model_label,
+            "mode": self.mode,
+            "request_id": self.request_id,
+            "baseline_candidate_events": self.baseline_candidate_events,
+            "kora_routed_events": self.kora_routed_events,
+            "avoided_model_call_events": self.avoided_model_call_events,
+            "provider_attempted_events": self.provider_attempted_events,
+            "provider_blocked_events": self.provider_blocked_events,
+            "no_network": self.no_network,
+            "no_provider_call": self.no_provider_call,
+            "contains_real_provider_response": self.contains_real_provider_response,
+            "contains_customer_data": self.contains_customer_data,
+            "contains_secret_material": self.contains_secret_material,
+            "notes": list(self.notes),
+        }
+
+
+def validate_provider_fixture(
+    fixture: Mapping[str, Any],
+) -> ProviderFixtureDryRunContract:
+    """Validate a provider fixture without attempting provider execution."""
+
+    if not isinstance(fixture, Mapping):
+        raise ProviderFixtureValidationError("Provider fixture must be a mapping.")
+
+    mode = _required_string(fixture, "mode")
+    if mode not in SAFE_PROVIDER_FIXTURE_MODES:
+        supported = ", ".join(SAFE_PROVIDER_FIXTURE_MODES)
+        raise ProviderFixtureValidationError(
+            f"Provider fixture mode {mode!r} is unsupported. Supported: {supported}."
+        )
+
+    no_network = _required_bool(fixture, "no_network")
+    if no_network is not True:
+        raise ProviderFixtureValidationError("Provider fixture must set no_network=true.")
+
+    no_provider_call = _required_bool(fixture, "no_provider_call")
+    if no_provider_call is not True:
+        raise ProviderFixtureValidationError(
+            "Provider fixture must set no_provider_call=true."
+        )
+
+    contains_real_provider_response = _required_bool(
+        fixture, "contains_real_provider_response"
+    )
+    if contains_real_provider_response is not False:
+        raise ProviderFixtureValidationError(
+            "Provider fixture must not contain real provider responses."
+        )
+
+    contains_customer_data = _required_bool(fixture, "contains_customer_data")
+    if contains_customer_data is not False:
+        raise ProviderFixtureValidationError(
+            "Provider fixture must not contain customer data."
+        )
+
+    contains_secret_material = _required_bool(fixture, "contains_secret_material")
+    if contains_secret_material is not False:
+        raise ProviderFixtureValidationError(
+            "Provider fixture must not contain secret material."
+        )
+
+    counters = {field_name: _required_counter(fixture, field_name) for field_name in _COUNTER_FIELDS}
+    if counters["provider_attempted_events"] != 0:
+        raise ProviderFixtureValidationError(
+            "Dry-run provider fixtures must keep provider_attempted_events at 0."
+        )
+
+    notes = _optional_notes(fixture.get("notes", []))
+
+    return ProviderFixtureDryRunContract(
+        fixture_version=_required_string(fixture, "fixture_version"),
+        provider_label=_required_string(fixture, "provider_label"),
+        model_label=_required_string(fixture, "model_label"),
+        mode=mode,
+        request_id=_required_string(fixture, "request_id"),
+        baseline_candidate_events=counters["baseline_candidate_events"],
+        kora_routed_events=counters["kora_routed_events"],
+        avoided_model_call_events=counters["avoided_model_call_events"],
+        provider_attempted_events=counters["provider_attempted_events"],
+        provider_blocked_events=counters["provider_blocked_events"],
+        no_network=no_network,
+        no_provider_call=no_provider_call,
+        contains_real_provider_response=contains_real_provider_response,
+        contains_customer_data=contains_customer_data,
+        contains_secret_material=contains_secret_material,
+        notes=notes,
+    )
+
+
+def _required_string(fixture: Mapping[str, Any], field_name: str) -> str:
+    value = fixture.get(field_name)
+    if not isinstance(value, str) or not value.strip():
+        raise ProviderFixtureValidationError(
+            f"Provider fixture field {field_name!r} must be a non-empty string."
+        )
+    return value
+
+
+def _required_bool(fixture: Mapping[str, Any], field_name: str) -> bool:
+    value = fixture.get(field_name)
+    if not isinstance(value, bool):
+        raise ProviderFixtureValidationError(
+            f"Provider fixture field {field_name!r} must be a boolean."
+        )
+    return value
+
+
+def _required_counter(fixture: Mapping[str, Any], field_name: str) -> int:
+    value = fixture.get(field_name)
+    if not isinstance(value, int) or isinstance(value, bool):
+        raise ProviderFixtureValidationError(
+            f"Provider fixture counter {field_name!r} must be an integer."
+        )
+    if value < 0:
+        raise ProviderFixtureValidationError(
+            f"Provider fixture counter {field_name!r} must be non-negative."
+        )
+    return value
+
+
+def _optional_notes(value: Any) -> list[str]:
+    if not isinstance(value, list) or not all(isinstance(note, str) for note in value):
+        raise ProviderFixtureValidationError(
+            "Provider fixture field 'notes' must be a list of strings."
+        )
+    return list(value)

--- a/tests/test_provider_fixture.py
+++ b/tests/test_provider_fixture.py
@@ -1,0 +1,147 @@
+import pytest
+
+from kora.provider_fixture import (
+    ProviderFixtureDryRunContract,
+    ProviderFixtureValidationError,
+    validate_provider_fixture,
+)
+
+
+def valid_fixture() -> dict[str, object]:
+    return {
+        "fixture_version": "0.1",
+        "provider_label": "example-provider",
+        "model_label": "example-model",
+        "mode": "dry_run",
+        "request_id": "dry_run_request_001",
+        "baseline_candidate_events": 2,
+        "kora_routed_events": 1,
+        "avoided_model_call_events": 1,
+        "provider_attempted_events": 0,
+        "provider_blocked_events": 2,
+        "no_network": True,
+        "no_provider_call": True,
+        "contains_real_provider_response": False,
+        "contains_customer_data": False,
+        "contains_secret_material": False,
+        "notes": ["Synthetic metadata only."],
+    }
+
+
+def test_valid_provider_fixture_passes() -> None:
+    contract = validate_provider_fixture(valid_fixture())
+
+    assert isinstance(contract, ProviderFixtureDryRunContract)
+    assert contract.mode == "dry_run"
+    assert contract.provider_label == "example-provider"
+    assert contract.model_label == "example-model"
+    assert contract.provider_attempted_events == 0
+    assert contract.provider_blocked_events == 2
+    assert contract.no_network is True
+    assert contract.no_provider_call is True
+
+
+def test_fixture_mode_alias_passes() -> None:
+    fixture = valid_fixture()
+    fixture["mode"] = "fixture"
+
+    contract = ProviderFixtureDryRunContract.from_mapping(fixture)
+
+    assert contract.mode == "fixture"
+
+
+@pytest.mark.parametrize(
+    ("field_name", "value", "message"),
+    [
+        ("no_network", False, "no_network=true"),
+        ("no_provider_call", False, "no_provider_call=true"),
+        (
+            "contains_real_provider_response",
+            True,
+            "must not contain real provider responses",
+        ),
+        ("contains_customer_data", True, "must not contain customer data"),
+        ("contains_secret_material", True, "must not contain secret material"),
+    ],
+)
+def test_provider_fixture_safety_flags_fail_closed(
+    field_name: str,
+    value: object,
+    message: str,
+) -> None:
+    fixture = valid_fixture()
+    fixture[field_name] = value
+
+    with pytest.raises(ProviderFixtureValidationError, match=message):
+        validate_provider_fixture(fixture)
+
+
+def test_provider_attempted_events_must_remain_zero() -> None:
+    fixture = valid_fixture()
+    fixture["provider_attempted_events"] = 1
+
+    with pytest.raises(ProviderFixtureValidationError, match="provider_attempted_events"):
+        validate_provider_fixture(fixture)
+
+
+@pytest.mark.parametrize(
+    "field_name",
+    [
+        "baseline_candidate_events",
+        "kora_routed_events",
+        "avoided_model_call_events",
+        "provider_attempted_events",
+        "provider_blocked_events",
+    ],
+)
+def test_provider_fixture_negative_counters_fail(field_name: str) -> None:
+    fixture = valid_fixture()
+    fixture[field_name] = -1
+
+    with pytest.raises(ProviderFixtureValidationError, match="non-negative"):
+        validate_provider_fixture(fixture)
+
+
+def test_provider_fixture_boolean_counter_fails() -> None:
+    fixture = valid_fixture()
+    fixture["avoided_model_call_events"] = True
+
+    with pytest.raises(ProviderFixtureValidationError, match="must be an integer"):
+        validate_provider_fixture(fixture)
+
+
+def test_provider_fixture_unknown_mode_fails() -> None:
+    fixture = valid_fixture()
+    fixture["mode"] = "remote_provider"
+
+    with pytest.raises(ProviderFixtureValidationError, match="unsupported"):
+        validate_provider_fixture(fixture)
+
+
+def test_provider_fixture_missing_required_string_fails() -> None:
+    fixture = valid_fixture()
+    fixture["provider_label"] = ""
+
+    with pytest.raises(ProviderFixtureValidationError, match="provider_label"):
+        validate_provider_fixture(fixture)
+
+
+def test_provider_fixture_notes_must_be_strings() -> None:
+    fixture = valid_fixture()
+    fixture["notes"] = ["safe", 123]
+
+    with pytest.raises(ProviderFixtureValidationError, match="notes"):
+        validate_provider_fixture(fixture)
+
+
+def test_provider_fixture_report_fields_are_aggregate_and_safe() -> None:
+    contract = validate_provider_fixture(valid_fixture())
+
+    report_fields = contract.report_fields()
+
+    assert report_fields["provider_label"] == "example-provider"
+    assert report_fields["provider_attempted_events"] == 0
+    assert report_fields["contains_real_provider_response"] is False
+    assert "prompt" not in report_fields
+    assert "response" not in report_fields
+    assert "api_key" not in report_fields


### PR DESCRIPTION
## Summary
- Adds a provider fixture schema and dry-run validation contract in `kora/provider_fixture.py`.
- Enforces no-network, no-provider-call, no-real-provider-response, no-customer-data, no-secret-material, and non-negative counter rules.
- Updates the real provider design docs to describe the concrete dry-run fixture validator and its fail-closed safety boundary.

## Validation
- `git diff --check`
- `python3 -m pytest`
- `python3 -m kora --help`
- `python3 -m kora examples list`
- `python3 -m kora run real_model_call_validation_fake -- --offline --adapter local_validation`
- `python3 -m kora run real_model_call_validation_fake -- --offline --adapter local_runtime`
- `python3 -m kora run customer_support_triage_fake_validation -- --offline --adapter local_validation`
- `python3 -m kora run customer_support_triage_fake_validation -- --offline --adapter local_runtime`
- `python3 -m kora run runtime_integrated_benchmark -- --offline`
- fail-closed adapter checks for `blocked` and `local_runtime_placeholder`
- public exposure scan
- claim safety scan
- network/provider safety scan
- secret/data safety scan

## Safety
- No real provider calls.
- No network calls.
- No subprocess runtime calls.
- No provider dependencies.
- No API key handling implementation.
- No raw benchmark artifacts committed.
- No release/tag/package changes.
- No claim expansion.
