### PR TITLE
Add public contributor pathway docs

### DIFF
--- a/.github/ISSUE_TEMPLATE/workload_proposal.md
+++ b/.github/ISSUE_TEMPLATE/workload_proposal.md
@@ -1,0 +1,57 @@
+---
+name: Workload proposal
+about: Propose a synthetic or sanitized workload for KORA validation
+title: "Workload proposal: "
+labels: workload, validation, discussion-needed
+assignees: ""
+---
+
+## Safety check
+
+Do not include secrets, API keys, private user/customer data, proprietary datasets, private credentials, production logs, or raw provider responses.
+
+Use synthetic or sanitized data only.
+
+## Workload name
+
+
+## Workload type
+
+
+## Current model/API/local runtime used, if any
+
+
+## Approximate request volume
+
+
+## Deterministic or repetitive request types
+
+
+## Model-required request types
+
+
+## Validation rules
+
+
+## Expected outputs or properties
+
+
+## Privacy class
+
+Choose one:
+
+- synthetic
+- sanitized
+- private, not suitable for public issue details
+
+## Can results be public?
+
+
+## Contact or GitHub handle, optional
+
+
+## Claim boundary
+
+This proposal does not establish production validation, production cost reduction, real API-cost reduction, broad workload superiority, or energy reduction.
+
+See the [workload proposal template](../../docs/community/workload-proposal-template.md) and [SECURITY.md](../../SECURITY.md) before adding sensitive details.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -77,6 +77,14 @@ Good first issues usually:
 
 Avoid starting with large runtime changes, new public commands, broad refactors, or changes that alter model-routing semantics.
 
+## Finding a first contribution
+
+Use the [contributor pathway](docs/community/contributor-pathway.md) to choose the right route for questions, bugs, PRs, and workload proposals.
+
+For candidate tasks that maintainers may later convert into GitHub issues, see [good first issue candidates](docs/community/good-first-issue-candidates.md).
+
+For validation workload ideas, use the [workload proposal template](docs/community/workload-proposal-template.md). Keep proposals synthetic or sanitized and do not include secrets, private data, proprietary datasets, or raw provider responses.
+
 ## Good first contribution types
 
 Good first contribution types include:

--- a/README.md
+++ b/README.md
@@ -217,6 +217,7 @@ KORA is a standalone open-source execution-control layer for AI workloads.
 
 Want to contribute? Start with:
 
