### PR TITLE
Add KORA Studio local server placeholder page

### DIFF
--- a/docs/kora-studio/README.md
+++ b/docs/kora-studio/README.md
@@ -92,6 +92,22 @@ Status:
 
 The server skeleton is not the full KORA Studio runtime or frontend. It exists to define the local server boundary for future Studio implementation work.
 
+## Static Preview Page
+
+The local server root serves a static preview page:
+
+```bash
+python3 -m kora studio --serve
+```
+
+Open locally:
+
+```text
+http://127.0.0.1:8765/
+```
+
+The page is preview-only. It uses embedded HTML/CSS, does not auto-launch a browser, does not call Ollama or providers, does not require API keys, and does not use a frontend framework yet.
+
 ## Implementation Planning
 
 - [KORA Studio implementation breakdown](kora-studio-implementation-breakdown.md)

--- a/docs/kora-studio/README.md
+++ b/docs/kora-studio/README.md
@@ -116,3 +116,4 @@ The page is preview-only. It uses embedded HTML/CSS, does not auto-launch a brow
 - [Fixtures plan](fixtures-plan.md)
 - [Fixture schema reference](fixture-schema-reference.md)
 - [Phase 0 sample fixtures](fixtures/README.md)
+- [Local server placeholder page](kora-studio-local-server-placeholder-page.md)

--- a/docs/kora-studio/kora-studio-implementation-breakdown.md
+++ b/docs/kora-studio/kora-studio-implementation-breakdown.md
@@ -82,6 +82,8 @@ Acceptance criteria:
 
 ## Phase 3 — Static Web UI Prototype
 
+Status: The local server root now serves a static preview page. The next step is to expand that placeholder into a static UI prototype while keeping it local-only and framework-free until a full frontend decision is made.
+
 Goal: Create a static UI prototype for KORA Studio.
 
 Screens:

--- a/docs/kora-studio/kora-studio-local-server-placeholder-page.md
+++ b/docs/kora-studio/kora-studio-local-server-placeholder-page.md
@@ -30,7 +30,7 @@ The server remains localhost-only by default. Browser auto-launch is not impleme
 - no browser launch
 - no Ollama integration
 - no provider calls
-- no model/runtime integration
+- no model/runtime integration yet
 - no project UI yet
 - no API keys required
 

--- a/docs/kora-studio/kora-studio-local-server-placeholder-page.md
+++ b/docs/kora-studio/kora-studio-local-server-placeholder-page.md
@@ -1,0 +1,43 @@
+# KORA Studio Local Server Placeholder Page
+
+## Status
+
+The KORA Studio local server placeholder page is a static preview page for the v0.1 server skeleton. It is not a full frontend and does not make KORA Studio production-ready.
+
+## How to Run
+
+```bash
+python3 -m kora studio --serve
+```
+
+Open the local page at:
+
+```text
+http://127.0.0.1:8765/
+```
+
+The server remains localhost-only by default. Browser auto-launch is not implemented.
+
+## Endpoints
+
+- `/` serves the static placeholder page
+- `/health` returns local health status JSON
+- `/status` returns local preview status, KORA Boost copy, docs paths, and fixture paths
+
+## Current Limitations
+
+- no full frontend yet
+- no browser launch
+- no Ollama integration
+- no provider calls
+- no model/runtime integration
+- no project UI yet
+- no API keys required
+
+## Claim Boundary
+
+The page is for deterministic-first local workflow exploration. It does not create production claims, API-cost claims, energy claims, benchmark claims, provider-validation claims, or deployment-readiness claims.
+
+## Privacy Boundary
+
+The placeholder page is static and self-contained. It does not expose environment variables, provider responses, private data, private internals, campaign material, or proprietary datasets.

--- a/kora/studio_server.py
+++ b/kora/studio_server.py
@@ -218,6 +218,7 @@ def render_studio_placeholder_html(status: dict[str, Any]) -> str:
           <li>No full frontend yet</li>
           <li>No browser launch yet</li>
           <li>No provider calls</li>
+          <li>No model/runtime integration yet</li>
           <li>No Ollama integration</li>
           <li>No API keys required</li>
           <li>No production/API-cost/energy claims</li>

