### PR TITLE
Add KORA Studio v0.1 planning docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ Useful entry points:
 - [Examples directory](examples/)
 - [Telemetry and observability counters](docs/telemetry-and-observability.md)
 - [Public language guide](docs/claims/kora-public-language-guide.md)
+- [KORA Studio planning docs](docs/kora-studio/README.md)
 - [Contact and discussion routes](docs/community/contact-and-discussion-routes.md)
 - [Community manager guide](docs/community/KORA_COMMUNITY_MANAGER_GUIDE.md)
 - [Contributing guide](CONTRIBUTING.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -27,6 +27,17 @@ KORA control layer architecture.
 - [Research agenda](research-agenda.md)
 - [Whitepaper](whitepaper.md)
 
+## KORA Studio Planning
+
+KORA Studio is future planning only. It is not implemented yet.
+
+- [KORA Studio overview](kora-studio/README.md)
+- [KORA Studio v0.1 product spec](kora-studio/kora-studio-v0-1-product-spec.md)
+- [KORA Studio MVP user flow](kora-studio/kora-studio-mvp-user-flow.md)
+- [KORA Studio architecture](kora-studio/kora-studio-architecture.md)
+- [KORA Boost copy system](kora-studio/kora-boost-copy-system.md)
+- [KORA Studio UI composition](kora-studio/kora-studio-ui-composition.md)
+
 ## Run
 
 - [Examples directory](../examples/)

--- a/docs/community/good-first-issue-candidates.md
+++ b/docs/community/good-first-issue-candidates.md
@@ -228,6 +228,8 @@ Estimated size: medium.
 
 ## KORA Studio Candidate Issues
 
+Use the [KORA Studio planning docs](../kora-studio/README.md) as the starting point for these candidates. The current planning packet includes the [v0.1 product spec](../kora-studio/kora-studio-v0-1-product-spec.md), [MVP user flow](../kora-studio/kora-studio-mvp-user-flow.md), [architecture plan](../kora-studio/kora-studio-architecture.md), [KORA Boost copy system](../kora-studio/kora-boost-copy-system.md), and [UI composition guide](../kora-studio/kora-studio-ui-composition.md).
+
 ### Draft KORA Studio MVP user flow
 
 Goal: Describe a small user flow for inspecting local validation reports.

--- a/docs/kora-studio/README.md
+++ b/docs/kora-studio/README.md
@@ -1,0 +1,62 @@
+# KORA Studio
+
+## Status
+
+KORA Studio is a future planning area. It is not implemented yet.
+
+## Purpose
+
+KORA Studio is intended to become a local-first AI workspace for Mac and Linux that helps users run local LLM workflows, compare Standard Mode and KORA Boost, and inspect KORA execution paths, model-call counters, and validation reports.
+
+## Core User Benefit
+
+KORA Boost
+
+Less waiting. Better answers. No hardware upgrade.
+
+KORA Boost handles simple work through fast paths and saves model power for the tasks that need it.
+
+## Initial Scope
+
+The first MVP should focus on:
+
+- Mac and Linux first
+- CLI launch
+- local browser UI
+- local runtime detection
+- Ollama-first model selection
+- Standard Mode vs KORA Boost
+- ChatGPT-like project chat
+- execution path visibility
+- model-call counters
+- local validation report viewer
+- local-only storage
+
+## Non-Scope
+
+KORA Studio v0.1 planning is:
+
+- not a hosted SaaS product yet
+- not a production monitoring platform yet
+- not an API-cost dashboard yet
+- not an energy dashboard yet
+- not a real provider billing dashboard yet
+- not a claim that KORA Studio is implemented today
+
+## Source Artifacts
+
+Likely source artifacts include:
+
+- local validation Markdown reports
+- JSON summaries from local validation examples
+- synthetic workload files
+- reviewer packet outputs
+- future local model validation reports
+
+## Public/Private Boundary
+
+KORA Studio docs in public KORA should describe technical design, local validation artifacts, and contributor-friendly planning only. Internal product strategy, launch planning, campaign materials, and private operating notes belong in the private internals repo.
+
+## Claim Boundary
+
+KORA Studio planning does not create new benchmark claims. It should only visualize already generated validation counters and claim-safe reports.

--- a/docs/kora-studio/kora-boost-copy-system.md
+++ b/docs/kora-studio/kora-boost-copy-system.md
@@ -1,0 +1,48 @@
+# KORA Boost Copy System
+
+## Purpose
+
+This doc defines user-facing copy for KORA Boost.
+
+## Primary Copy
+
+KORA Boost
+
+Less waiting. Better answers. No hardware upgrade.
+
+KORA Boost handles simple work through fast paths and saves model power for the tasks that need it.
+
+## Standard Mode Copy
+
+Standard Mode
+
+Run the local model directly.
+
+## KORA Boost Mode Copy
+
+KORA Boost
+
+Less waiting. Better answers. No hardware upgrade.
+
+## Technical Tooltip
+
+Simple tasks take the fast path. Harder tasks use the model when it matters.
+
+## Optional Marketing Copy
+
+Use only when a stronger marketing line is needed:
+
+Bigger-model answers. Faster everyday tasks. Same hardware.
+
+Do not combine this line with the primary copy in the same UI block.
+
+## Copy Rules
+
+- lead with user benefit
+- explain technical reason only after benefit
+- do not claim KORA Studio is implemented until code exists
+- do not claim production cost reduction
+- do not claim real API-cost reduction
+- do not claim energy reduction
+- do not claim bigger models physically run if they do not
+- prefer "bigger-model answers" or "bigger-model feel" over "runs a bigger model"

--- a/docs/kora-studio/kora-studio-architecture.md
+++ b/docs/kora-studio/kora-studio-architecture.md
@@ -1,0 +1,100 @@
+# KORA Studio Architecture
+
+## Architecture Status
+
+This is a planning architecture. KORA Studio is not implemented yet.
+
+## Components
+
+### CLI Launcher
+
+Responsibilities:
+
+- `kora studio`
+- start local Studio server
+- open browser
+- pass local configuration
+
+### Local Studio Server
+
+Responsibilities:
+
+- serve web UI
+- detect system/runtime status
+- expose local APIs
+- manage project/session state
+- invoke KORA execution paths
+- read local validation reports
+- never upload data by default
+
+### Web UI
+
+Responsibilities:
+
+- welcome/setup screen
+- model selection
+- project chat
+- execution trace panel
+- counter dashboard
+- report viewer
+
+### KORA Runtime Layer
+
+Responsibilities:
+
+- Standard Mode direct local model path
+- KORA Boost execution-control path
+- deterministic/fast path routing
+- model escalation
+- validation result
+- telemetry counters
+
+### Local Model Runtime
+
+Initial runtime:
+
+- Ollama first
+
+Future runtimes:
+
+- llama.cpp
+- MLX
+- vLLM
+- other local runtimes
+
+Future runtime support must be explicit opt-in and fail-closed until implemented.
+
+### Local Storage
+
+Options:
+
+- SQLite or local JSON first
+- project metadata
+- conversation history
+- execution traces
+- report references
+
+## Data Flow
+
+```text
+CLI -> Local Studio Server -> Browser UI
+Browser UI -> KORA Runtime Layer -> Local Runtime
+KORA Runtime Layer -> Execution Trace -> Counter Dashboard
+Validation Reports -> Report Viewer
+```
+
+## Security and Privacy
+
+- local-first
+- no API keys required for v0.1 local flow
+- no cloud upload by default
+- no raw provider responses committed
+- no private data in public artifacts
+
+## Non-Goals
+
+- no hosted cloud dashboard
+- no user accounts
+- no billing
+- no production monitoring
+- no provider cost dashboard in v0.1

--- a/docs/kora-studio/kora-studio-mvp-user-flow.md
+++ b/docs/kora-studio/kora-studio-mvp-user-flow.md
@@ -1,0 +1,66 @@
+# KORA Studio MVP User Flow
+
+## Overview
+
+1. Install/launch from CLI.
+2. Run `kora studio`.
+3. Browser opens local Studio UI.
+4. Studio checks local system and runtime.
+5. User sees recommended local model.
+6. User compares Standard Mode and KORA Boost.
+7. User pulls/downloads model if needed.
+8. User creates/opens project.
+9. User starts chat.
+10. User sees answer plus execution trace.
+11. User views model-call counters.
+12. User opens validation/report history.
+
+## Flow 1 — First Launch
+
+- local-only intro
+- Mac/Linux support
+- no API key required
+- runtime check
+- Open Studio CTA
+
+## Flow 2 — Model Selection
+
+- detected machine panel
+- direct model recommendation
+- KORA Boost recommended workflow
+- Ollama status
+- model pull status
+
+## Flow 3 — Project Chat
+
+- project sidebar
+- chat panel
+- model selector
+- Standard Mode / KORA Boost toggle
+- local runtime status
+
+## Flow 4 — Execution Trace
+
+- selected route
+- model called yes/no
+- deterministic path used
+- validation result
+- latency
+- counters
+
+## Flow 5 — Reports / Validation Viewer
+
+- local report list
+- Markdown report preview
+- counter summary
+- claim boundary note
+- no cloud upload by default
+
+## Error States
+
+- Ollama not installed
+- model not downloaded
+- local runtime unavailable
+- report path missing
+- unsupported adapter selected
+- `local_runtime_placeholder` fail-closed

--- a/docs/kora-studio/kora-studio-ui-composition.md
+++ b/docs/kora-studio/kora-studio-ui-composition.md
@@ -1,0 +1,127 @@
+# KORA Studio UI Composition
+
+## Purpose
+
+This doc describes the initial visual/UI composition for KORA Studio.
+
+## Visual Direction
+
+- dark technical UI
+- local-first status indicators
+- cyan for normal paths
+- amber for KORA Boost or model escalation highlights
+- green for local runtime ready / validation passed
+- avoid cloud/SaaS visual language in v0.1
+
+## Screens
+
+### 1. Welcome / Setup
+
+Purpose: Introduce KORA Studio as a future local-first workspace and guide the user into a local setup flow.
+
+Key UI elements:
+
+- local-only status strip
+- Mac/Linux support note
+- runtime readiness checklist
+- Open Studio CTA
+- no API key required note
+
+Key copy:
+
+- KORA Studio
+- Local-first AI workspace
+- Less waiting. Better answers. No hardware upgrade.
+
+Claim-safety notes:
+
+- State that Studio is a planned v0.1 experience until implementation exists.
+- Do not imply hosted accounts, cloud sync, or production monitoring.
+- Do not present validation counters as production evidence.
+
+### 2. Model Selection
+
+Purpose: Help users understand local machine capability, local runtime status, and the initial model path.
+
+Key UI elements:
+
+- detected machine panel
+- Ollama runtime status
+- supported model list
+- recommended direct model card
+- KORA Boost recommendation card
+- model pull/download status
+
+Key copy:
+
+- Standard Mode
+- Run the local model directly.
+- KORA Boost handles simple work through fast paths and saves model power for the tasks that need it.
+
+Claim-safety notes:
+
+- Describe model recommendations as local setup guidance, not benchmark proof.
+- Keep future runtime support explicit opt-in and fail-closed until implemented.
+- Do not claim that larger models physically run on unsupported hardware.
+
+### 3. Project Chat Workspace
+
+Purpose: Provide a project-based chat surface where users can compare Standard Mode and KORA Boost behavior.
+
+Key UI elements:
+
+- project sidebar
+- chat panel
+- model selector
+- Standard Mode / KORA Boost toggle
+- local runtime status
+- execution trace panel
+- model-call counter cards
+
+Key copy:
+
+- KORA Boost
+- Less waiting. Better answers. No hardware upgrade.
+- Simple tasks take the fast path. Harder tasks use the model when it matters.
+
+Claim-safety notes:
+
+- Do not use the primary copy and optional stronger marketing line in the same UI block.
+- Label counters as local project/session counters.
+- Avoid cost, billing, energy, or production claims.
+
+### 4. Reports / Validation Viewer
+
+Purpose: Let users inspect local validation reports and aggregate counters without uploading artifacts.
+
+Key UI elements:
+
+- local report list
+- Markdown report preview
+- counter summary cards
+- adapter/runtime metadata
+- claim boundary note
+- local file path indicator
+
+Key copy:
+
+- Local validation reports
+- Aggregate counters only
+- No cloud upload by default
+
+Claim-safety notes:
+
+- Reports should use claim-safe boundary language from existing validation docs.
+- Do not show raw provider responses, secrets, private data, or proprietary datasets.
+- Do not convert local/no-network counters into production claims.
+
+## UI Composition Reference
+
+A concept board was generated during planning showing four UI areas:
+
+- Welcome / Setup
+- Model Selection
+- Project Chat Workspace
+- Reports / Validation Viewer
+
+Do not commit binary image assets in this task unless explicitly provided and approved. Do not reference local/private image paths.

--- a/docs/kora-studio/kora-studio-v0-1-product-spec.md
+++ b/docs/kora-studio/kora-studio-v0-1-product-spec.md
@@ -1,0 +1,76 @@
+# KORA Studio v0.1 Product Spec
+
+## Product Definition
+
+KORA Studio v0.1 is a local-first AI workspace for Mac and Linux that launches from the KORA CLI, opens a local browser UI, helps users choose local models, and lets them use Standard Mode or KORA Boost for project-based AI chat and validation visibility.
+
+## Target Users
+
+- local AI users
+- developers testing local LLM workflows
+- AI app builders
+- technical reviewers
+- contributors exploring KORA validation
+
+## User Problem
+
+Local model users often do not know which model their machine can run, how to compare direct model usage with KORA-controlled execution, or how much model work is being avoided.
+
+## Core Promise
+
+Less waiting. Better answers. No hardware upgrade.
+
+## KORA Boost Explanation
+
+KORA Boost handles simple work through fast paths and saves model power for the tasks that need it.
+
+## Standard Mode
+
+Standard Mode runs the selected local model directly.
+
+## KORA Boost
+
+KORA Boost routes simple or structured work through fast local paths first, then uses the model when deeper reasoning is needed.
+
+## MVP Features
+
+- CLI launch: `kora studio`
+- local web UI
+- browser auto-open
+- system capability detection
+- Ollama runtime check
+- supported local model list
+- recommended direct model
+- KORA Boost recommendation
+- model pull/download status
+- project-based chat
+- execution path panel
+- model-call counter cards
+- validation report viewer
+- local storage
+
+## MVP Non-Features
+
+- no cloud sync
+- no team accounts
+- no billing
+- no hosted SaaS
+- no provider billing dashboard
+- no energy dashboard
+- no real provider adapter by default
+- no production monitoring
+
+## Success Criteria
+
+- user can launch Studio locally
+- user can see local runtime status
+- user can choose a model
+- user can switch Standard Mode / KORA Boost
+- user can chat within a project
+- user can inspect execution path
+- user can see model-call counters
+- user can open local validation reports
+
+## Claim Safety
+
+Do not describe KORA Studio v0.1 as proving production cost reduction, real API-cost reduction, energy reduction, production validation, or broad workload superiority.


### PR DESCRIPTION
## Summary
- Add public-safe KORA Studio future-planning overview
- Add v0.1 product spec, MVP user flow, and architecture plan
- Add KORA Boost copy system and UI composition guide
- Update README/docs/community links

## Scope Boundaries
- No implementation added
- No product/existence claim added
- No cost/API/energy claims added
- No real provider calls or dependencies added
- No generated report artifacts committed

## Validation
- git diff --check
- git diff --cached --check
- python3 -m pytest
- python3 -m kora --help
- python3 -m kora examples list
- python3 -m kora run real_model_call_validation_fake -- --offline
- python3 -m kora run customer_support_triage_fake_validation -- --offline
- python3 -m kora run customer_support_triage_fake_validation -- --offline --report-md /tmp/kora_customer_support_validation.md
- python3 -m kora run direct_vs_kora -- --offline
- python3 -m kora run runtime_integrated_benchmark -- --offline

## Secret / Claim Scan
- Scanned changed public files for secret markers, real-looking contact data, private campaign text, production/API/energy claim phrases, ChatGPT, and Codex
- Matches were limited to explicit non-claim/claim-safety language and the requested ChatGPT-like project chat planning phrase