### PR TITLE
docs: add documentation PR checklist

### DIFF
--- a/docs/community/contributor-pathway.md
+++ b/docs/community/contributor-pathway.md
@@ -94,6 +94,17 @@ Prefer small PRs. A good first PR usually changes one concern, touches a small n
 
 Include tests or docs when they are relevant. Avoid bundling unrelated changes such as documentation cleanup, runtime behavior, formatting, and benchmark wording in the same PR.
 
+## Documentation PR Checklist
+
+For documentation-only PRs:
+
+- Keep the PR small.
+- Touch one document or one topic.
+- Do not add secrets or private data.
+- Do not change benchmark claims.
+- Do not add production-cost, real API-cost, energy, or production-validation claims.
+- Mention the changed file in the PR description.
+
 ## Review Expectations
 
 Reviewers will expect:


### PR DESCRIPTION
## Summary
- add a concise checklist for documentation-only PRs
- keep guidance claim-safe and limited to public contributor behavior

Fixes #103

## Validation
- `git diff --check`

Note: `python -m pytest` could not be run locally because `pytest` is not installed in this Python environment.