### PR TITLE
docs: clarify KORA Studio planning scope

### DIFF
--- a/docs/kora-studio/README.md
+++ b/docs/kora-studio/README.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-KORA Studio is a future planning area. It is not implemented yet.
+KORA Studio is an early local implementation and planning area. It is not a complete product, hosted service, or production-ready workflow yet.
 
 ## Planning Scope
 

--- a/docs/kora-studio/README.md
+++ b/docs/kora-studio/README.md
@@ -4,6 +4,10 @@
 
 KORA Studio is a future planning area. It is not implemented yet.
 
+## Planning Scope
+
+The Studio documents describe candidate UI, workflow, fixture, and report-viewer ideas until implementation work lands in code. Current KORA validation remains CLI-based through local examples and generated validation reports. Do not describe Studio behavior as shipped unless the corresponding runtime, CLI, or server code exists in this repository.
+
 ## Purpose
 
 KORA Studio is intended to become a local-first AI workspace for Mac and Linux that helps users run local LLM workflows, compare Standard Mode and KORA Boost, and inspect KORA execution paths, model-call counters, and validation reports.


### PR DESCRIPTION
## Summary
- add a short planning-scope note to the KORA Studio README
- clarify that Studio docs describe candidate UI/workflow ideas until matching implementation exists
- point current validation expectations back to CLI/local validation reports

Fixes #105

## Validation
- `git diff --check`

Note: `python -m pytest` could not be run locally because `pytest` is not installed in this Python environment.