### PR TITLE
Add KORA Studio CLI skeleton

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -42,6 +42,7 @@ KORA Studio is future planning only. It is not implemented yet.
 - [KORA Studio dashboard counter schema](kora-studio/dashboard-counter-schema.md)
 - [KORA Studio fixtures plan](kora-studio/fixtures-plan.md)
 - [KORA Studio fixture schema reference](kora-studio/fixture-schema-reference.md)
+- CLI skeleton: `python3 -m kora studio`
 
 ## Run
 

--- a/docs/kora-studio/README.md
+++ b/docs/kora-studio/README.md
@@ -61,6 +61,16 @@ KORA Studio docs in public KORA should describe technical design, local validati
 
 KORA Studio planning does not create new benchmark claims. It should only visualize already generated validation counters and claim-safe reports.
 
+## CLI Skeleton
+
+A minimal planning/preview CLI skeleton is available:
+
+```bash
+python3 -m kora studio
+```
+
+The command prints the current KORA Studio status and links to the Studio docs and fixtures. It does not start a server, open a browser, call a model runtime, call a provider, or require API keys. The next implementation phases are tracked in the [KORA Studio implementation breakdown](kora-studio-implementation-breakdown.md).
+
 ## Implementation Planning
 
 - [KORA Studio implementation breakdown](kora-studio-implementation-breakdown.md)

--- a/docs/kora-studio/kora-studio-implementation-breakdown.md
+++ b/docs/kora-studio/kora-studio-implementation-breakdown.md
@@ -41,6 +41,8 @@ No code required.
 
 ## Phase 1 — CLI Launch Skeleton
 
+Status: Initial CLI skeleton is available through `python3 -m kora studio`. It prints planning/preview status only; it does not start a server, open a browser, call a model runtime, or call a provider.
+
 Goal: Add a `kora studio` command that starts a placeholder local server or prints clear next-step status.
 
 Scope:

--- a/kora/cli.py
+++ b/kora/cli.py
@@ -10,6 +10,7 @@ import sys
 from pathlib import Path
 
 from kora.cost_model import compute_savings
+from kora.studio_status import get_studio_status, render_studio_status_text
 from kora.telemetry import load_json, render_markdown_report, summarize_run
 
 
@@ -137,6 +138,15 @@ def main(argv: list[str] | None = None) -> int:
     run_parser.add_argument("example", help="example name under examples/")
     run_parser.add_argument("example_args", nargs=argparse.REMAINDER, help="arguments passed to the example")
 
+    studio_parser = subparsers.add_parser(
+        "studio",
+        help="show KORA Studio planning/preview status",
+        description="Show KORA Studio planning/preview status. This command does not start a server, open a browser, or call a model runtime.",
+    )
+    studio_parser.add_argument("--status", action="store_true", help="show planning/preview status")
+    studio_parser.add_argument("--no-browser", action="store_true", help="accepted for future compatibility; no browser is launched")
+    studio_parser.add_argument("--open-browser", action="store_true", help="accepted for future compatibility; browser launch is not implemented yet")
+
     telemetry_parser = subparsers.add_parser("telemetry", help="summarize a run JSON file")
     telemetry_parser.add_argument("--input", required=True, help="path to run/report JSON")
     telemetry_parser.add_argument("--json-out", help="output path for telemetry JSON")
@@ -156,6 +166,11 @@ def main(argv: list[str] | None = None) -> int:
         if extra_args and extra_args[0] == "--":
             extra_args = extra_args[1:]
         return _run_example(args.example, extra_args)
+
+    if args.command == "studio":
+        status = get_studio_status()
+        print(render_studio_status_text(status), end="")
+        return 0
 
     if args.command == "telemetry":
         input_path = Path(args.input)

--- a/kora/studio_status.py
+++ b/kora/studio_status.py
@@ -1,0 +1,48 @@
+"""Planning-stage status helpers for the KORA Studio CLI skeleton."""
+
+from __future__ import annotations
+
+from typing import Any
+
+KORA_BOOST_MESSAGE = "Less waiting. Better answers. No hardware upgrade."
+KORA_BOOST_TECHNICAL_EXPLANATION = (
+    "KORA Boost handles simple work through fast paths and saves model power "
+    "for the tasks that need it."
+)
+DOCS_PATH = "docs/kora-studio/README.md"
+FIXTURES_PATH = "docs/kora-studio/fixtures/"
+
+
+def get_studio_status() -> dict[str, Any]:
+    """Return static planning-stage status for KORA Studio."""
+
+    return {
+        "status": "planning",
+        "implementation": "cli_skeleton",
+        "server_available": False,
+        "browser_launch_available": False,
+        "provider_calls_enabled": False,
+        "local_runtime_required": False,
+        "docs_path": DOCS_PATH,
+        "fixtures_path": FIXTURES_PATH,
+        "kora_boost_message": KORA_BOOST_MESSAGE,
+        "kora_boost_technical_explanation": KORA_BOOST_TECHNICAL_EXPLANATION,
+    }
+
+
+def render_studio_status_text(status: dict[str, Any]) -> str:
+    """Render KORA Studio planning-stage status for CLI output."""
+
+    lines = [
+        "KORA Studio is in planning/preview mode.",
+        str(status["kora_boost_message"]),
+        str(status["kora_boost_technical_explanation"]),
+        "Current status: CLI skeleton only. No local server is started yet.",
+        "Browser launch: not implemented yet.",
+        "Provider calls: disabled. No provider calls are made.",
+        "Local runtime: not required for this command.",
+        "API keys: not required.",
+        f"Docs: {status['docs_path']}",
+        f"Fixtures: {status['fixtures_path']}",
+    ]
+    return "\n".join(lines) + "\n"