+- [Contributor pathway](docs/community/contributor-pathway.md)
 - [CONTRIBUTING.md](CONTRIBUTING.md)
 - [Good first issue candidates](docs/good_first_issues.md)
 - [SECURITY.md](SECURITY.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -96,6 +96,8 @@ Additional evidence and release docs:
 ## Help Test
 
 - [Help Test KORA](community/help-test-kora.md)
+- [Contributor pathway](community/contributor-pathway.md)
+- [Workload proposal template](community/workload-proposal-template.md)
 - [KORA validation roadmap](benchmarks/validation-roadmap.md)
 - [KORA social media announcement guide](community/KORA_SOCIAL_MEDIA_ANNOUNCEMENT_GUIDE.md)
 - [KORA community manager guide](community/KORA_COMMUNITY_MANAGER_GUIDE.md)
@@ -112,6 +114,9 @@ Good candidate workloads:
 
 - [Canonical governance document](../GOVERNANCE.md)
 - [Contributing guide](../CONTRIBUTING.md)
+- [Contributor pathway](community/contributor-pathway.md)
+- [Good first issue candidates](community/good-first-issue-candidates.md)
+- [Workload proposal template](community/workload-proposal-template.md)
 - [Security policy](../SECURITY.md)
 - [Code of conduct](../CODE_OF_CONDUCT.md)
 - [KORA open roles](community/2026-05-06-kora-open-roles.md)

--- a/docs/community/contributor-pathway.md
+++ b/docs/community/contributor-pathway.md
@@ -1,0 +1,119 @@
+# KORA Contributor Pathway
+
+## Purpose
+
+This document helps developers, technical reviewers, and AI app builders find the right way to participate in KORA.
+
+KORA is an open-source execution-control layer for AI workloads. The best early contributions make the public docs, examples, tests, validation paths, and synthetic workload specs easier to understand and verify.
+
+## Who This Is For
+
+- AI app developers
+- infrastructure engineers
+- Python developers
+- documentation contributors
+- benchmark/workload contributors
+- technical reviewers
+
+## Where To Start
+
+1. Read the [README](../../README.md).
+2. Run the local examples.
+3. Review the [local validation reviewer packet](../benchmarks/local-validation-reviewer-packet.md).
+4. Pick a small contribution.
+5. Open an issue or PR.
+6. Propose a workload through the recommended discussion route once enabled.
+
+## Communication Routes
+
+- Questions: GitHub Discussions Q&A, once enabled.
+- Workload proposals: GitHub Discussions Workload Proposals, once enabled.
+- Bugs: GitHub Issues.
+- Security issues: follow [SECURITY.md](../../SECURITY.md).
+- PRs: small, scoped pull requests.
+
+TODO: Canonical GitHub Discussions/contact route is still being finalized.
+
+## Good First Contribution Areas
+
+- documentation polish
+- examples
+- tests
+- synthetic workload specs
+- validation report templates
+- README clarity
+- reviewer packet improvements
+- local/no-network validation docs
+- KORA Studio planning docs and mock data only
+
+## What Not To Start With
+
+- real provider adapters
+- API cost claims
+- production cost claims
+- benchmark claim rewrites
+- release/tag/version work
+- repository settings
+- security-sensitive changes
+- large architecture rewrites
+- private internals/campaign docs
+
+## Public/Private Boundary
+
+The public KORA repository contains technical truth, docs, examples, tests, validation paths, issue templates, and public contribution guidance.
+
+The private internals repository contains internal messaging, community coordination, social planning, launch operations, and other non-public operating material.
+
+Contributors should not add private campaign materials or internal workflow notes to public KORA. Keep public docs focused on technical behavior, reproducible examples, contribution guidance, and claim-safe validation language.
+
+## Claim Safety
+
+Approved public alpha claim:
+
+> KORA reduced model invocations by 80% in a reproducible deterministic-heavy benchmark workload.
+
+Local validation wording:
+
+> KORA's local no-network validation examples show that KORA can measure avoided model-call events in synthetic workloads.
+
+Explicit non-claims:
+
+- no production cost reduction proof
+- no real API-cost reduction proof
+- no production benchmark proof
+- no full runtime-integrated real-provider benchmark evidence
+- no broad workload superiority proof
+- no energy reduction evidence
+- no formal government validation
+- no signed partner validation unless actually signed and documented
+- no guaranteed adoption or funding
+
+## Contribution Size
+
+Prefer small PRs. A good first PR usually changes one concern, touches a small number of files, and is easy to verify.
+
+Include tests or docs when they are relevant. Avoid bundling unrelated changes such as documentation cleanup, runtime behavior, formatting, and benchmark wording in the same PR.
+
+## Review Expectations
+
+Reviewers will expect:
+
+- CI/tests should pass.
+- No secrets.
+- No raw provider responses.
+- No private data.
+- No unsupported claims.
+- Public/private boundary respected.
+
+## KORA Studio Participation
+
+KORA Studio work should be decomposed into small issues before implementation. Useful early tasks are planning, static fixtures, and local-only prototypes, such as:
+
+- validation report viewer
+- sample JSON fixtures
+- static UI mockups
+- local dashboard prototype
+- report packet viewer
+- no real provider integration at first
+
+This is future planning. It is not a claim that KORA Studio already exists as a product.

--- a/docs/community/good-first-issue-candidates.md
+++ b/docs/community/good-first-issue-candidates.md
@@ -1,0 +1,342 @@
+# Good First Issue Candidates
+
+## Purpose
+
+These are candidate tasks for future GitHub issues. They are not active assignments until maintainers review and explicitly approve issue creation.
+
+## Documentation Candidates
+
+### Add an example output block for customer-support triage local validation
+
+Goal: Show a short, claim-safe sample output from the local/no-network customer-support triage example.
+
+Files likely touched: `docs/workloads/customer-support-triage.md`, `docs/benchmarks/local-validation-reviewer-packet.md`.
+
+Acceptance criteria: The example uses synthetic counters only, does not include raw prompts or provider responses, and links to the reviewer packet.
+
+Suggested labels: `good first issue`, `documentation`, `examples`, `validation`, `claim-safe`.
+
+Estimated size: small.
+
+### Improve glossary for validation counters
+
+Goal: Clarify terms such as `baseline_model_calls`, `kora_model_calls`, `avoided_model_calls`, and `model_escalations`.
+
+Files likely touched: `docs/telemetry-and-observability.md`, `docs/benchmarks/local-validation-reviewer-packet.md`.
+
+Acceptance criteria: Each counter has a concise definition and the wording distinguishes local/no-network counters from production evidence.
+
+Suggested labels: `good first issue`, `documentation`, `validation`, `claim-safe`.
+
+Estimated size: small.
+
+### Add a short FAQ entry explaining local no-network validation
+
+Goal: Add a short public FAQ entry that explains why local validation does not require API keys or external providers.
+
+Files likely touched: `docs/README.md`, `docs/benchmarks/local-validation-reviewer-packet.md`, or a future FAQ file.
+
+Acceptance criteria: The entry states that examples use synthetic workloads and do not prove production cost reduction or real API-cost reduction.
+
+Suggested labels: `good first issue`, `documentation`, `validation`, `claim-safe`.
+
+Estimated size: small.
+
+### Add README link to contributor pathway
+
+Goal: Make the contributor pathway easy to find from the README.
+
+Files likely touched: `README.md`.
+
+Acceptance criteria: README gains a concise link without expanding marketing copy.
+
+Suggested labels: `good first issue`, `documentation`.
+
+Estimated size: small.
+
+### Add docs note for generated report artifacts
+
+Goal: Explain where generated Markdown reports should be written and when they should not be committed.
+
+Files likely touched: `docs/benchmarks/local-validation-reviewer-packet.md`, `CONTRIBUTING.md`.
+
+Acceptance criteria: The note recommends `/tmp` or another local path and warns against committing raw provider responses, secrets, or private data.
+
+Suggested labels: `good first issue`, `documentation`, `validation`, `claim-safe`.
+
+Estimated size: small.
+
+### Improve claim-safe wording examples
+
+Goal: Add more examples of allowed and not-allowed wording for benchmark and local validation claims.
+
+Files likely touched: `docs/claims/kora-public-language-guide.md`, `docs/claims/kora-claim-registry.md`.
+
+Acceptance criteria: New examples preserve the approved alpha claim and explicit non-claims.
+
+Suggested labels: `documentation`, `claim-safe`, `help wanted`.
+
+Estimated size: medium.
+
+### Add troubleshooting entry for report path permissions
+
+Goal: Help users resolve errors when `--report-md` points to a non-writable location.
+
+Files likely touched: `docs/benchmarks/local-validation-reviewer-packet.md`, possibly example docs.
+
+Acceptance criteria: The entry suggests a writable local path and does not add machine-local paths.
+
+Suggested labels: `good first issue`, `documentation`, `validation`.
+
+Estimated size: small.
+
+### Add workload schema field explanations
+
+Goal: Explain each field used by synthetic workload specs in plain language.
+
+Files likely touched: `docs/workloads/customer-support-triage.md`, future workload docs.
+
+Acceptance criteria: Field explanations cover route class, expected route, validation rule, privacy class, and expected response type.
+
+Suggested labels: `documentation`, `workload`, `validation`.
+
+Estimated size: medium.
+
+## Test Candidates
+
+### Add tests for report boundary language
+
+Goal: Ensure generated validation reports keep explicit non-claim language.
+
+Files likely touched: `tests/test_validation_report.py`, `tests/test_customer_support_triage_fake_validation.py`.
+
+Acceptance criteria: Tests fail if reports drop the production, real API-cost, provider, or energy non-claims.
+
+Suggested labels: `good first issue`, `tests`, `validation`, `claim-safe`.
+
+Estimated size: small.
+
+### Add tests for workload route class counts
+
+Goal: Check that synthetic customer-support route class counts stay aligned with expected counters.
+
+Files likely touched: `tests/test_customer_support_triage_workload.py`.
+
+Acceptance criteria: Tests verify deterministic and model-required class totals.
+
+Suggested labels: `tests`, `workload`, `validation`.
+
+Estimated size: small.
+
+### Add tests for adapter selector error messages
+
+Goal: Confirm unsupported adapter choices fail clearly.
+
+Files likely touched: `tests/test_model_call.py`, CLI-related tests.
+
+Acceptance criteria: Tests cover invalid adapter names and clear error text.
+
+Suggested labels: `tests`, `validation`.
+
+Estimated size: small.
+
+### Add tests for local runtime placeholder failure behavior
+
+Goal: Ensure design-only runtime placeholders remain fail-closed.
+
+Files likely touched: `tests/test_model_call.py`, `tests/test_customer_support_triage_fake_validation.py`.
+
+Acceptance criteria: Tests prove no provider call is attempted and error messaging is explicit.
+
+Suggested labels: `tests`, `validation`, `claim-safe`.
+
+Estimated size: small.
+
+### Add tests for README/doc link integrity if repo supports it
+
+Goal: Catch broken relative links in public docs.
+
+Files likely touched: new or existing docs test file, `pyproject.toml` only if a dependency-free approach is used.
+
+Acceptance criteria: Test covers key Markdown links without adding heavy dependencies.
+
+Suggested labels: `tests`, `documentation`, `help wanted`.
+
+Estimated size: medium.
+
+## Workload Candidates
+
+### Draft RAG answer-routing synthetic workload spec
+
+Goal: Define a sanitized synthetic workload for RAG answer-routing decisions.
+
+Files likely touched: `docs/workloads/`.
+
+Acceptance criteria: Spec separates deterministic retrieval checks from model-required answer generation and includes privacy boundaries.
+
+Suggested labels: `workload`, `documentation`, `validation`, `discussion-needed`.
+
+Estimated size: medium.
+
+### Draft agent budget-guard synthetic workload spec
+
+Goal: Define a synthetic workload for agent tasks with budget and escalation rules.
+
+Files likely touched: `docs/workloads/`.
+
+Acceptance criteria: Spec includes request classes, budget rules, validation expectations, and non-claim boundaries.
+
+Suggested labels: `workload`, `documentation`, `validation`, `discussion-needed`.
+
+Estimated size: medium.
+
+### Expand customer-support triage workload to 100 synthetic requests
+
+Goal: Extend the existing synthetic workload with broader coverage while keeping all data fake.
+
+Files likely touched: `docs/workloads/customer-support-triage.md`, example fixtures if used.
+
+Acceptance criteria: Adds balanced deterministic and model-required cases, with no private data or real identifiers.
+
+Suggested labels: `workload`, `examples`, `validation`.
+
+Estimated size: medium.
+
+### Add validation rules for structured lookup routes
+
+Goal: Make lookup placeholder validation more explicit.
+
+Files likely touched: `docs/workloads/customer-support-triage.md`, tests if behavior exists.
+
+Acceptance criteria: Rules explain expected lookup placeholders without implying real backend integration.
+
+Suggested labels: `workload`, `documentation`, `validation`.
+
+Estimated size: small.
+
+### Add synthetic multilingual support triage samples without private data
+
+Goal: Draft synthetic multilingual samples for future routing validation.
+
+Files likely touched: `docs/workloads/customer-support-triage.md` or a new workload note.
+
+Acceptance criteria: Samples use fake content only and avoid claims about broad language coverage.
+
+Suggested labels: `workload`, `examples`, `discussion-needed`, `claim-safe`.
+
+Estimated size: medium.
+
+## KORA Studio Candidate Issues
+
+### Draft KORA Studio MVP user flow
+
+Goal: Describe a small user flow for inspecting local validation reports.
+
+Files likely touched: `docs/community/` or future Studio planning docs.
+
+Acceptance criteria: Flow is clearly future planning and does not claim a shipped product.
+
+Suggested labels: `kora-studio`, `documentation`, `discussion-needed`.
+
+Estimated size: medium.
+
+### Define validation report viewer requirements
+
+Goal: List fields and states a report viewer should show.
+
+Files likely touched: future Studio planning docs.
+
+Acceptance criteria: Requirements focus on local reports, aggregate counters, safety boundaries, and no raw provider responses.
+
+Suggested labels: `kora-studio`, `validation`, `documentation`.
+
+Estimated size: medium.
+
+### Create static mockup for local validation report viewer
+
+Goal: Create a static, non-runtime mockup for a local report viewer.
+
+Files likely touched: future docs or examples area after maintainer approval.
+
+Acceptance criteria: Mockup uses sample synthetic data only and does not add app dependencies.
+
+Suggested labels: `kora-studio`, `examples`, `help wanted`.
+
+Estimated size: medium.
+
+### Add sample JSON fixture for Studio dashboard
+
+Goal: Add a small synthetic fixture for future dashboard planning.
+
+Files likely touched: future fixture location after maintainer approval.
+
+Acceptance criteria: Fixture includes aggregate counters only, no raw prompts, no private data, and no provider responses.
+
+Suggested labels: `kora-studio`, `validation`, `examples`.
+
+Estimated size: small.
+
+### Define dashboard counter cards
+
+Goal: Specify counter cards for total requests, baseline model calls, KORA model calls, and avoided model-call events.
+
+Files likely touched: future Studio planning docs.
+
+Acceptance criteria: Text distinguishes local/no-network events from production evidence.
+
+Suggested labels: `kora-studio`, `documentation`, `claim-safe`.
+
+Estimated size: small.
+
+### Define workload selector UI
+
+Goal: Describe a future UI for selecting synthetic workload reports.
+
+Files likely touched: future Studio planning docs.
+
+Acceptance criteria: Selector is scoped to local files or fixtures and does not imply provider integration.
+
+Suggested labels: `kora-studio`, `documentation`, `discussion-needed`.
+
+Estimated size: small.
+
+### Define report export/download behavior
+
+Goal: Specify safe export behavior for generated reports.
+
+Files likely touched: future Studio planning docs.
+
+Acceptance criteria: Export guidance warns against secrets, private data, raw provider responses, and unsupported claims.
+
+Suggested labels: `kora-studio`, `validation`, `documentation`, `claim-safe`.
+
+Estimated size: medium.
+
+### Create first static report packet viewer prototype
+
+Goal: Build a local static prototype for reading a sample report packet after maintainer approval.
+
+Files likely touched: future prototype directory.
+
+Acceptance criteria: Prototype uses synthetic sample data only, has no real provider integration, and avoids new runtime dependencies unless approved.
+
+Suggested labels: `kora-studio`, `examples`, `help wanted`, `discussion-needed`.
+
+Estimated size: medium.
+
+## Labels To Use Later
+
+- `good first issue`
+- `documentation`
+- `tests`
+- `examples`
+- `validation`
+- `workload`
+- `kora-studio`
+- `help wanted`
+- `discussion-needed`
+- `claim-safe`
+
+## Issue Creation Note
+
+These candidates should be converted into real GitHub issues only after maintainer review and explicit approval.

--- a/docs/community/workload-proposal-template.md
+++ b/docs/community/workload-proposal-template.md
@@ -1,0 +1,94 @@
+# Workload Proposal Template
+
+## Purpose
+
+This template helps developers propose workloads for KORA validation.
+
+Good workload proposals explain where deterministic routing, validation rules, escalation rules, or budget controls may avoid unnecessary model-call events while preserving correctness and safety.
+
+## Before You Submit
+
+Use synthetic or sanitized data only.
+
+Do not include:
+
+- secrets
+- API keys
+- private user/customer data
+- proprietary datasets
+- raw provider responses
+- private credentials
+- production logs
+
+## Proposal Fields
+
+- Workload name
+- Workload type
+- Current model/API/local runtime used, if any
+- Approximate request volume
+- Deterministic/repetitive request types
+- Model-required request types
+- Validation rules
+- Expected outputs/properties
+- Privacy class
+- Can results be public?
+- Contact or GitHub handle, optional
+
+## Example Proposal
+
+```text
+Workload name:
+Synthetic customer-support triage
+
+Workload type:
+Support request routing and response validation
+
+Current model/API/local runtime used, if any:
+None for the proposal. Local/no-network validation is preferred for the first pass.
+
+Approximate request volume:
+12 synthetic requests for the first draft; 100 synthetic requests for a later expanded draft.
+
+Deterministic/repetitive request types:
+- Password reset instructions
+- Refund policy link requests
+- Shipping status instructions
+- Account email change instructions
+- Standard return window questions
+- Order status lookup placeholders
+
+Model-required request types:
+- Ambiguous complaint
+- Multi-intent request
+- Unusual policy edge case
+- Sensitive escalation
+
+Validation rules:
+- required_link_present
+- policy_value_matches
+- lookup_placeholder_present
+- escalation_reason_present
+- no_private_data_emitted
+
+Expected outputs/properties:
+- Deterministic FAQ requests route to known handlers.
+- Policy requests return approved policy keys.
+- Lookup requests use placeholder routes only.
+- Ambiguous or sensitive requests include an escalation reason.
+- Aggregate counters include baseline model-call events, KORA-routed model-call events, and avoided model-call events.
+
+Privacy class:
+synthetic
+
+Can results be public?
+Yes, if the workload remains synthetic and the report includes only aggregate counters and claim-safe boundary language.
+
+Contact or GitHub handle, optional:
+GitHub handle only; no private contact details required.
+```
+
+## Claim Boundary
+
+Accepted workloads do not automatically imply production validation, production cost reduction, real API-cost reduction, broad workload superiority, or energy reduction.
+
+KORA's local no-network validation examples show that KORA can measure avoided model-call events in synthetic workloads. Production or provider-specific claims require separate reviewed evidence and explicit approval.


### PR DESCRIPTION
## Summary

Adds public contributor pathway documentation for KORA without creating real GitHub issues or changing repository settings.

## Included

- Contributor pathway doc for questions, bugs, PRs, workload proposals, and KORA Studio planning participation
- Good-first-issue candidate list for future maintainer-approved issue creation
- Workload proposal template doc
- Workload proposal issue template for later use
- README, docs index, and contributing links updated

## Scope boundaries

- No real GitHub issues created
- No labels created or modified
- No repository settings changed
- No releases, tags, package versions, or release assets changed
- No raw benchmark artifacts uploaded or committed
- No real provider API calls implemented
- No provider/runtime dependencies added

## Validation

- `git diff --check` passed
- `git diff --cached --check` passed
- `python3 -m pytest` passed: 139 passed
- `python3 -m kora --help` passed
- `python3 -m kora examples list` passed
- `python3 -m kora run real_model_call_validation_fake -- --offline` passed
- `python3 -m kora run customer_support_triage_fake_validation -- --offline` passed
- `python3 -m kora run customer_support_triage_fake_validation -- --offline --report-md /tmp/kora_customer_support_validation.md` passed; report stayed in `/tmp` and was not committed
- `python3 -m kora run direct_vs_kora -- --offline` passed
- `python3 -m kora run runtime_integrated_benchmark -- --offline` passed

## Safety confirmation

Changed-file scans found only explicit privacy warnings and non-claim boundary language. No secrets, API keys, private data, raw provider responses, real contact details, private prompt workflows, or private internals/campaign content were added.

This PR preserves the approved public alpha claim and does not add unsupported production cost-reduction, real API-cost reduction, production benchmark, full runtime-integrated real-provider benchmark, broad workload superiority, or energy-reduction claims.
