### PR TITLE
Add KORA Studio Phase 0 fixtures

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -41,6 +41,7 @@ KORA Studio is future planning only. It is not implemented yet.
 - [KORA Studio report viewer requirements](kora-studio/report-viewer-requirements.md)
 - [KORA Studio dashboard counter schema](kora-studio/dashboard-counter-schema.md)
 - [KORA Studio fixtures plan](kora-studio/fixtures-plan.md)
+- [KORA Studio fixture schema reference](kora-studio/fixture-schema-reference.md)
 
 ## Run
 

--- a/docs/kora-studio/README.md
+++ b/docs/kora-studio/README.md
@@ -67,3 +67,5 @@ KORA Studio planning does not create new benchmark claims. It should only visual
 - [Report viewer requirements](report-viewer-requirements.md)
 - [Dashboard counter schema](dashboard-counter-schema.md)
 - [Fixtures plan](fixtures-plan.md)
+- [Fixture schema reference](fixture-schema-reference.md)
+- [Phase 0 sample fixtures](fixtures/README.md)

--- a/docs/kora-studio/fixture-schema-reference.md
+++ b/docs/kora-studio/fixture-schema-reference.md
@@ -1,0 +1,51 @@
+# KORA Studio Fixture Schema Reference
+
+## Purpose
+
+This doc describes static fixture shapes for future KORA Studio UI work. The fixtures are planning samples only and do not mean KORA Studio is implemented.
+
+## Common Fields
+
+- `fixture_id`: stable identifier for the sample artifact.
+- `fixture_type`: sample category, such as `local_validation_summary`, `dashboard_counters`, or `project_chat_session`.
+- `mode`: validation or UI mode represented by the fixture.
+- `provider`: local validation or runtime label represented by the fixture.
+- `model`: model label represented by the fixture.
+- `privacy_class`: fixture privacy class; public Studio fixtures should use `synthetic`.
+- `claim_boundary`: explicit boundary text for what the fixture does and does not show.
+
+## Counter Fields
+
+- `total_requests`: number of requests or tasks represented by the sample.
+- `baseline_model_calls`: model-call events recorded by the direct baseline path.
+- `kora_model_calls`: model-call events recorded by the KORA-controlled path.
+- `avoided_model_calls`: baseline model calls minus KORA model calls.
+- `avoided_model_call_rate`: avoided model calls divided by baseline model calls when available.
+- `deterministic_routes`: requests handled by deterministic or fast local paths.
+- `model_escalations`: requests escalated to the selected model-call path.
+- `validation_pass_count`: validation checks that passed.
+- `validation_fail_count`: validation checks that failed.
+- `error_count`: runtime or validation errors counted by the sample.
+- `fallback_count`: requests that fell back because a route was unsupported or unresolved.
+
+## Project Chat Fields
+
+- `project`: project metadata, including project id, name, mode, selected model, runtime, and privacy class.
+- `messages`: synthetic user and assistant messages for a future project chat UI mock.
+- `execution_traces`: route-level trace objects connected to messages.
+
+## Report Viewer Fields
+
+- `report_title`: display title for the report.
+- `report_path`: local sample path used for UI planning.
+- `sections`: expected report sections for navigation.
+- `counters`: aggregate counter object extracted from a report or companion JSON.
+- `boundary_warnings`: warnings the UI should keep visible near report content.
+
+## Claim-Safe Display Rules
+
+- show measured counters only
+- do not convert avoided model calls into cost savings
+- do not show energy savings
+- do not imply production validation
+- label local/no-network validation clearly

--- a/docs/kora-studio/fixtures-plan.md
+++ b/docs/kora-studio/fixtures-plan.md
@@ -6,6 +6,10 @@ This plan defines safe fixture types for future KORA Studio prototypes before ru
 
 Fixtures should use synthetic, aggregate, local-only data and should not imply that KORA Studio is implemented.
 