--- a/tests/test_kora_studio_cli.py
+++ b/tests/test_kora_studio_cli.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+
+from kora.studio_status import get_studio_status, render_studio_status_text
+
+APPROVED_BOOST_MESSAGE = "Less waiting. Better answers. No hardware upgrade."
+TECHNICAL_EXPLANATION = (
+    "KORA Boost handles simple work through fast paths and saves model power "
+    "for the tasks that need it."
+)
+
+
+def _run_kora_studio(*args: str) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    env.pop("OPENAI_API_KEY", None)
+    env.pop("ANTHROPIC_API_KEY", None)
+    return subprocess.run(
+        [sys.executable, "-m", "kora", "studio", *args],
+        check=False,
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+
+def test_kora_studio_help_works() -> None:
+    completed = _run_kora_studio("--help")
+
+    assert completed.returncode == 0
+    assert "planning/preview status" in completed.stdout
+    assert "--no-browser" in completed.stdout
+    assert "--open-browser" in completed.stdout
+
+
+def test_kora_studio_status_command_is_safe_noop() -> None:
+    completed = _run_kora_studio()
+
+    assert completed.returncode == 0
+    assert "KORA Studio is in planning/preview mode." in completed.stdout
+    assert APPROVED_BOOST_MESSAGE in completed.stdout
+    assert TECHNICAL_EXPLANATION in completed.stdout
+    assert "No local server is started yet." in completed.stdout
+    assert "Provider calls: disabled. No provider calls are made." in completed.stdout
+    assert "API keys: not required." in completed.stdout
+    assert "Docs: docs/kora-studio/README.md" in completed.stdout
+    assert "Fixtures: docs/kora-studio/fixtures/" in completed.stdout
+    assert completed.stderr == ""
+
+
+def test_kora_studio_inert_browser_flags_do_not_launch_browser() -> None:
+    completed = _run_kora_studio("--open-browser", "--no-browser")
+
+    assert completed.returncode == 0
+    assert "Browser launch: not implemented yet." in completed.stdout
+    assert "No local server is started yet." in completed.stdout
+
+
+def test_get_studio_status_is_planning_skeleton() -> None:
+    status = get_studio_status()
+
+    assert status["status"] == "planning"
+    assert status["implementation"] == "cli_skeleton"
+    assert status["server_available"] is False
+    assert status["browser_launch_available"] is False
+    assert status["provider_calls_enabled"] is False
+    assert status["local_runtime_required"] is False
+    assert status["docs_path"] == "docs/kora-studio/README.md"
+    assert status["fixtures_path"] == "docs/kora-studio/fixtures/"
+    assert status["kora_boost_message"] == APPROVED_BOOST_MESSAGE
+
+
+def test_render_studio_status_text_includes_boundaries() -> None:
+    text = render_studio_status_text(get_studio_status())
+
+    assert text.endswith("\n")
+    assert "CLI skeleton only" in text
+    assert "No provider calls are made" in text
+    assert "Local runtime: not required" in text


### PR DESCRIPTION
## Summary
- add `python3 -m kora studio` CLI skeleton
- print planning/preview status with approved KORA Boost copy
- keep browser launch, local server, model runtime, and provider calls disabled/not implemented
- add pure status helper and CLI tests
- update KORA Studio docs and docs index

## Safety
- no server/browser/runtime implementation added
- no provider/runtime calls added
- no dependencies added
- no package version changes
- no cost/API/energy claims added

## Validation
- `git diff --check`
- `python3 -m pytest tests/test_kora_studio_cli.py`
- `python3 -m pytest`
- `python3 -m kora --help`
- `python3 -m kora studio --help`
- `python3 -m kora studio`
- `python3 -m kora examples list`
- `python3 -m kora run real_model_call_validation_fake -- --offline`
- `python3 -m kora run customer_support_triage_fake_validation -- --offline`
- `python3 -m kora run customer_support_triage_fake_validation -- --offline --report-md /tmp/kora_customer_support_validation.md`
- `python3 -m kora run direct_vs_kora -- --offline`
- `python3 -m kora run runtime_integrated_benchmark -- --offline`
