### PR TITLE
Add KORA first paper citation audit

### DIFF
--- a/docs/paper/kora-first-paper-bibliography-notes.md
+++ b/docs/paper/kora-first-paper-bibliography-notes.md
@@ -35,9 +35,21 @@ Status:
 - Final citation style is still pending.
 - Final bibliography normalization and citation audit are still pending.
 
+## Citation Audit v0.1
+
+[KORA First Paper Citation Audit v0.1](kora-first-paper-citation-audit-v0-1.md) has been created.
+
+Status:
+
+- Preliminary references are traceable to [R01] through [R10].
+- BibTeX remains pending.
+- Final citation style remains pending.
+- Metadata normalization remains pending.
+- The audit maps reference use to claim boundaries and forbidden citation uses.
+
 Recommended next pass:
 
-Normalize the final bibliography style, audit every citation against the tracker, and add BibTeX only if all required fields are fully verified from official sources.
+Choose a citation style, normalize the final bibliography, audit every citation against the tracker, and add BibTeX only if all required fields are fully verified from official sources.
 
 ## Target Citation Areas
 

--- a/docs/paper/kora-first-paper-citation-audit-v0-1.md
+++ b/docs/paper/kora-first-paper-citation-audit-v0-1.md
@@ -1,0 +1,143 @@
+# KORA First Paper Citation Audit v0.1
+
+## Purpose
+
+This audit checks reference consistency, citation safety, and claim boundaries for manuscript v0.2. It is a bibliography-readiness document, not a final bibliography and not a submission-readiness claim.
+
+## Scope
+
+This audit covers:
+
+- manuscript v0.2
+- references [R01] through [R10]
+- preliminary references section
+- related work framing
+- claim boundary language
+
+It does not add BibTeX, final citation style, new references, or new evidence claims.
+
+## Citation Inventory
+
+| ID | Reference topic | Appears in manuscript | Appears in References section | Tracker status | Action |
+|---|---|---|---|---|---|
+| [R01] | vLLM / PagedAttention | Yes | Yes | verified | normalize later |
+| [R02] | MLPerf Inference | Yes | Yes | verified | normalize later |
+| [R03] | ONNX Runtime docs | Yes | Yes | verified | needs citation style decision |
+| [R04] | LangGraph Graph API docs | Yes | Yes | verified | needs citation style decision |
+| [R05] | DSPy | Yes | Yes | verified | normalize later |
+| [R06] | Retrieval-Augmented Generation | Yes | Yes | verified | normalize later |
+| [R07] | Apache Airflow DAG docs | Yes | Yes | verified | needs citation style decision |
+| [R08] | Snakemake | Yes | Yes | verified | normalize later |
+| [R09] | llama.cpp | Yes | Yes | verified | needs citation style decision |
+| [R10] | ACM Artifact Review and Badging | Yes | Yes | verified | needs citation style decision |
+
+## Reference Normalization Status
+
+### [R01] vLLM / PagedAttention
+
+- Preliminary reference usability: usable as a preliminary paper reference.
+- Metadata still missing: final venue/citation-format normalization.
+- BibTeX ready: no.
+- Source traceability: traceable to arXiv URL and DOI recorded in the tracker.
+
+### [R02] MLPerf Inference
+
+- Preliminary reference usability: usable as a preliminary benchmark-methodology reference.
+- Metadata still missing: final citation-format normalization and full author handling.
+- BibTeX ready: no.
+- Source traceability: traceable to arXiv URL recorded in the tracker.
+
+### [R03] ONNX Runtime docs
+
+- Preliminary reference usability: usable as official documentation context.
+- Metadata still missing: final documentation citation style and exact access-date formatting.
+- BibTeX ready: no.
+- Source traceability: traceable to official documentation URL recorded in the tracker.
+
+### [R04] LangGraph Graph API docs
+
+- Preliminary reference usability: usable as official documentation context.
+- Metadata still missing: final documentation citation style and exact access-date formatting.
+- BibTeX ready: no.
+- Source traceability: traceable to official documentation URL recorded in the tracker.
+
+### [R05] DSPy
+
+- Preliminary reference usability: usable as a preliminary programmatic-LM-workflow reference.
+- Metadata still missing: final venue/citation-format normalization.
+- BibTeX ready: no.
+- Source traceability: traceable to arXiv URL recorded in the tracker.
+
+### [R06] Retrieval-Augmented Generation
+
+- Preliminary reference usability: usable as a preliminary RAG background reference.
+- Metadata still missing: final citation-format normalization.
+- BibTeX ready: no.
+- Source traceability: traceable to arXiv URL and DOI recorded in the tracker.
+
+### [R07] Apache Airflow DAG docs
+
+- Preliminary reference usability: usable as official DAG/workflow documentation context.
+- Metadata still missing: final documentation citation style and exact access-date formatting.
+- BibTeX ready: no.
+- Source traceability: traceable to official Apache Airflow documentation URL recorded in the tracker.
+
+### [R08] Snakemake
+
+- Preliminary reference usability: usable as a preliminary workflow-engine reference.
+- Metadata still missing: final citation-format normalization.
+- BibTeX ready: no.
+- Source traceability: traceable to DOI recorded in the tracker.
+
+### [R09] llama.cpp
+
+- Preliminary reference usability: usable as official repository context for future local runtime work.
+- Metadata still missing: final software/repository citation style and exact access-date formatting.
+- BibTeX ready: no.
+- Source traceability: traceable to official GitHub repository URL recorded in the tracker.
+
+### [R10] ACM Artifact Review and Badging
+
+- Preliminary reference usability: usable as official artifact-practice guidance context.
+- Metadata still missing: final policy/documentation citation style.
+- BibTeX ready: no.
+- Source traceability: traceable to official ACM policy URL recorded in the tracker.
+
+## Claim-Support Mapping
+
+| Claim or statement type | References used | Supported use | Boundary |
+|---|---|---|---|
+| LLM serving systems context | [R01], [R02], [R03] | Background on model serving, inference benchmarking, and runtime context | Does not support KORA outperforming serving systems. |
+| Workflow/DAG orchestration context | [R07], [R08] | Background on explicit workflows, DAGs, and reproducible pipelines | Does not support KORA replacing workflow systems. |
+| Agent/programmatic AI context | [R04], [R05] | Background on graph-based agent execution and programmatic LM workflows | Does not support KORA replacing agent frameworks. |
+| RAG context | [R06] | Background for retrieval-grounded generation and contrast with KORA routing | Does not support KORA replacing RAG. |
+| Local runtime context | [R03], [R09] | Future-work context for local model/runtime systems | Does not support current local runtime validation evidence. |
+| Benchmarking/reproducibility context | [R02] | Benchmark-methodology background | Does not support KORA production benchmark proof. |
+| Artifact evaluation context | [R10] | Artifact-practice and transparency background | Does not indicate formal artifact evaluation approval. |
+| KORA 80/100 result | KORA benchmark docs and reproducible deterministic-heavy benchmark evidence | Supports the approved deterministic-heavy benchmark claim | External references do not imply production savings, real API-cost reduction, energy reduction, or broad superiority. |
+
+## Forbidden Citation Uses
+
+- Do not cite external systems as proof KORA is superior.
+- Do not cite references as production cost reduction proof.
+- Do not cite references as real API-cost reduction proof.
+- Do not cite references as energy reduction evidence.
+- Do not cite references as production benchmark evidence.
+- Do not cite references as formal artifact evaluation approval.
+
+## Bibliography Gaps
+
+- Final citation style selection pending.
+- BibTeX pending.
+- Exact venue/metadata audit pending where needed.
+- Additional references needed for agent/tool-use.
+- Semantic caching references may be needed.
+- Synthetic workload reproducibility references may be needed.
+- Local runtime references may need expansion.
+- Venue-specific artifact guidance may be needed.
+
+## Next Step
+
+- Task 316C or later: bibliography normalization pass after citation style decision.
+- Optional additional reference verification pass for missing categories.
+- Manuscript v0.3 only after bibliography and claim audit are stable.