+## Phase 0 Fixture Location
+
+Phase 0 sample fixtures now live under `docs/kora-studio/fixtures/`. The fixture directory contains reviewed static JSON samples for future Studio UI and implementation planning.
+
 ## Sample Fixture Types
 
 - local validation summary fixture

--- a/docs/kora-studio/fixtures/README.md
+++ b/docs/kora-studio/fixtures/README.md
@@ -1,0 +1,32 @@
+# KORA Studio Fixtures
+
+## Status
+
+These fixtures are static planning/sample artifacts for future KORA Studio implementation. They are not generated from production traffic.
+
+## Purpose
+
+Fixtures help future Studio development by providing stable sample data for the report viewer, counter dashboard, workload viewer, and project chat mock.
+
+## Privacy
+
+- synthetic data only
+- no API keys
+- no secrets
+- no private user data
+- no raw provider responses
+- no production logs
+- no proprietary datasets
+
+## Included Fixtures
+
+- `local-validation-summary.sample.json`
+- `customer-support-triage-summary.sample.json`
+- `dashboard-counters.sample.json`
+- `project-chat-session.sample.json`
+- `report-viewer-metadata.sample.json`
+- `kora-boost-mode-card.sample.json`
+
+## Claim Boundary
+
+Fixtures do not create new evidence or claims. They exist only to support UI and implementation planning.

--- a/docs/kora-studio/fixtures/customer-support-triage-summary.sample.json
+++ b/docs/kora-studio/fixtures/customer-support-triage-summary.sample.json
@@ -1,0 +1,32 @@
+{
+  "fixture_id": "kora_studio_customer_support_triage_summary_v0_1",
+  "fixture_type": "customer_support_triage_summary",
+  "workload_id": "customer_support_triage_synthetic_v1",
+  "mode": "customer_support_triage_local_validation",
+  "provider": "local_validation",
+  "model": "deterministic-local",
+  "privacy_class": "synthetic",
+  "total_requests": 12,
+  "baseline_model_calls": 12,
+  "kora_model_calls": 4,
+  "avoided_model_calls": 8,
+  "avoided_model_call_rate": 0.6667,
+  "deterministic_routes": 8,
+  "model_escalations": 4,
+  "validation_pass_count": 12,
+  "validation_fail_count": 0,
+  "error_count": 0,
+  "fallback_count": 0,
+  "route_classes": [
+    "deterministic_faq",
+    "deterministic_policy",
+    "structured_lookup",
+    "model_required"
+  ],
+  "notes": [
+    "Static sample fixture for future KORA Studio workload and report UI planning.",
+    "Uses synthetic customer-support route classes and aggregate counters only.",
+    "No external APIs, provider credentials, raw prompts, or private user data are included."
+  ],
+  "claim_boundary": "This fixture is synthetic local/no-network sample data for UI planning. It is not real provider validation, real API-cost reduction evidence, production validation, production cost reduction proof, or energy reduction evidence."
+}

