### PR TITLE
Integrate provider fixture status into validation reports

### DIFF
--- a/docs/benchmarks/local-validation-reviewer-packet.md
+++ b/docs/benchmarks/local-validation-reviewer-packet.md
@@ -97,6 +97,7 @@ Generated local/no-network reports are organized to separate:
 
 For successful local/no-network validation reports, provider fixture dry-run contract status is expected to show:
 
+- `fixture_contract_status`: `passed`
 - `mode`: `dry_run`
 - `no_network`: `true`
 - `no_provider_call`: `true`
@@ -106,6 +107,8 @@ For successful local/no-network validation reports, provider fixture dry-run con
 - `provider_attempted_events`: `0`
 
 This contract status is a local dry-run report field. It is not a provider request, provider response, credential check, network call, or real-provider validation.
+
+If fixture validation fails, report generation must stop rather than writing a misleading success report.
 
 ## Adapter Selection
 

--- a/docs/benchmarks/real-provider-test-harness-design.md
+++ b/docs/benchmarks/real-provider-test-harness-design.md
@@ -296,7 +296,7 @@ Before any future real-provider validation, reports should include:
 
 Reports should not include cost fields in dry-run mode. If cost fields are added in a later real-provider task, estimated and measured values must be separated and claim-reviewed.
 
-Current local/no-network validation reports include a provider fixture dry-run contract status section for reviewer visibility. That section is aggregate metadata only. It records values such as `mode=dry_run`, `no_network=true`, `no_provider_call=true`, `provider_attempted_events=0`, and prohibited-content flags set to false. It does not include provider requests, provider responses, credentials, customer data, raw prompts, network calls, or provider execution.
+Current local/no-network validation reports include a provider fixture dry-run contract status section for reviewer visibility. That section is aggregate metadata only. It records values such as `fixture_contract_status=passed`, `mode=dry_run`, `no_network=true`, `no_provider_call=true`, `provider_attempted_events=0`, and prohibited-content flags set to false. It does not include provider requests, provider responses, credentials, customer data, raw prompts, network calls, or provider execution. If fixture validation fails, report generation should fail closed instead of writing a misleading success report.
 
 ## Future CI Test Plan
 

--- a/kora/provider_fixture.py
+++ b/kora/provider_fixture.py
@@ -56,6 +56,7 @@ class ProviderFixtureDryRunContract:
         """Return aggregate report fields safe for reviewer-facing summaries."""
 
         return {
+            "fixture_contract_status": "passed",
             "fixture_version": self.fixture_version,
             "provider_label": self.provider_label,
             "model_label": self.model_label,

--- a/kora/validation_report.py
+++ b/kora/validation_report.py
@@ -152,7 +152,12 @@ def render_local_validation_markdown(summary: dict[str, Any]) -> str:
     if isinstance(provider_fixture, dict):
         lines.extend(
             [
-                _summary_line("Status", "available"),
+                _summary_line(
+                    "Fixture contract status",
+                    provider_fixture.get("fixture_contract_status", "passed"),
+                ),
+                _summary_line("Fixture version", provider_fixture.get("fixture_version")),
+                _summary_line("Request id", provider_fixture.get("request_id")),
                 _summary_line("Mode", provider_fixture.get("mode")),
                 _summary_line("Provider label", provider_fixture.get("provider_label")),
                 _summary_line("Model label", provider_fixture.get("model_label")),

--- a/tests/test_customer_support_triage_fake_validation.py
+++ b/tests/test_customer_support_triage_fake_validation.py
@@ -246,6 +246,27 @@ def test_customer_support_triage_fake_validation_report_with_local_runtime_adapt
     assert "- Provider attempted events: `0`" in report
 
 
+def test_customer_support_triage_report_fixture_validation_failure_fails_closed(
+    monkeypatch,
+) -> None:
+    module = _load_example_module()
+
+    def fail_validation(_fixture):
+        raise ValueError("fixture validation failed closed")
+
+    monkeypatch.setattr(module, "validate_provider_fixture", fail_validation)
+
+    try:
+        module.build_customer_support_triage_fake_validation_summary(
+            offline=True,
+            adapter_kind="local_runtime",
+        )
+    except ValueError as exc:
+        assert "fixture validation failed closed" in str(exc)
+    else:
+        raise AssertionError("expected fixture validation failure")
+
+
 def test_customer_support_triage_fake_validation_blocked_adapter_fails_closed(
     tmp_path: Path,
 ) -> None:

--- a/tests/test_provider_fixture.py
+++ b/tests/test_provider_fixture.py
@@ -139,6 +139,7 @@ def test_provider_fixture_report_fields_are_aggregate_and_safe() -> None:
 
     report_fields = contract.report_fields()
 
+    assert report_fields["fixture_contract_status"] == "passed"
     assert report_fields["provider_label"] == "example-provider"
     assert report_fields["provider_attempted_events"] == 0
     assert report_fields["contains_real_provider_response"] is False

--- a/tests/test_validation_report.py
+++ b/tests/test_validation_report.py
@@ -36,6 +36,7 @@ def _summary() -> dict[str, object]:
         "production_benchmark_evidence": False,
         "energy_evidence": False,
         "provider_fixture_dry_run_contract": {
+            "fixture_contract_status": "passed",
             "fixture_version": "0.1",
             "provider_label": "local_validation",
             "model_label": "deterministic-local",
@@ -99,6 +100,9 @@ def test_render_local_validation_markdown_includes_report_packet_fields() -> Non
     assert "- Baseline candidate events: `12`" in markdown
     assert "- KORA routed events: `4`" in markdown
     assert "- Avoided model-call events: `8`" in markdown
+    assert "- Fixture contract status: `passed`" in markdown
+    assert "- No network: `yes`" in markdown
+    assert "- No provider call: `yes`" in markdown
     assert "- Provider attempted events: `0`" in markdown
 
 


### PR DESCRIPTION
Summary:
- Integrates provider fixture dry-run validation status into local/no-network Markdown reports.
- Adds an explicit `fixture_contract_status=passed` field to validated provider fixture report fields.
- Makes report output clearer about no-network, no-provider-call, no-secret, and no-customer-data boundaries.
- Adds tests for report output and fail-closed fixture validation behavior.

Validation:
- git diff --check
- python3 -m pytest
- python3 -m kora --help
- python3 -m kora examples list
- python3 -m kora run real_model_call_validation_fake -- --offline --adapter local_validation
- python3 -m kora run real_model_call_validation_fake -- --offline --adapter local_runtime
- python3 -m kora run customer_support_triage_fake_validation -- --offline --adapter local_validation
- python3 -m kora run customer_support_triage_fake_validation -- --offline --adapter local_runtime
- python3 -m kora run customer_support_triage_fake_validation -- --offline --adapter local_runtime --report-md /tmp/kora_task281_customer_support_local_runtime.md
- python3 -m kora run runtime_integrated_benchmark -- --offline
- fail-closed adapter checks for blocked and local_runtime_placeholder
- public exposure scan
- claim safety scan
- network/provider safety scan
- secret/data safety scan

Safety:
- No real provider calls.
- No network calls.
- No subprocess runtime calls.
- No provider dependencies.
- No API key handling implementation.
- No raw benchmark artifacts committed.
- No release/tag/package changes.
- No claim expansion.