### PR TITLE
Add KORA first paper evidence packet

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -103,6 +103,14 @@ Additional evidence and release docs:
 - [v0.3.0-alpha post-release cleanup plan](reports/v0.3.0-alpha-post-release-cleanup-plan.md)
 - [v0.3.1-alpha roadmap](planning/v0.3.1-alpha-roadmap.md)
 
+## Paper Preparation
+
+- [KORA first paper outline](paper/kora-first-paper-outline.md)
+- [KORA first paper evidence summary](paper/kora-first-paper-evidence-summary.md)
+- [KORA first paper figures and tables](paper/kora-first-paper-figures-and-tables.md)
+- [KORA first paper claim boundary](paper/kora-first-paper-claim-boundary.md)
+- [KORA first paper missing evidence checklist](paper/kora-first-paper-missing-evidence-checklist.md)
+
 ## Help Test
 
 - [Help Test KORA](community/help-test-kora.md)

--- a/docs/paper/kora-first-paper-claim-boundary.md
+++ b/docs/paper/kora-first-paper-claim-boundary.md
@@ -1,0 +1,39 @@
+# KORA First Paper Claim Boundary
+
+## Approved Claims
+
+KORA reduced model invocations by 80% in a reproducible deterministic-heavy benchmark workload.
+
+KORA's local no-network validation examples show that KORA can measure avoided model-call events in synthetic workloads.
+
+## Conditional Future Claims
+
+After local model validation:
+
+KORA reduced measured local model invocations by X% in a runtime-integrated local model validation workload.
+
+After real provider validation:
+
+KORA reduced measured provider model invocations by X% in a runtime-integrated validation workload using real model calls.
+
+These conditional claims require reviewed workload definitions, commands, counters, reports, and claim language before use.
+
+## Not Allowed Yet
+
+- production cost reduction proof
+- real API-cost reduction proof
+- production benchmark proof
+- energy reduction proof
+- broad workload superiority
+- production-proven claim
+
+## Paper Language Rules
+
+- Use "model invocations" instead of "cost" unless cost is actually measured.
+- Use "synthetic workload" where applicable.
+- Use "local/no-network validation" where applicable.
+- Avoid "production" unless explicitly describing a non-claim or limitation.
+- Avoid "API cost reduction" unless explicitly describing a non-claim or future evidence requirement.
+- Avoid "energy reduction" unless explicitly describing a non-claim or future evidence requirement.
+- Do not imply broad workload superiority from deterministic-heavy or customer-support synthetic results.
+- Do not imply real provider validation from local/no-network examples.

--- a/docs/paper/kora-first-paper-evidence-summary.md
+++ b/docs/paper/kora-first-paper-evidence-summary.md
@@ -1,0 +1,77 @@
+# KORA First Paper Evidence Summary
+
+## Evidence Overview
+
+The first KORA paper should use the evidence that is already reproducible in the public repository: the deterministic-heavy benchmark, the customer-support triage synthetic local/no-network validation workload, and the validation/reporting infrastructure that records aggregate counters and claim boundaries.
+
+The current evidence supports model invocation reduction claims in documented workloads. It does not support production cost, real API-cost, production validation, broad workload superiority, or energy claims.
+
+## Deterministic-Heavy Benchmark
+
+| Metric | Value |
+|---|---:|
+| Total tasks | 100 |
+| Baseline model calls | 100 |
+| KORA-controlled model calls | 20 |
+| Avoided model calls | 80 |
+| Avoided model-call rate | 80% |
+| Mismatches | 0 |
+
+Claim-safe interpretation:
+
+KORA reduced model invocations by 80% in a reproducible deterministic-heavy benchmark workload. This means the benchmark recorded 80 fewer model invocations in the KORA-controlled path than in the baseline path while preserving expected benchmark outputs with zero mismatches. It should not be interpreted as proof of production cost reduction, real API-cost reduction, production validation, broad workload superiority, or energy reduction.
+
+## Customer-Support Triage Synthetic Workload
+
+| Metric | Value |
+|---|---:|
+| Total requests | 12 |
+| Baseline model calls | 12 |
+| KORA-controlled model calls | 4 |
+| Avoided model calls | 8 |
+| Avoided model-call rate | 66.67% |
+| Deterministic routes | 8 |
+| Model escalations | 4 |
+
+Claim-safe interpretation:
+
+This is local/no-network validation only and not real provider validation. The workload uses synthetic customer-support requests to exercise deterministic FAQ, policy, structured lookup, and model-required route classes. The current example shows that KORA can measure avoided model-call events in a synthetic application-shaped workload without API keys, external providers, private data, or network calls.
+
+## Validation Infrastructure
+
+Current validation infrastructure includes:
+
+- local/no-network validation examples
+- Markdown report generation
+- reviewer packet
+- adapter selection skeleton
+- blocked local runtime placeholder
+- provider-neutral `ModelCallAdapter`
+- deterministic local validation adapter
+- explicit local runtime stub for deterministic in-process local/no-network validation
+- fail-closed blocked adapter paths
+- customer-support triage synthetic workload
+
+## Reproduction Commands
+
+```bash
+python3 -m pytest
+python3 -m kora examples list
+python3 -m kora run runtime_integrated_benchmark -- --offline
+python3 -m kora run customer_support_triage_fake_validation -- --offline
+python3 -m kora run customer_support_triage_fake_validation -- --offline --report-md /tmp/kora_customer_support_validation.md
+```
+
+## Evidence Boundaries
+
+The current evidence does not claim:
+
+- production cost reduction proof
+- real API-cost reduction proof
+- production benchmark proof
+- full runtime-integrated real-provider benchmark evidence
+- broad workload superiority proof
+- energy reduction evidence
+- formal government validation
+- signed partner validation unless actually signed and documented
+- guaranteed adoption or funding