--- a/docs/kora-studio/fixtures/dashboard-counters.sample.json
+++ b/docs/kora-studio/fixtures/dashboard-counters.sample.json
@@ -1,0 +1,95 @@
+{
+  "fixture_id": "kora_studio_dashboard_counters_v0_1",
+  "fixture_type": "dashboard_counters",
+  "title": "Local validation counter cards",
+  "cards": [
+    {
+      "key": "total_requests",
+      "label": "Total requests",
+      "value": 12,
+      "unit": "requests",
+      "explanation": "Number of synthetic requests in the local validation fixture.",
+      "claim_safety_note": "Display as local fixture data only."
+    },
+    {
+      "key": "baseline_model_calls",
+      "label": "Baseline model calls",
+      "value": 12,
+      "unit": "events",
+      "explanation": "Model-call events counted for the direct baseline path.",
+      "claim_safety_note": "Do not convert this value into billing or production evidence."
+    },
+    {
+      "key": "kora_model_calls",
+      "label": "KORA model calls",
+      "value": 4,
+      "unit": "events",
+      "explanation": "Model-call events counted for the KORA-controlled path.",
+      "claim_safety_note": "Label as local/no-network validation counters."
+    },
+    {
+      "key": "avoided_model_calls",
+      "label": "Avoided model calls",
+      "value": 8,
+      "unit": "events",
+      "explanation": "Baseline model calls minus KORA model calls in the fixture.",
+      "claim_safety_note": "Do not convert this value into billing or production evidence."
+    },
+    {
+      "key": "avoided_model_call_rate",
+      "label": "Avoided model-call rate",
+      "value": 0.6667,
+      "unit": "ratio",
+      "explanation": "Avoided model calls divided by baseline model calls in the fixture.",
+      "claim_safety_note": "Do not convert this ratio into billing, provider, or energy claims."
+    },
+    {
+      "key": "deterministic_routes",
+      "label": "Deterministic routes",
+      "value": 8,
+      "unit": "routes",
+      "explanation": "Requests handled through deterministic or fast local paths.",
+      "claim_safety_note": "Applies only to the synthetic fixture."
+    },
+    {
+      "key": "model_escalations",
+      "label": "Model escalations",
+      "value": 4,
+      "unit": "routes",
+      "explanation": "Requests escalated to the selected model-call path.",
+      "claim_safety_note": "Display as local fixture routing behavior."
+    },
+    {
+      "key": "validation_pass_count",
+      "label": "Validation passes",
+      "value": 12,
+      "unit": "checks",
+      "explanation": "Validation checks that passed in the fixture.",
+      "claim_safety_note": "Does not imply production validation."
+    },
+    {
+      "key": "validation_fail_count",
+      "label": "Validation failures",
+      "value": 0,
+      "unit": "checks",
+      "explanation": "Validation checks that failed in the fixture.",
+      "claim_safety_note": "Applies only to sample fixture data."
+    },
+    {
+      "key": "error_count",
+      "label": "Errors",
+      "value": 0,
+      "unit": "events",
+      "explanation": "Runtime or validation errors counted in the fixture.",
+      "claim_safety_note": "Does not imply production reliability."
+    },
+    {
+      "key": "fallback_count",
+      "label": "Fallbacks",
+      "value": 0,
+      "unit": "events",
+      "explanation": "Requests that fell back because a route was unsupported or unresolved.",
+      "claim_safety_note": "Display as synthetic fixture behavior only."
+    }
+  ]
+}

--- a/docs/kora-studio/fixtures/kora-boost-mode-card.sample.json
+++ b/docs/kora-studio/fixtures/kora-boost-mode-card.sample.json
@@ -1,0 +1,22 @@
+{
+  "fixture_id": "kora_studio_kora_boost_mode_card_v0_1",
+  "fixture_type": "kora_boost_mode_card",
+  "card_title": "KORA Boost",
+  "marketing_message": "Less waiting. Better answers. No hardware upgrade.",
+  "technical_explanation": "KORA Boost handles simple work through fast paths and saves model power for the tasks that need it.",
+  "standard_mode_copy": {
+    "title": "Standard Mode",
+    "description": "Run the local model directly."
+  },
+  "kora_boost_copy": {
+    "title": "KORA Boost",
+    "description": "Less waiting. Better answers. No hardware upgrade."
+  },
+  "tooltip": "Simple tasks take the fast path. Harder tasks use the model when it matters.",
+  "claim_safety": [
+    "no production cost reduction claim",
+    "no real API-cost reduction claim",
+    "no energy reduction claim",
+    "no claim that larger models physically run without validation"
+  ]
+}