--- a/docs/paper/kora-first-paper-manuscript-v0-2.md
+++ b/docs/paper/kora-first-paper-manuscript-v0-2.md
@@ -212,7 +212,7 @@ KORA is complementary to model serving systems, workflow orchestrators, agent fr
 
 ## References
 
-This preliminary references section uses only verified entries from the first reference pass. Citation style and BibTeX are not final.
+This preliminary references section uses only verified entries from the first reference pass. Citation style and BibTeX are not final. See [KORA First Paper Citation Audit v0.1](kora-first-paper-citation-audit-v0-1.md) for citation consistency, traceability, and claim-boundary notes.
 
 - [R01] Woosuk Kwon, Zhuohan Li, Siyuan Zhuang, Ying Sheng, Lianmin Zheng, Cody Hao Yu, Joseph E. Gonzalez, Hao Zhang, and Ion Stoica. "Efficient Memory Management for Large Language Model Serving with PagedAttention." SOSP 2023; arXiv:2309.06180. Source: https://arxiv.org/abs/2309.06180; https://doi.org/10.48550/arXiv.2309.06180
 - [R02] Vijay Janapa Reddi et al. "MLPerf Inference Benchmark." arXiv:1911.02549, 2019; revised 2020. Source: https://arxiv.org/abs/1911.02549

--- a/docs/paper/kora-first-paper-missing-evidence-checklist.md
+++ b/docs/paper/kora-first-paper-missing-evidence-checklist.md
@@ -34,12 +34,14 @@
 - Figure generation.
 - Bibliography/references.
 - Manuscript v0.2 reference-integration review.
