### PR TITLE
docs: show sample examples list output

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -47,6 +47,16 @@ python3 -m kora run direct_vs_kora -- --offline
 python3 -m kora run runtime_integrated_benchmark -- --offline
 ```
 
+A local `python3 -m kora examples list` run should include entries like these; your checkout may list additional examples:
+
+```text
+Runnable examples
+- customer_support_triage_fake_validation: customer-support triage local no-network validation example (graph.json: no)
+- direct_vs_kora: direct call vs KORA-controlled path (graph.json: yes)
+- real_model_call_validation_fake: local no-network model-call validation example (graph.json: no)
+- runtime_integrated_benchmark: initial runtime-path benchmark harness (graph.json: no)
+```
+
 Some example command names are compatibility-preserving. The local validation examples emit public-facing `local_validation` provider labels.
 Use `--report-md /tmp/kora_validation.md` with local validation examples to generate reviewer-facing Markdown reports from aggregate counters.
 


### PR DESCRIPTION
## Summary

Adds a concise sample output snippet for `python3 -m kora examples list` in the docs, noting that local checkouts may include additional examples.

## Type of change

- [x] Docs only
- [ ] CLI / example
- [ ] Benchmark / evidence
- [ ] Code / tests
- [ ] Security-sensitive

## Verification

- [x] Validation commands were run or marked not applicable.
- [x] Claim hygiene checked.
- [x] No unsupported production, API-cost, benchmark, broad workload, or energy claims added.
- [x] No raw benchmark JSON artifacts committed.
- [x] No local absolute paths introduced.
- [x] No release, tag, package-version, or release-asset changes unless explicitly approved.

List commands run and results:

```text
python3 -m kora examples list
# passed; output includes customer_support_triage_fake_validation, direct_vs_kora,
# real_model_call_validation_fake, and runtime_integrated_benchmark

python3 -m pytest
# 139 passed in 3.06s
```

Useful references: [CONTRIBUTING.md](../CONTRIBUTING.md), [SECURITY.md](../SECURITY.md), [experiments/README.md](../experiments/README.md), and [docs/README.md](../docs/README.md).

## Scope check

- [x] No unrelated refactors
- [x] No public surface expansion without discussion
- [x] Deterministic-first behavior preserved
- [x] No hidden model calls introduced
- [x] README, docs, examples, and templates remain factual and alpha-scoped

## Notes for reviewer

Fixes #97.

Docs-only change; no code behavior changed.