--- a/kora/studio_server.py
+++ b/kora/studio_server.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import html
 import json
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from typing import Any, Callable
@@ -81,27 +82,176 @@ def render_studio_server_status_text(status: dict[str, Any]) -> str:
 
 
 def render_studio_placeholder_html(status: dict[str, Any]) -> str:
-    """Render a minimal placeholder page for the preview server."""
+    """Render the static KORA Studio preview page."""
 
-    return """<!doctype html>
-<html lang="en">
+    docs_path = html.escape(str(status["docs_path"]), quote=True)
+    fixtures_path = html.escape(str(status["fixtures_path"]), quote=True)
+    boost_message = html.escape(str(status["kora_boost_message"]), quote=True)
+    boost_explanation = html.escape(str(status["kora_boost_technical_explanation"]), quote=True)
+
+    return f"""<!doctype html>
+<html lang=\"en\">
 <head>
-  <meta charset="utf-8">
+  <meta charset=\"utf-8\">
+  <meta name=\"viewport\" content=\"width=device-width, initial-scale=1\">
   <title>KORA Studio Preview</title>
+  <style>
+    :root {{
+      color-scheme: dark;
+      --bg: #071014;
+      --panel: #0d1b22;
+      --panel-2: #10242d;
+      --text: #edf7fa;
+      --muted: #9fb3bd;
+      --cyan: #32d1e6;
+      --amber: #f0b44c;
+      --green: #57d68d;
+      --line: #24424d;
+    }}
+    * {{ box-sizing: border-box; }}
+    body {{
+      margin: 0;
+      background: var(--bg);
+      color: var(--text);
+      font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      line-height: 1.5;
+    }}
+    main {{
+      width: min(1040px, calc(100% - 40px));
+      margin: 0 auto;
+      padding: 48px 0;
+    }}
+    .topline {{
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 16px;
+      margin-bottom: 32px;
+    }}
+    .badge {{
+      display: inline-flex;
+      align-items: center;
+      border: 1px solid var(--green);
+      color: var(--green);
+      border-radius: 999px;
+      padding: 6px 12px;
+      font-size: 13px;
+      font-weight: 700;
+    }}
+    h1 {{
+      margin: 0 0 12px;
+      font-size: clamp(34px, 6vw, 64px);
+      letter-spacing: 0;
+      line-height: 1.05;
+    }}
+    h2 {{
+      margin: 0 0 14px;
+      font-size: 20px;
+      letter-spacing: 0;
+    }}
+    p {{ margin: 0; }}
+    .hero {{
+      border: 1px solid var(--line);
+      background: linear-gradient(180deg, var(--panel), var(--panel-2));
+      border-radius: 8px;
+      padding: 28px;
+    }}
+    .boost {{
+      color: var(--cyan);
+      font-size: 24px;
+      font-weight: 800;
+      margin-top: 18px;
+    }}
+    .technical {{
+      color: var(--muted);
+      max-width: 760px;
+      margin-top: 10px;
+      font-size: 16px;
+    }}
+    .grid {{
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+      gap: 16px;
+      margin-top: 20px;
+    }}
+    section {{
+      border: 1px solid var(--line);
+      background: var(--panel);
+      border-radius: 8px;
+      padding: 20px;
+    }}
+    ul {{
+      margin: 0;
+      padding-left: 20px;
+      color: var(--muted);
+    }}
+    li + li {{ margin-top: 8px; }}
+    code {{
+      color: var(--amber);
+      background: #071014;
+      border: 1px solid var(--line);
+      border-radius: 6px;
+      padding: 2px 6px;
+      overflow-wrap: anywhere;
+    }}
+    a {{ color: var(--cyan); }}
+    .status-list strong {{ color: var(--text); }}
+  </style>
 </head>
 <body>
   <main>