--- a/docs/kora-studio/fixtures/local-validation-summary.sample.json
+++ b/docs/kora-studio/fixtures/local-validation-summary.sample.json
@@ -1,0 +1,25 @@
+{
+  "fixture_id": "kora_studio_local_validation_summary_v0_1",
+  "fixture_type": "local_validation_summary",
+  "mode": "local_no_network_model_call_validation",
+  "provider": "local_validation",
+  "model": "deterministic-local",
+  "privacy_class": "synthetic",
+  "total_requests": 10,
+  "baseline_model_calls": 10,
+  "kora_model_calls": 4,
+  "avoided_model_calls": 6,
+  "avoided_model_call_rate": 0.6,
+  "deterministic_routes": 6,
+  "model_escalations": 4,
+  "validation_pass_count": 10,
+  "validation_fail_count": 0,
+  "error_count": 0,
+  "fallback_count": 0,
+  "notes": [
+    "Static sample fixture for future KORA Studio UI planning.",
+    "Uses aggregate local/no-network validation counters only.",
+    "No provider request, provider response, credential, or customer data is included."
+  ],
+  "claim_boundary": "This fixture is synthetic local/no-network sample data for UI planning. It is not real provider validation, real API-cost reduction evidence, production validation, production cost reduction proof, or energy reduction evidence."
+}

--- a/docs/kora-studio/fixtures/project-chat-session.sample.json
+++ b/docs/kora-studio/fixtures/project-chat-session.sample.json
@@ -1,0 +1,78 @@
+{
+  "fixture_id": "kora_studio_project_chat_session_v0_1",
+  "fixture_type": "project_chat_session",
+  "project": {
+    "project_id": "studio_demo_project_001",
+    "name": "Synthetic support planning demo",
+    "mode": "kora_boost",
+    "selected_model": "deterministic-local",
+    "runtime": "local_validation",
+    "privacy_class": "synthetic"
+  },
+  "messages": [
+    {
+      "message_id": "msg_001",
+      "role": "user",
+      "content": "Where can I find the shipping status for a sample order?"
+    },
+    {
+      "message_id": "msg_002",
+      "role": "assistant",
+      "content": "Use the account order page and select the sample tracking link. This fixture answer follows a deterministic support-policy route."
+    },
+    {
+      "message_id": "msg_003",
+      "role": "user",
+      "content": "A sample customer says the order status and account email do not match. What should happen next?"
+    },
+    {
+      "message_id": "msg_004",
+      "role": "assistant",
+      "content": "The fixture routes this ambiguous account-support request to model escalation, then validates that the answer asks for safe account-verification steps without exposing private data."
+    }
+  ],
+  "execution_traces": [
+    {
+      "trace_id": "trace_001",
+      "message_id": "msg_002",
+      "selected_route": "deterministic_policy",
+      "model_called": false,
+      "deterministic_route_used": true,
+      "model_escalation_used": false,
+      "validation_result": "passed",
+      "latency_ms": 12,
+      "counters": {
+        "baseline_model_calls": 1,
+        "kora_model_calls": 0,
+        "avoided_model_calls": 1,
+        "deterministic_routes": 1,
+        "model_escalations": 0,
+        "validation_pass_count": 1,
+        "validation_fail_count": 0,
+        "error_count": 0,
+        "fallback_count": 0
+      }
+    },
+    {
+      "trace_id": "trace_002",
+      "message_id": "msg_004",
+      "selected_route": "model_required",
+      "model_called": true,
+      "deterministic_route_used": false,
+      "model_escalation_used": true,
+      "validation_result": "passed",
+      "latency_ms": 86,
+      "counters": {
+        "baseline_model_calls": 1,
+        "kora_model_calls": 1,
+        "avoided_model_calls": 0,
+        "deterministic_routes": 0,
+        "model_escalations": 1,
+        "validation_pass_count": 1,
+        "validation_fail_count": 0,
+        "error_count": 0,
+        "fallback_count": 0
+      }
+    }
+  ]
+}