--- a/docs/paper/kora-first-paper-figures-and-tables.md
+++ b/docs/paper/kora-first-paper-figures-and-tables.md
@@ -1,0 +1,87 @@
+# KORA First Paper Figures and Tables
+
+## Figure 1 - Model-First vs KORA-Controlled Execution
+
+Describe the contrast between a model-first path and a KORA-controlled path.
+
+Model-first path:
+
+```text
+request -> prompt -> model -> output
+```
+
+KORA-controlled path:
+
+```text
+request -> task graph -> deterministic route or model escalation -> validation -> telemetry
+```
+
+The figure should show that KORA inserts execution control before inference and records route decisions and counters.
+
+## Figure 2 - KORA Execution-Control Architecture
+
+Describe the main execution-control components:
+
+- task graph
+- deterministic handlers
+- validation/policy
+- model escalation
+- telemetry/counters
+
+The figure should emphasize the decision boundary between deterministic handling and model escalation.
+
+## Figure 3 - Customer-Support Triage Routing
+
+Describe the route classes in the synthetic customer-support triage workload:
+
+- `deterministic_faq`
+- `deterministic_policy`
+- `structured_lookup`
+- `model_required`
+
+The figure should show deterministic FAQ, policy, and structured lookup requests bypassing model-call events, while `model_required` requests escalate.
+
+## Table 1 - Deterministic-Heavy Benchmark Results
+
+| Metric | Value |
+|---|---:|
+| Total tasks | 100 |
+| Baseline model calls | 100 |
+| KORA-controlled model calls | 20 |
+| Avoided model calls | 80 |
+| Avoided model-call rate | 80% |
+| Mismatches | 0 |
+
+## Table 2 - Customer-Support Triage Local Validation Results
+
+| Metric | Value |
+|---|---:|
+| Total requests | 12 |
+| Baseline model calls | 12 |
+| KORA-controlled model calls | 4 |
+| Avoided model calls | 8 |
+| Avoided model-call rate | 66.67% |
+| Deterministic routes | 8 |
+| Model escalations | 4 |
+
+## Table 3 - Claim Boundary Matrix
+
+| Statement | Allowed? | Evidence needed | Current status |
+|---|---|---|---|
+| Model invocation reduction in benchmark | Yes | Reproducible deterministic-heavy benchmark counters | Supported: 80% reduction in current deterministic-heavy benchmark |
+| Local/no-network validation | Yes | Local examples, synthetic workloads, aggregate counters | Supported for current local/no-network examples |
+| Real provider validation | No, not yet | Runtime-integrated real provider commands, reviewed counters, sanitized report | Not available |
+| Real API-cost reduction | No, not yet | Billing or explicitly configured cost methodology, baseline, reviewed report | Not available |
+| Production cost reduction | No, not yet | Production methodology, traffic, baseline, measured results, review | Not available |
+| Energy reduction | No, not yet | Energy measurement methodology and results | Not available |
+
+## Table 4 - Route Type and Expected Latency Direction
+
+| Route type | Baseline path | KORA path | Expected latency direction |
+|---|---|---|---|
+| Deterministic FAQ | Baseline model call | KORA fast path | Expected faster |
+| Policy lookup | Baseline model call | KORA fast path | Expected faster |
+| Structured lookup | Baseline model call | KORA handler | Expected faster |
+| `model_required` | Baseline model call | KORA routing plus model escalation | KORA may add routing overhead |
+
+These latency directions are hypotheses or expected directions until p50/p95 latency data is captured and reviewed.

--- a/docs/paper/kora-first-paper-missing-evidence-checklist.md
+++ b/docs/paper/kora-first-paper-missing-evidence-checklist.md
@@ -1,0 +1,31 @@
+# Missing Evidence Checklist
+
+## Needed Before First Draft
+
+- Confirm latest benchmark command and output.
+- Capture deterministic-heavy benchmark result in a reviewer-safe summary.
+- Capture customer-support local validation result.
+- Confirm all commands pass on a clean checkout.
+- Identify exact tables to include.
+
+## Nice To Have Before Draft
+
+- Expanded 100-request customer-support workload.
+- Local model runtime validation, for example Ollama.
+- p50/p95 latency for deterministic vs model-required routes.
+- Repeated runs.
+- Qualitative examples of deterministic route classes.
+
+## Not Needed For First Paper
+
+- OpenAI/Claude API cost validation.
+- Production traffic.
+- Energy measurement.
+- Hosted KORA Studio.
+- Real customer data.
+
+## Follow-Up Papers / Technical Reports
+
+- OpenAI/Claude API cost reduction technical report.
+- Energy/sustainability paper.
+- Production-like application workload report.