+- Citation audit v0.1 review.
 - Final verified bibliography.
 
 ## References and figures needed
 
 - Additional verified related work references.
 - Final citation format and bibliography normalization.
+- Final citation audit review.
 - Verified BibTeX entries if a BibTeX workflow is selected.
 - Figure 1 architecture.
 - Figure 2 execution-control layer.
@@ -62,7 +64,16 @@ First verified reference pass:
 - 10 references partially collected across the target related-work categories.
 - Verified references recorded in the reference tracker.
 - Manuscript v0.2 created with verified references integrated as preliminary citation labels.
+- Citation audit v0.1 created.
 - Final citation format, final bibliography, and BibTeX still pending.
+
+Additional reference categories still pending:
+
+- Agent/tool-use references.
+- Semantic caching references if the manuscript discusses caching in more detail.
+- Synthetic workload reproducibility references.
+- Local runtime references beyond the current preliminary context.
+- Venue-specific artifact guidance.
 
 ## Follow-Up Papers / Technical Reports
 

--- a/docs/paper/kora-first-paper-reference-plan.md
+++ b/docs/paper/kora-first-paper-reference-plan.md
@@ -35,6 +35,15 @@ Completed on 2026-05-11.
 - Final citation style, final bibliography normalization, and BibTeX remain pending.
 - No fake citations or unsupported production, API-cost, energy, production-validation, broad superiority, or cited-system superiority claims added.
 
+### Citation Audit v0.1
+
+Completed on 2026-05-11.
+
+- Citation audit v0.1 created.
+- References [R01] through [R10] checked for manuscript use, References-section presence, tracker status, and source traceability.
+- Claim-support mapping added for related-work context and the KORA 80/100 benchmark result.
+- Bibliography normalization and citation style selection remain pending.
+
 ## Reference Categories
 
 ### 1. LLM serving and inference systems

--- a/docs/paper/kora-first-paper-submission-readiness.md
+++ b/docs/paper/kora-first-paper-submission-readiness.md
@@ -8,6 +8,8 @@ The current paper track has a thesis, manuscript v0.2, claim-boundary docs, revi
 
 The reference scaffold now exists, and the first verified reference pass has collected 10 citation candidates across the major related-work categories. Manuscript v0.2 integrates those verified references as preliminary citation labels. No fake citations or unverified BibTeX entries have been added.
 
+Citation audit v0.1 exists and maps preliminary references to manuscript use, traceability status, and claim boundaries.
+
 ## Ready
 
 - Thesis.
@@ -21,12 +23,14 @@ The reference scaffold now exists, and the first verified reference pass has col
 - Figure and table planning docs.
 - Reference scaffold.
 - First verified reference pass.
+- Citation audit v0.1.
 
 ## Needed Before arXiv / Workshop Submission
 
 - More references collected and verified.
 - Final citation style selected.
 - Final bibliography entries normalized.
+- Final citation audit review completed.
 - Figure drafts created.
 - Tables finalized.
 - Clean command transcript captured.
@@ -53,6 +57,6 @@ These are suggested formats only. This document does not claim acceptance, endor
 
 ## Reference Status
 
-The first verified reference pass is complete, and manuscript v0.2 integrates the verified references as preliminary citation labels and a preliminary references section. The paper is still not submission-ready because the final bibliography style is not selected, final normalized bibliography entries are pending, and BibTeX has not been added.
+The first verified reference pass is complete, manuscript v0.2 integrates the verified references as preliminary citation labels and a preliminary references section, and citation audit v0.1 exists. The paper is still not submission-ready because the final bibliography style is not selected, final normalized bibliography entries are pending, and BibTeX has not been added.
 
 No fake citations were added. Future citation work should use only verified tracker entries and should not support production, API-cost, energy, production-validation, broad superiority, or cited-system superiority claims.


### PR DESCRIPTION
## Summary
- create citation audit v0.1 for manuscript v0.2 references [R01]-[R10]
- lightly normalize manuscript v0.2 to link the audit from the preliminary references section
- update bibliography, readiness, missing-evidence, and reference-plan docs

## Scope and boundaries
- no BibTeX added
- no fake citations added
- no new references added
- no new claims added
- paper remains not submission-ready

## Validation
- git diff --check
- python3 -m pytest
- python3 -m kora --help
- python3 -m kora examples list
- python3 -m kora run runtime_integrated_benchmark -- --offline
- python3 -m kora run customer_support_triage_fake_validation -- --offline
- python3 -m kora run direct_vs_kora -- --offline

## Remaining gaps
- final citation style selection
- final bibliography normalization
- BibTeX only after required metadata is fully verified
- additional reference verification for missing categories