--- a/docs/kora-studio/fixtures/report-viewer-metadata.sample.json
+++ b/docs/kora-studio/fixtures/report-viewer-metadata.sample.json
@@ -1,0 +1,36 @@
+{
+  "fixture_id": "kora_studio_report_viewer_metadata_v0_1",
+  "fixture_type": "report_viewer_metadata",
+  "report_title": "Local No-Network Validation Report",
+  "report_path": "/tmp/kora_customer_support_validation.md",
+  "generated_at": "2026-05-10T00:00:00Z",
+  "mode": "customer_support_triage_local_validation",
+  "workload_id": "customer_support_triage_synthetic_v1",
+  "privacy_class": "synthetic",
+  "sections": [
+    "Summary",
+    "Counters",
+    "Boundary",
+    "Reproduction",
+    "Notes"
+  ],
+  "counters": {
+    "total_requests": 12,
+    "baseline_model_calls": 12,
+    "kora_model_calls": 4,
+    "avoided_model_calls": 8,
+    "avoided_model_call_rate": 0.6667,
+    "deterministic_routes": 8,
+    "model_escalations": 4,
+    "validation_pass_count": 12,
+    "validation_fail_count": 0,
+    "error_count": 0,
+    "fallback_count": 0
+  },
+  "boundary_warnings": [
+    "Local/no-network validation counters only.",
+    "No cloud upload by default.",
+    "Do not commit generated reports by default.",
+    "Do not treat fixture counters as production evidence."
+  ]
+}

--- a/docs/kora-studio/kora-studio-implementation-breakdown.md
+++ b/docs/kora-studio/kora-studio-implementation-breakdown.md
@@ -34,6 +34,8 @@ Deliverables:
 - `docs/kora-studio/fixtures-plan.md`
 - `docs/kora-studio/report-viewer-requirements.md`
 - `docs/kora-studio/dashboard-counter-schema.md`
+- `docs/kora-studio/fixture-schema-reference.md`
+- `docs/kora-studio/fixtures/`
 
 No code required.
 

