### PR TITLE
Upgrade local validation report packet

### DIFF
--- a/docs/benchmarks/local-validation-reviewer-packet.md
+++ b/docs/benchmarks/local-validation-reviewer-packet.md
@@ -79,11 +79,33 @@ Observed local/no-network baseline examples from the current reviewer pass:
 python3 -m kora run real_model_call_validation_fake -- --offline --report-md /tmp/kora_local_validation.md
 
 python3 -m kora run customer_support_triage_fake_validation -- --offline --report-md /tmp/kora_customer_support_validation.md
+
+python3 -m kora run customer_support_triage_fake_validation -- --offline --adapter local_runtime --report-md /tmp/kora_customer_support_local_runtime.md
 ```
 
 Reports are written only when `--report-md` is provided. Use `/tmp` or another local output path for generated artifacts unless a report is intentionally selected for review.
 
 Generated reports are not committed by default. They contain aggregate counters and boundary language. They do not contain raw prompts, raw provider responses, secrets, or private data.
+
+Generated local/no-network reports are organized to separate:
+
+- report metadata, including report type, generated timestamp, adapter kind, provider label, model label, offline status, no-network status, and fail-closed status
+- aggregate synthetic evidence, including baseline candidate events, KORA-routed model-call events, and avoided model-call events
+- adapter-selection result, including the selected local/no-network adapter and labels
+- provider fixture dry-run contract status, using aggregate metadata only
+- safety boundaries, interpretation, and explicit non-claims
+
+For successful local/no-network validation reports, provider fixture dry-run contract status is expected to show:
+
+- `mode`: `dry_run`
+- `no_network`: `true`
+- `no_provider_call`: `true`
+- `contains_real_provider_response`: `false`
+- `contains_customer_data`: `false`
+- `contains_secret_material`: `false`
+- `provider_attempted_events`: `0`
+
+This contract status is a local dry-run report field. It is not a provider request, provider response, credential check, network call, or real-provider validation.
 
 ## Adapter Selection
 

--- a/docs/benchmarks/real-provider-test-harness-design.md
+++ b/docs/benchmarks/real-provider-test-harness-design.md
@@ -296,6 +296,8 @@ Before any future real-provider validation, reports should include:
 
 Reports should not include cost fields in dry-run mode. If cost fields are added in a later real-provider task, estimated and measured values must be separated and claim-reviewed.
 
+Current local/no-network validation reports include a provider fixture dry-run contract status section for reviewer visibility. That section is aggregate metadata only. It records values such as `mode=dry_run`, `no_network=true`, `no_provider_call=true`, `provider_attempted_events=0`, and prohibited-content flags set to false. It does not include provider requests, provider responses, credentials, customer data, raw prompts, network calls, or provider execution.
+
 ## Future CI Test Plan
 
 Future CI tests can validate the dry-run contract without provider access:

--- a/examples/customer_support_triage_fake_validation/run.py
+++ b/examples/customer_support_triage_fake_validation/run.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import argparse
 import json
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
@@ -18,6 +19,7 @@ from kora.model_call import (
     available_model_call_adapters,
     select_model_call_adapter,
 )
+from kora.provider_fixture import validate_provider_fixture
 from kora.validation_report import render_local_validation_markdown
 
 DEFAULT_WORKLOAD = Path("experiments/workloads/customer_support_triage_synthetic_v1.json")
@@ -159,6 +161,42 @@ def _run_kora_controlled_path(
     )
 
 
+def _generated_at() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def _provider_fixture_contract_fields(
+    *,
+    provider_label: str,
+    model_label: str,
+    baseline_candidate_events: int,
+    kora_routed_events: int,
+    avoided_model_call_events: int,
+) -> dict[str, Any]:
+    fixture = {
+        "fixture_version": "0.1",
+        "provider_label": provider_label,
+        "model_label": model_label,
+        "mode": "dry_run",
+        "request_id": "customer_support_triage_local_validation_report",
+        "baseline_candidate_events": baseline_candidate_events,
+        "kora_routed_events": kora_routed_events,
+        "avoided_model_call_events": avoided_model_call_events,
+        "provider_attempted_events": 0,
+        "provider_blocked_events": 0,
+        "no_network": True,
+        "no_provider_call": True,
+        "contains_real_provider_response": False,
+        "contains_customer_data": False,
+        "contains_secret_material": False,
+        "notes": [
+            "Generated from aggregate local/no-network validation counters.",
+            "No provider request, provider response, credential, or customer data is included.",
+        ],
+    }
+    return validate_provider_fixture(fixture).report_fields()
+
+
 def build_customer_support_triage_fake_validation_summary(
     *,
     offline: bool = True,
@@ -192,17 +230,24 @@ def build_customer_support_triage_fake_validation_summary(
         if baseline_summary.model_calls
         else 0.0
     )
+    provider_label = baseline_responses[0].provider
+    model_label = baseline_responses[0].model
 
     return {
+        "report_type": "local_no_network_validation_packet",
+        "generated_at": _generated_at(),
         "ok": error_count == 0 and validation_fail_count == 0,
         "mode": "customer_support_triage_local_validation",
         "offline": True,
+        "no_network": True,
+        "no_provider_call": True,
+        "fail_closed_status": "not_applicable_successful_local_adapter",
         "workload_id": workload.get("workload_id"),
         "workload_path": str(workload_path),
         "privacy_class": workload.get("privacy_class"),
         "adapter": baseline_responses[0].metadata.get("adapter", adapter_kind),
-        "provider": baseline_responses[0].provider,
-        "model": baseline_responses[0].model,
+        "provider": provider_label,
+        "model": model_label,
         "total_requests": len(requests),
         "baseline_model_calls": baseline_summary.model_calls,
         "kora_model_calls": kora_summary.model_calls,
@@ -221,7 +266,20 @@ def build_customer_support_triage_fake_validation_summary(
         "latency_total_ms": kora_summary.latency_total_ms,
         "raw_prompts_emitted": False,
         "raw_responses_emitted": False,
-        "command": "python3 -m kora run customer_support_triage_fake_validation -- --offline",
+        "api_cost_evidence": False,
+        "production_benchmark_evidence": False,
+        "energy_evidence": False,
+        "provider_fixture_dry_run_contract": _provider_fixture_contract_fields(
+            provider_label=provider_label,
+            model_label=model_label,
+            baseline_candidate_events=baseline_summary.model_calls,
+            kora_routed_events=kora_summary.model_calls,
+            avoided_model_call_events=avoided_model_calls,
+        ),
+        "command": (
+            "python3 -m kora run customer_support_triage_fake_validation -- "
+            f"--offline --adapter {adapter_kind}"
+        ),
         "claim_boundary": CLAIM_BOUNDARY,
         "notes": [
             "Synthetic customer-support triage workload only.",

--- a/examples/real_model_call_validation_fake/run.py
+++ b/examples/real_model_call_validation_fake/run.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import argparse
 import json
 from dataclasses import dataclass
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Literal
 
@@ -24,6 +25,7 @@ from kora.model_call import (
     available_model_call_adapters,
     select_model_call_adapter,
 )
+from kora.provider_fixture import validate_provider_fixture
 from kora.validation_report import render_local_validation_markdown
 
 Route = Literal["deterministic", "model_required"]
@@ -193,6 +195,42 @@ def _run_kora_controlled_path(
     )
 
 
+def _generated_at() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def _provider_fixture_contract_fields(
+    *,
+    provider_label: str,
+    model_label: str,
+    baseline_candidate_events: int,
+    kora_routed_events: int,
+    avoided_model_call_events: int,
+) -> dict[str, Any]:
+    fixture = {
+        "fixture_version": "0.1",
+        "provider_label": provider_label,
+        "model_label": model_label,
+        "mode": "dry_run",
+        "request_id": "real_model_call_local_validation_report",
+        "baseline_candidate_events": baseline_candidate_events,
+        "kora_routed_events": kora_routed_events,
+        "avoided_model_call_events": avoided_model_call_events,
+        "provider_attempted_events": 0,
+        "provider_blocked_events": 0,
+        "no_network": True,
+        "no_provider_call": True,
+        "contains_real_provider_response": False,
+        "contains_customer_data": False,
+        "contains_secret_material": False,
+        "notes": [
+            "Generated from aggregate local/no-network validation counters.",
+            "No provider request, provider response, credential, or customer data is included.",
+        ],
+    }
+    return validate_provider_fixture(fixture).report_fields()
+
+
 def build_fake_model_call_validation_summary(
     *,
     offline: bool = True,
@@ -224,14 +262,21 @@ def build_fake_model_call_validation_summary(
         if baseline_summary.model_calls
         else 0.0
     )
+    provider_label = baseline_responses[0].provider
+    model_label = baseline_responses[0].model
 
     return {
+        "report_type": "local_no_network_validation_packet",
+        "generated_at": _generated_at(),
         "ok": error_count == 0 and validation_fail_count == 0,
         "mode": "local_no_network_model_call_validation",
         "offline": True,
+        "no_network": True,
+        "no_provider_call": True,
+        "fail_closed_status": "not_applicable_successful_local_adapter",
         "adapter": baseline_responses[0].metadata.get("adapter", adapter_kind),
-        "provider": baseline_responses[0].provider,
-        "model": baseline_responses[0].model,
+        "provider": provider_label,
+        "model": model_label,
         "total_requests": total_requests,
         "baseline_model_calls": baseline_summary.model_calls,
         "kora_model_calls": kora_summary.model_calls,
@@ -251,7 +296,20 @@ def build_fake_model_call_validation_summary(
         "privacy_class": "synthetic",
         "raw_prompts_emitted": False,
         "raw_responses_emitted": False,
-        "command": "python3 -m kora run real_model_call_validation_fake -- --offline",
+        "api_cost_evidence": False,
+        "production_benchmark_evidence": False,
+        "energy_evidence": False,
+        "provider_fixture_dry_run_contract": _provider_fixture_contract_fields(
+            provider_label=provider_label,
+            model_label=model_label,
+            baseline_candidate_events=baseline_summary.model_calls,
+            kora_routed_events=kora_summary.model_calls,
+            avoided_model_call_events=avoided_model_calls,
+        ),
+        "command": (
+            "python3 -m kora run real_model_call_validation_fake -- "
+            f"--offline --adapter {adapter_kind}"
+        ),
         "claim_boundary": CLAIM_BOUNDARY,
         "notes": [
             "Synthetic workload only.",

--- a/kora/validation_report.py
+++ b/kora/validation_report.py
@@ -6,10 +6,11 @@ from typing import Any
 
 
 BOUNDARY_TEXT = (
-    "This report describes local no-network validation using a deterministic "
-    "local validation adapter. It is not real provider validation, real "
-    "API-cost reduction evidence, production validation, production "
-    "cost-reduction proof, or energy-reduction evidence."
+    "This report describes local/no-network validation using a selected "
+    "local adapter, including the deterministic local validation adapter. "
+    "It is not real provider validation, real API-cost reduction evidence, "
+    "production validation, production cost-reduction proof, or "
+    "energy-reduction evidence."
 )
 
 COUNTER_KEYS = (
@@ -28,6 +29,18 @@ COUNTER_KEYS = (
     "output_tokens_total",
 )
 
+NON_CLAIMS = (
+    "no production cost reduction proof",
+    "no real API-cost reduction proof",
+    "no production benchmark proof",
+    "no full runtime-integrated real-provider benchmark evidence",
+    "no broad workload superiority proof",
+    "no energy reduction evidence",
+    "no formal government validation",
+    "no signed partner validation unless actually signed and documented",
+    "no guaranteed adoption or funding",
+)
+
 
 def _display(value: Any) -> str:
     if value is None:
@@ -41,20 +54,54 @@ def _summary_line(label: str, value: Any) -> str:
     return f"- {label}: `{_display(value)}`"
 
 
+def _bool_status(value: Any) -> str:
+    if value is True:
+        return "yes"
+    if value is False:
+        return "no"
+    return "N/A"
+
+
 def render_local_validation_markdown(summary: dict[str, Any]) -> str:
     """Render a claim-safe Markdown report from local validation counters."""
 
-    workload = summary.get("workload_id") or summary.get("workload_path") or "synthetic local workload"
+    workload = (
+        summary.get("workload_id")
+        or summary.get("workload_path")
+        or "synthetic local workload"
+    )
     command = summary.get("command")
     notes = summary.get("notes")
+    provider_fixture = summary.get("provider_fixture_dry_run_contract")
 
     lines = [
         "# Local No-Network Validation Report",
         "",
+        "## Report Metadata",
+        "",
+        _summary_line(
+            "Report type",
+            summary.get("report_type", "local_no_network_validation_packet"),
+        ),
+        _summary_line("Generated at", summary.get("generated_at", "N/A")),
+        _summary_line("Mode", summary.get("mode")),
+        _summary_line("Adapter kind", summary.get("adapter")),
+        _summary_line("Provider label", summary.get("provider")),
+        _summary_line("Model label", summary.get("model")),
+        _summary_line("Offline", _bool_status(summary.get("offline"))),
+        _summary_line("No network", _bool_status(summary.get("no_network"))),
+        _summary_line(
+            "No real provider call",
+            _bool_status(summary.get("no_provider_call")),
+        ),
+        _summary_line(
+            "Fail-closed status",
+            summary.get("fail_closed_status", "not_applicable"),
+        ),
+        "",
         "## Summary",
         "",
         _summary_line("Workload", workload),
-        _summary_line("Mode", summary.get("mode")),
         _summary_line("Provider", summary.get("provider")),
         _summary_line("Model", summary.get("model")),
         _summary_line("Privacy class", summary.get("privacy_class")),
@@ -83,11 +130,109 @@ def render_local_validation_markdown(summary: dict[str, Any]) -> str:
     lines.extend(
         [
             "",
+            "## Adapter Selection Result",
+            "",
+            _summary_line("Adapter kind", summary.get("adapter")),
+            _summary_line("Provider label", summary.get("provider")),
+            _summary_line("Model label", summary.get("model")),
+            _summary_line(
+                "Local/no-network status",
+                _bool_status(summary.get("no_network")),
+            ),
+            _summary_line(
+                "Real provider calls attempted",
+                "no" if summary.get("no_provider_call") is True else "N/A",
+            ),
+            "",
+            "## Provider Fixture Dry-Run Contract",
+            "",
+        ]
+    )
+
+    if isinstance(provider_fixture, dict):
+        lines.extend(
+            [
+                _summary_line("Status", "available"),
+                _summary_line("Mode", provider_fixture.get("mode")),
+                _summary_line("Provider label", provider_fixture.get("provider_label")),
+                _summary_line("Model label", provider_fixture.get("model_label")),
+                _summary_line(
+                    "Baseline candidate events",
+                    provider_fixture.get("baseline_candidate_events"),
+                ),
+                _summary_line(
+                    "KORA routed events",
+                    provider_fixture.get("kora_routed_events"),
+                ),
+                _summary_line(
+                    "Avoided model-call events",
+                    provider_fixture.get("avoided_model_call_events"),
+                ),
+                _summary_line(
+                    "Provider attempted events",
+                    provider_fixture.get("provider_attempted_events"),
+                ),
+                _summary_line(
+                    "Provider blocked events",
+                    provider_fixture.get("provider_blocked_events"),
+                ),
+                _summary_line("No network", _bool_status(provider_fixture.get("no_network"))),
+                _summary_line(
+                    "No provider call",
+                    _bool_status(provider_fixture.get("no_provider_call")),
+                ),
+                _summary_line(
+                    "Contains real provider response",
+                    _bool_status(provider_fixture.get("contains_real_provider_response")),
+                ),
+                _summary_line(
+                    "Contains customer data",
+                    _bool_status(provider_fixture.get("contains_customer_data")),
+                ),
+                _summary_line(
+                    "Contains secret material",
+                    _bool_status(provider_fixture.get("contains_secret_material")),
+                ),
+            ]
+        )
+    else:
+        lines.append("- Status: `not provided`")
+
+    lines.extend(
+        [
+            "",
             "## Boundary",
             "",
             BOUNDARY_TEXT,
             "",
-            "This report must not include raw prompts, raw provider responses, secrets, or private user data.",
+            (
+                "This report must not include raw prompts, raw provider responses, "
+                "secrets, or private user data."
+            ),
+            "",
+            "- No real provider call.",
+            "- No network call.",
+            "- No API-cost evidence.",
+            "- No production benchmark evidence.",
+            "- No energy evidence.",
+            "",
+            "## Interpretation",
+            "",
+            (
+                "KORA's local no-network validation examples show that KORA can "
+                "measure avoided model-call events in synthetic workloads."
+            ),
+            "",
+            (
+                "The counters in this report are aggregate local/no-network "
+                "validation counters. They separate direct baseline candidate "
+                "events, KORA-routed model-call events, and avoided model-call "
+                "events in synthetic workloads."
+            ),
+            "",
+            "## Explicit Non-Claims",
+            "",
+            *[f"- {non_claim}" for non_claim in NON_CLAIMS],
             "",
             "## Reproduction",
             "",

--- a/tests/test_customer_support_triage_fake_validation.py
+++ b/tests/test_customer_support_triage_fake_validation.py
@@ -193,6 +193,20 @@ def test_customer_support_triage_fake_validation_report_with_explicit_adapter(
     report = report_path.read_text(encoding="utf-8")
     assert "customer_support_triage_local_validation" in report
     assert "local_validation" in report
+    assert "## Report Metadata" in report
+    assert "## Adapter Selection Result" in report
+    assert "## Provider Fixture Dry-Run Contract" in report
+    assert "## Explicit Non-Claims" in report
+    assert "- Adapter kind: `local_validation`" in report
+    assert "- Local/no-network status: `yes`" in report
+    assert "- Baseline candidate events: `12`" in report
+    assert "- KORA routed events: `4`" in report
+    assert "- Avoided model-call events: `8`" in report
+    assert "no production cost reduction proof" in report
+    assert "no real API-cost reduction proof" in report
+    assert "no energy reduction evidence" in report
+    assert "real API cost reduction" not in report
+    assert "production cost reduction proof." not in report
 
 
 def test_customer_support_triage_fake_validation_report_with_local_runtime_adapter(
@@ -224,6 +238,12 @@ def test_customer_support_triage_fake_validation_report_with_local_runtime_adapt
     report = report_path.read_text(encoding="utf-8")
     assert "customer_support_triage_local_validation" in report
     assert "local_runtime" in report
+    assert "- Adapter kind: `local_runtime`" in report
+    assert "- Provider label: `local_runtime`" in report
+    assert "- Model label: `deterministic-local-runtime`" in report
+    assert "- No network: `yes`" in report
+    assert "- No provider call: `yes`" in report
+    assert "- Provider attempted events: `0`" in report
 
 
 def test_customer_support_triage_fake_validation_blocked_adapter_fails_closed(

--- a/tests/test_validation_report.py
+++ b/tests/test_validation_report.py
@@ -8,6 +8,13 @@ from kora.validation_report import render_local_validation_markdown
 def _summary() -> dict[str, object]:
     return {
         "mode": "customer_support_triage_local_validation",
+        "report_type": "local_no_network_validation_packet",
+        "generated_at": "2026-05-09T00:00:00Z",
+        "offline": True,
+        "no_network": True,
+        "no_provider_call": True,
+        "fail_closed_status": "not_applicable_successful_local_adapter",
+        "adapter": "local_validation",
         "workload_id": "customer_support_triage_synthetic_v1",
         "provider": "local_validation",
         "model": "deterministic-local",
@@ -25,6 +32,27 @@ def _summary() -> dict[str, object]:
         "fallback_count": 0,
         "input_tokens_total": 50,
         "output_tokens_total": 50,
+        "api_cost_evidence": False,
+        "production_benchmark_evidence": False,
+        "energy_evidence": False,
+        "provider_fixture_dry_run_contract": {
+            "fixture_version": "0.1",
+            "provider_label": "local_validation",
+            "model_label": "deterministic-local",
+            "mode": "dry_run",
+            "request_id": "customer_support_triage_local_validation_report",
+            "baseline_candidate_events": 12,
+            "kora_routed_events": 4,
+            "avoided_model_call_events": 8,
+            "provider_attempted_events": 0,
+            "provider_blocked_events": 0,
+            "no_network": True,
+            "no_provider_call": True,
+            "contains_real_provider_response": False,
+            "contains_customer_data": False,
+            "contains_secret_material": False,
+            "notes": ["Synthetic metadata only."],
+        },
         "command": "python3 -m kora run customer_support_triage_fake_validation -- --offline",
         "notes": ["Synthetic workload only."],
     }
@@ -34,9 +62,14 @@ def test_render_local_validation_markdown_includes_core_sections() -> None:
     markdown = render_local_validation_markdown(_summary())
 
     assert "# Local No-Network Validation Report" in markdown
+    assert "## Report Metadata" in markdown
     assert "## Summary" in markdown
     assert "## Counters" in markdown
+    assert "## Adapter Selection Result" in markdown
+    assert "## Provider Fixture Dry-Run Contract" in markdown
     assert "## Boundary" in markdown
+    assert "## Interpretation" in markdown
+    assert "## Explicit Non-Claims" in markdown
     assert "## Reproduction" in markdown
     assert "## Notes" in markdown
 
@@ -53,6 +86,22 @@ def test_render_local_validation_markdown_includes_required_counters() -> None:
     assert "| `output_tokens_total` | 50 |" in markdown
 
 
+def test_render_local_validation_markdown_includes_report_packet_fields() -> None:
+    markdown = render_local_validation_markdown(_summary())
+
+    assert "- Report type: `local_no_network_validation_packet`" in markdown
+    assert "- Adapter kind: `local_validation`" in markdown
+    assert "- Provider label: `local_validation`" in markdown
+    assert "- Model label: `deterministic-local`" in markdown
+    assert "- Offline: `yes`" in markdown
+    assert "- No network: `yes`" in markdown
+    assert "- No real provider call: `yes`" in markdown
+    assert "- Baseline candidate events: `12`" in markdown
+    assert "- KORA routed events: `4`" in markdown
+    assert "- Avoided model-call events: `8`" in markdown
+    assert "- Provider attempted events: `0`" in markdown
+
+
 def test_render_local_validation_markdown_is_claim_safe() -> None:
     markdown = render_local_validation_markdown(_summary())
 
@@ -65,6 +114,9 @@ def test_render_local_validation_markdown_is_claim_safe() -> None:
     assert "raw prompts" in markdown
     assert "raw provider responses" in markdown
     assert "private user data" in markdown
+    assert "no production cost reduction proof" in markdown
+    assert "no real API-cost reduction proof" in markdown
+    assert "no energy reduction evidence" in markdown
 
 
 def test_render_local_validation_markdown_does_not_emit_raw_payloads() -> None:
@@ -74,6 +126,9 @@ def test_render_local_validation_markdown_does_not_emit_raw_payloads() -> None:
     assert "raw_response" not in markdown
     assert "OPENAI_API_KEY" not in markdown
     assert "ANTHROPIC_API_KEY" not in markdown
+    assert "reduces real API costs" not in markdown
+    assert "reduces production AI costs" not in markdown
+    assert "reduces energy consumption" not in markdown
 
 
 def test_customer_support_example_writes_markdown_report(tmp_path: Path) -> None:
@@ -103,6 +158,11 @@ def test_customer_support_example_writes_markdown_report(tmp_path: Path) -> None
     assert "| `kora_model_calls` | 4 |" in report
     assert "customer_support_triage_local_validation" in report
     assert "local_validation" in report
+    assert "## Provider Fixture Dry-Run Contract" in report
+    assert "- Adapter kind: `local_validation`" in report
+    assert "- No network: `yes`" in report
+    assert "- No provider call: `yes`" in report
+    assert "no real API-cost reduction proof" in report
 
 
 def test_real_model_call_example_writes_markdown_report(tmp_path: Path) -> None:
@@ -132,3 +192,5 @@ def test_real_model_call_example_writes_markdown_report(tmp_path: Path) -> None:
     assert "| `kora_model_calls` | 4 |" in report
     assert "local_no_network_model_call_validation" in report
     assert "deterministic-local" in report
+    assert "## Adapter Selection Result" in report
+    assert "## Explicit Non-Claims" in report


### PR DESCRIPTION
Summary:
- Improves the local/no-network validation report packet.
- Separates synthetic evidence, adapter state, avoided model-call events, provider fixture status, and explicit non-claims.
- Updates tests/docs for reviewer-facing reproducibility.

Validation:
- git diff --check
- python3 -m pytest -> 138 passed
- python3 -m kora --help
- python3 -m kora examples list
- python3 -m kora run real_model_call_validation_fake -- --offline --adapter local_validation
- python3 -m kora run real_model_call_validation_fake -- --offline --adapter local_runtime
- python3 -m kora run customer_support_triage_fake_validation -- --offline --adapter local_validation
- python3 -m kora run customer_support_triage_fake_validation -- --offline --adapter local_runtime
- python3 -m kora run customer_support_triage_fake_validation -- --offline --adapter local_runtime --report-md /tmp/kora_task278_customer_support_local_runtime.md
- sed -n '1,240p' /tmp/kora_task278_customer_support_local_runtime.md
- python3 -m kora run runtime_integrated_benchmark -- --offline
- fail-closed adapter checks for blocked and local_runtime_placeholder
- public exposure scan
- claim safety scan
- network/provider safety scan
- secret/data safety scan

Safety:
- No real provider calls.
- No network calls.
- No subprocess runtime calls.
- No provider dependencies.
- No API key handling implementation.
- No raw benchmark artifacts committed.
- No release/tag/package changes.
- No claim expansion.