-    <h1>KORA Studio Preview</h1>
-    <p>Less waiting. Better answers. No hardware upgrade.</p>
-    <p>No provider calls. No browser launch. No Ollama calls.</p>
-    <p>Docs: {docs_path}</p>
-    <p>Fixtures: {fixtures_path}</p>
+    <div class=\"topline\">
+      <strong>KORA Studio</strong>
+      <span class=\"badge\">Preview / Local-only</span>
+    </div>
+    <div class=\"hero\">
+      <h1>KORA Studio Preview</h1>
+      <p class=\"boost\">{boost_message}</p>
+      <p class=\"technical\">{boost_explanation}</p>
+    </div>
+    <div class=\"grid\">
+      <section>
+        <h2>Current Status</h2>
+        <ul class=\"status-list\">
+          <li><strong>Local server skeleton</strong></li>
+          <li>No full frontend yet</li>
+          <li>No browser launch yet</li>
+          <li>No Ollama/provider calls</li>
+          <li>No API keys required</li>
+        </ul>
+      </section>
+      <section>
+        <h2>What Works Today</h2>
+        <ul>
+          <li>CLI status</li>
+          <li>localhost server skeleton</li>
+          <li>health/status endpoints</li>
+          <li>fixture-backed planning data</li>
+        </ul>
+      </section>
+      <section>
+        <h2>Coming Next</h2>
+        <ul>
+          <li>report viewer</li>
+          <li>counter dashboard</li>
+          <li>project chat shell</li>
+          <li>Ollama detection</li>
+        </ul>
+      </section>
+      <section>
+        <h2>Local References</h2>
+        <ul>
+          <li><a href=\"/health\">/health</a></li>
+          <li><a href=\"/status\">/status</a></li>
+          <li><code>{docs_path}</code></li>
+          <li><code>{fixtures_path}</code></li>
+        </ul>
+      </section>
+    </div>
   </main>
 </body>
 </html>
-""".format(
-        docs_path=status["docs_path"], fixtures_path=status["fixtures_path"]
-    )
+"""
 
 
 def create_studio_request_handler(status_provider: StatusProvider | None = None) -> type[BaseHTTPRequestHandler]:

--- a/kora/studio_server.py
+++ b/kora/studio_server.py
@@ -94,7 +94,7 @@ def render_studio_placeholder_html(status: dict[str, Any]) -> str:
 <head>
   <meta charset=\"utf-8\">
   <meta name=\"viewport\" content=\"width=device-width, initial-scale=1\">
