### PR TITLE
Add KORA EOD report for adapter baseline workstream

### DIFF
--- a/docs/eod/kora_eod_2026_05_09_adapter_baseline_provider_fixture_workstream.md
+++ b/docs/eod/kora_eod_2026_05_09_adapter_baseline_provider_fixture_workstream.md
@@ -1,0 +1,110 @@
+# KORA EOD Report - Adapter Baseline and Provider Fixture Workstream
+
+## Date
+
+2026-05-09
+
+## Public Repo
+
+https://github.com/Krako-Labs/KORA
+
+## Public HEAD At Start
+
+`66f25119240d328e3446a8ccb3481f79c84419c0`
+
+## Current Validation State
+
+- `python3 -m pytest` -> `139 passed`
+- Public exposure scan -> no matches
+- Claim safety scan -> only explicit non-claim / boundary language
+- Network/provider safety scan -> no unsafe executable provider/runtime dependency
+- Secret/data safety scan -> no real secrets
+
+## Completed Workstream Summary
+
+- Repo-specific GitHub credential/context separation completed.
+- Public internal workflow exposure cleanup completed.
+- Explicit adapter-selection option completed.
+- Opt-in `local_runtime` adapter completed.
+- Real provider adapter design-only packet completed.
+- Real provider test harness design-only packet completed.
+- Provider fixture dry-run contract completed.
+- Local validation report packet upgraded.
+- Provider fixture report integration completed.
+
+## Merged PRs
+
+- PR #68: explicit adapter selection
+- PR #69: public internal workflow cleanup
+- PR #70: local validation reviewer packet polish
+- PR #71: opt-in local runtime adapter
+- PR #72: real provider adapter design packet
+- PR #73: real provider test harness design packet
+- PR #74: provider fixture dry-run contract
+- PR #75: local validation report packet upgrade
+- PR #76: provider fixture report integration
+
+## Current Adapter State
+
+- Default adapter: `local_validation`
+- Explicit local adapter: `local_runtime`
+- `local_runtime` provider label: `local_runtime`
+- `local_runtime` model label: `deterministic-local-runtime`
+- `blocked` remains fail-closed
+- `local_runtime_placeholder` remains fail-closed/design-only
+- Future real provider adapter remains design-only; no implementation yet
+
+## Current Baseline Summary
+
+- `runtime_integrated_benchmark --offline`: avoided simulated invocations `80/100`
+- `real_model_call_validation_fake --adapter local_runtime`: baseline `10`, KORA `4`, avoided `6`
+- `customer_support_triage_fake_validation --adapter local_runtime`: baseline `12`, KORA `4`, avoided `8`
+
+## Current Report Packet State
+
+- `fixture_contract_status`: `passed`
+- `no_network`: `yes`
+- `no_provider_call`: `yes`
+- `provider_attempted_events`: `0`
+- Baseline / KORA / avoided counters included
+- Safety boundaries included
+- Interpretation included
+- Explicit non-claims included
+
+## Current Provider Fixture State
+
+- Stdlib-only dry-run fixture validator
+- Requires `no_network=true`
+- Requires `no_provider_call=true`
+- Rejects real provider responses
+- Rejects customer data
+- Rejects secret material
+- Rejects negative counters
+- Rejects unsafe modes
+- Rejects `provider_attempted_events > 0`
+
+## Safe Interpretation
+
+KORA's local/no-network validation now provides reproducible synthetic evidence that KORA can measure avoided model-call events under deterministic and fixture-validated conditions.
+
+## Safe Public Claim
+
+KORA reduced model invocations by 80% in a reproducible deterministic-heavy benchmark workload.
+
+## Explicit Non-Claims
+
+- no production cost reduction proof
+- no real API-cost reduction proof
+- no production benchmark proof
+- no full runtime-integrated real-provider benchmark evidence
+- no broad workload superiority proof
+- no energy reduction evidence
+- no formal government validation
+- no signed partner validation unless actually signed and documented
+- no guaranteed adoption or funding
+
+## Next Public Technical Priorities
+
+1. Optional old worktree cleanup after explicit approval.
+2. Future real-provider work only after explicit approval and safety gates.
+3. No provider/API/cost/energy claim expansion until real evidence exists.


### PR DESCRIPTION
- Summary:
  - Adds a public EOD report for the adapter-selection, local-runtime, provider-fixture, and report-packet workstream.
  - Records current validation status and claim boundaries.
  - Keeps internal workflow handoff materials local-only.
- Validation:
  - git diff --check
  - python3 -m pytest
  - local report generation
  - public exposure scan
  - claim safety scan
  - network/provider safety scan
  - secret/data safety scan
- Safety:
  - No real provider calls.
  - No network calls.
  - No raw benchmark artifacts committed.
  - No release/tag/package changes.
  - No claim expansion.
  - No internal workflow content added to public docs.