--- a/tests/test_kora_studio_fixtures.py
+++ b/tests/test_kora_studio_fixtures.py
@@ -1,0 +1,122 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+FIXTURE_DIR = Path("docs/kora-studio/fixtures")
+REQUIRED_COUNTERS = {
+    "total_requests",
+    "baseline_model_calls",
+    "kora_model_calls",
+    "avoided_model_calls",
+    "avoided_model_call_rate",
+    "deterministic_routes",
+    "model_escalations",
+    "validation_pass_count",
+    "validation_fail_count",
+    "error_count",
+    "fallback_count",
+}
+APPROVED_BOOST_MESSAGE = "Less waiting. Better answers. No hardware upgrade."
+BLOCKED_KEY_FRAGMENTS = {
+    "api_key",
+    "password",
+    "raw_provider_response",
+    "raw_response",
+    "provider_response",
+}
+POSITIVE_CLAIM_PHRASES = {
+    "production cost savings",
+    "real api-cost savings",
+    "energy savings",
+    "production validated",
+    "production validation proof",
+}
+
+
+def _fixture_paths() -> list[Path]:
+    return sorted(FIXTURE_DIR.glob("*.json"))
+
+
+def _walk(value: Any) -> list[Any]:
+    items = [value]
+    if isinstance(value, dict):
+        for key, nested in value.items():
+            items.append(key)
+            items.extend(_walk(nested))
+    elif isinstance(value, list):
+        for nested in value:
+            items.extend(_walk(nested))
+    return items
+
+
+def _load(path: Path) -> dict[str, Any]:
+    with path.open(encoding="utf-8") as handle:
+        data = json.load(handle)
+    assert isinstance(data, dict), f"{path} must contain a JSON object"
+    return data
+
+
+def test_kora_studio_json_fixtures_are_valid() -> None:
+    paths = _fixture_paths()
+    assert paths, "expected KORA Studio JSON fixtures"
+
+    for path in paths:
+        data = _load(path)
+        assert data.get("fixture_id"), f"{path} missing fixture_id"
+        assert data.get("fixture_type"), f"{path} missing fixture_type"
+
+
+def test_kora_studio_fixtures_use_synthetic_privacy_class() -> None:
+    for path in _fixture_paths():
+        data = _load(path)
+        privacy_class = data.get("privacy_class")
+        if privacy_class is not None:
+            assert privacy_class == "synthetic", f"{path} must use synthetic privacy"
+        project = data.get("project")
+        if isinstance(project, dict) and "privacy_class" in project:
+            assert project["privacy_class"] == "synthetic", f"{path} project must be synthetic"
+
+
+def test_kora_studio_fixtures_do_not_include_secret_or_raw_response_fields() -> None:
+    for path in _fixture_paths():
+        data = _load(path)
+        for item in _walk(data):
+            if not isinstance(item, str):
+                continue
+            lowered = item.lower()
+            assert not lowered.startswith("sk-"), f"{path} contains secret-looking token"
+            assert not lowered.startswith("ghp_"), f"{path} contains GitHub token-looking value"
+            for blocked in BLOCKED_KEY_FRAGMENTS:
+                assert blocked not in lowered, f"{path} contains blocked field or value {blocked!r}"
+
+
+def test_kora_studio_summary_and_counter_fixtures_include_required_counters() -> None:
+    for path in _fixture_paths():
+        data = _load(path)
+        fixture_type = str(data.get("fixture_type"))
+        if fixture_type in {"local_validation_summary", "customer_support_triage_summary"}:
+            assert REQUIRED_COUNTERS.issubset(data), f"{path} missing required counters"
+        if fixture_type == "dashboard_counters":
+            card_keys = {card.get("key") for card in data.get("cards", [])}
+            assert REQUIRED_COUNTERS == card_keys, f"{path} dashboard cards must match counters"
+        if fixture_type == "report_viewer_metadata":
+            counters = data.get("counters")
+            assert isinstance(counters, dict), f"{path} missing counters object"
+            assert REQUIRED_COUNTERS.issubset(counters), f"{path} missing report counters"
+
+
+def test_kora_boost_copy_fixture_uses_approved_marketing_message() -> None:
+    data = _load(FIXTURE_DIR / "kora-boost-mode-card.sample.json")
+    assert data["marketing_message"] == APPROVED_BOOST_MESSAGE
+    assert data["kora_boost_copy"]["description"] == APPROVED_BOOST_MESSAGE
+
+
+def test_kora_studio_fixtures_do_not_make_positive_cost_or_energy_claims() -> None:
+    for path in _fixture_paths():
+        data = _load(path)
+        text_values = [item.lower() for item in _walk(data) if isinstance(item, str)]
+        for text in text_values:
+            for phrase in POSITIVE_CLAIM_PHRASES:
+                assert phrase not in text, f"{path} contains positive claim phrase {phrase!r}"


### PR DESCRIPTION
## Summary
- Add KORA Studio Phase 0 fixture directory
- Add sample local validation summary fixture
- Add customer-support triage summary fixture
- Add dashboard counter fixture
- Add project chat session fixture
- Add report viewer metadata fixture
- Add KORA Boost mode card fixture
- Add fixture schema reference
- Add deterministic fixture validity tests

## Scope Boundaries
- Documentation and static fixtures only
- No KORA Studio runtime/server/frontend code added
- No real provider calls or provider/runtime dependencies added
- No generated report artifacts committed
- No cost/API/energy claims added

## Validation
- git diff --check
- git diff --cached --check
- python3 -m pytest tests/test_kora_studio_fixtures.py
- python3 -m pytest
- python3 -m kora --help
- python3 -m kora examples list
- python3 -m kora run real_model_call_validation_fake -- --offline
- python3 -m kora run customer_support_triage_fake_validation -- --offline
- python3 -m kora run customer_support_triage_fake_validation -- --offline --report-md /tmp/kora_customer_support_validation.md
- python3 -m kora run direct_vs_kora -- --offline
- python3 -m kora run runtime_integrated_benchmark -- --offline

## Secret / Claim Scan
- Scanned changed Studio docs, fixtures, and fixture tests for secret markers, real-looking contact data, private campaign text, production/API/energy claim phrases, ChatGPT, and Codex
- Matches were limited to explicit non-claim/safety language and test guard strings