-  <title>KORA Studio Preview</title>
+  <title>KORA Studio</title>
   <style>
     :root {{
       color-scheme: dark;
@@ -205,19 +205,22 @@ def render_studio_placeholder_html(status: dict[str, Any]) -> str:
       <span class=\"badge\">Preview / Local-only</span>
     </div>
     <div class=\"hero\">
-      <h1>KORA Studio Preview</h1>
+      <h1>KORA Studio</h1>
       <p class=\"boost\">{boost_message}</p>
-      <p class=\"technical\">{boost_explanation}</p>
+      <p class=\"technical\">This is a local placeholder page for the KORA Studio v0.1 skeleton. {boost_explanation}</p>
     </div>
     <div class=\"grid\">
       <section>
         <h2>Current Status</h2>
         <ul class=\"status-list\">
           <li><strong>Local server skeleton</strong></li>
+          <li>Deterministic-first local workflow exploration</li>
           <li>No full frontend yet</li>
           <li>No browser launch yet</li>
-          <li>No Ollama/provider calls</li>
+          <li>No provider calls</li>
+          <li>No Ollama integration</li>
           <li>No API keys required</li>
+          <li>No production/API-cost/energy claims</li>
         </ul>
       </section>
       <section>

--- a/tests/test_kora_studio_server.py
+++ b/tests/test_kora_studio_server.py
@@ -142,6 +142,7 @@ def test_static_preview_html_content_is_safe_and_complete() -> None:
     assert "No full frontend yet" in html
     assert "No browser launch yet" in html
     assert "No provider calls" in html
+    assert "No model/runtime integration yet" in html
     assert "No Ollama integration" in html
     assert "No API keys required" in html
     assert "/health" in html

--- a/tests/test_kora_studio_server.py
+++ b/tests/test_kora_studio_server.py
@@ -116,7 +116,7 @@ def test_request_handler_serves_health_status_and_placeholder() -> None:
     assert status["server"] == "local-only"
     assert status["provider_calls_enabled"] is False
     assert status["ollama_calls_enabled"] is False
-    assert "KORA Studio Preview" in html
+    assert "KORA Studio" in html
     assert APPROVED_BOOST_MESSAGE in html
     assert "Preview / Local-only" in html
     assert "/health" in html
@@ -131,14 +131,18 @@ def test_static_preview_html_content_is_safe_and_complete() -> None:
     html = render_studio_placeholder_html(get_studio_server_status())
 
     assert html.startswith("<!doctype html>")
-    assert "KORA Studio Preview" in html
+    assert "KORA Studio" in html
     assert "Preview / Local-only" in html
     assert APPROVED_BOOST_MESSAGE in html
     assert TECHNICAL_EXPLANATION in html
+    assert "local placeholder page for the KORA Studio v0.1 skeleton" in html
     assert "local server skeleton" in html.lower()
+    assert "Deterministic-first local workflow exploration" in html
+    assert "No production/API-cost/energy claims" in html
     assert "No full frontend yet" in html
     assert "No browser launch yet" in html
-    assert "No Ollama/provider calls" in html
+    assert "No provider calls" in html
+    assert "No Ollama integration" in html
     assert "No API keys required" in html
     assert "/health" in html
     assert "/status" in html

--- a/tests/test_kora_studio_server.py
+++ b/tests/test_kora_studio_server.py
@@ -16,6 +16,7 @@ from kora.studio_server import (
     get_studio_server_status,
     get_studio_status_payload,
     is_allowed_studio_host,
+    render_studio_placeholder_html,
     render_studio_server_status_text,
 )
 
@@ -117,4 +118,41 @@ def test_request_handler_serves_health_status_and_placeholder() -> None:
     assert status["ollama_calls_enabled"] is False
     assert "KORA Studio Preview" in html
     assert APPROVED_BOOST_MESSAGE in html
-    assert "No provider calls. No browser launch. No Ollama calls." in html
+    assert "Preview / Local-only" in html
+    assert "/health" in html
+    assert "/status" in html
+    assert "provider calls enabled" not in html.lower()
+    assert "production cost reduction" not in html.lower()
+    assert "real api-cost reduction" not in html.lower()
+    assert "energy reduction" not in html.lower()
+
+
+def test_static_preview_html_content_is_safe_and_complete() -> None:
+    html = render_studio_placeholder_html(get_studio_server_status())
+
+    assert html.startswith("<!doctype html>")
+    assert "KORA Studio Preview" in html
+    assert "Preview / Local-only" in html
+    assert APPROVED_BOOST_MESSAGE in html
+    assert TECHNICAL_EXPLANATION in html
+    assert "local server skeleton" in html.lower()
+    assert "No full frontend yet" in html
+    assert "No browser launch yet" in html
+    assert "No Ollama/provider calls" in html
+    assert "No API keys required" in html
+    assert "/health" in html
+    assert "/status" in html
+    assert "docs/kora-studio/README.md" in html
+    assert "docs/kora-studio/fixtures/" in html
+    assert "CLI status" in html
+    assert "fixture-backed planning data" in html
+    assert "report viewer" in html
+    assert "counter dashboard" in html
+    assert "project chat shell" in html
+    assert "Ollama detection" in html
+    assert "OPENAI_API_KEY" not in html
+    assert "ANTHROPIC_API_KEY" not in html
+    assert "provider calls enabled" not in html.lower()
+    assert "production cost reduction" not in html.lower()
+    assert "real api-cost reduction" not in html.lower()
+    assert "energy reduction" not in html.lower()


### PR DESCRIPTION
## Summary
- add a static placeholder page for the KORA Studio local server `/` endpoint
- preserve `/health` and `/status`
- include current local-server status, endpoint links, limitations, and claim-safe deterministic-first local workflow wording
- add `docs/kora-studio/kora-studio-local-server-placeholder-page.md`
- update server tests and Studio docs index

## Safety
- no frontend framework or external build dependencies
- no external CSS/JS/assets/CDNs
- no browser launch behavior
- no Ollama integration
- no provider calls
- no model/runtime integration
- no production/API-cost/energy claims

## Validation
- `git diff --check`
- `python3 -m pytest`
- `python3 -m kora --help`
- `python3 -m kora studio`
- `python3 -m kora studio --help`

Local server endpoint validation:
- bounded `python3 -m kora studio --serve --host 127.0.0.1 --port 8878`
- requested `/`, `/health`, and `/status`
- confirmed placeholder title, endpoint links, limitations, health OK, local-only status, provider calls disabled
- terminated subprocess cleanly