--- a/docs/paper/kora-first-paper-outline.md
+++ b/docs/paper/kora-first-paper-outline.md
@@ -1,0 +1,62 @@
+# KORA First Paper Outline
+
+## Working Title Options
+
+Recommended primary title:
+
+KORA: Deterministic-First Execution Control for Reducing Model Invocations in AI Workloads
+
+Other options:
+
+- Structure First, Inference Second: Execution-Control Routing for AI Workloads
+- Reducing Unnecessary Model Calls with Deterministic-First AI Execution
+- KORA: An Execution-Control Layer for Model-Efficient AI Workloads
+- Fast Paths Before Inference: Model Invocation Reduction in AI Systems
+
+## Thesis
+
+Most AI applications call a model too early. KORA introduces an execution-control layer that routes deterministic and structured work before inference and escalates to a model only when needed.
+
+## Abstract Draft
+
+Many model-first AI systems convert each request directly into a prompt, even when part of the workload can be handled through structured rules, validation, or deterministic routing. KORA introduces deterministic-first execution control: requests are represented as controlled execution paths, deterministic work is routed before inference, and model escalation is reserved for cases that need it. This paper compares a baseline path against a KORA-controlled path using a reproducible deterministic-heavy benchmark and a synthetic customer-support local/no-network validation workload. In the deterministic-heavy benchmark, KORA reduced model invocations by 80% while preserving expected benchmark outcomes with zero mismatches. The customer-support workload shows how local/no-network validation can measure avoided model-call events, deterministic routes, and model escalations in an application-shaped synthetic workload. These results are evidence of model invocation reduction and validation plumbing in documented workloads; they are not production cost reduction proof or real API-cost proof.
+
+## Contributions
+
+- Execution-control architecture for routing AI requests before inference.
+- Deterministic-first routing model for structured or policy-bound work.
+- Model escalation boundary for requests that cannot be safely handled deterministically.
+- Telemetry and counter reporting for baseline model calls, KORA-controlled model calls, avoided model calls, validation outcomes, and route classes.
+- Reproducible deterministic-heavy benchmark evidence showing an 80% model invocation reduction.
+- Synthetic application-shaped validation workload for customer-support triage using local/no-network execution.
+
+## Paper Structure
+
+1. Introduction
+2. Motivation
+3. KORA Architecture
+4. Execution Model
+5. Evaluation Methodology
+6. Results
+7. Discussion
+8. Limitations
+9. Future Work
+10. Conclusion
+
+## Key Claims
+
+- KORA reduced model invocations by 80% in a reproducible deterministic-heavy benchmark workload.
+- KORA's local no-network validation examples show that KORA can measure avoided model-call events in synthetic workloads.
+- In the customer-support triage synthetic workload, the local validation path records 8 avoided model-call events out of 12 requests.
+- KORA provides a provider-neutral model-call adapter boundary for measuring model-call events in validation harnesses.
+- KORA separates deterministic routes from model escalations in the current local/no-network validation examples.
+
+## Limitations
+
+- Current evidence uses synthetic workloads.
+- Current evidence does not use production traffic.
+- Current evidence does not prove real API-cost reduction.
+- Current evidence does not include energy measurement.
+- Local/no-network validation is not real provider validation.
+- The customer-support triage evidence is application-shaped but not a production benchmark.
+- Latency direction for deterministic fast paths is expected from avoiding model calls, but p50/p95 latency evidence should be captured before stronger latency claims are made.


### PR DESCRIPTION
## Summary

- Adds the first KORA paper outline
- Adds a claim-safe evidence summary for the deterministic-heavy benchmark and customer-support local/no-network validation
- Adds planned figures and tables
- Adds a first-paper claim boundary document
- Adds a missing evidence checklist
- Adds Paper Preparation links to the docs index

## Safety

- No full paper draft added
- No new claims beyond approved benchmark and local/no-network validation wording
- No production cost, real API-cost, production validation, broad workload superiority, or energy claims added as proof
- No generated benchmark/report artifacts committed
- No provider/runtime dependencies added
- No real provider API calls implemented
- No private internals/campaign content exposed

## Validation

- [x] git diff --check
- [x] python3 -m pytest
- [x] python3 -m kora --help
- [x] python3 -m kora examples list
- [x] python3 -m kora run runtime_integrated_benchmark -- --offline
- [x] python3 -m kora run customer_support_triage_fake_validation -- --offline
- [x] python3 -m kora run customer_support_triage_fake_validation -- --offline --report-md /tmp/kora_customer_support_validation.md
- [x] python3 -m kora run direct_vs_kora -- --offline
- [x] changed-file public/private, secret, and claim-safety scan