### PR TITLE
Add KORA first paper v0.3 reference integration plan

### DIFF
--- a/docs/paper/kora-first-paper-bibliography-notes.md
+++ b/docs/paper/kora-first-paper-bibliography-notes.md
@@ -72,6 +72,20 @@ Recommended next pass:
 
 Select the final citation style or perform a narrow manuscript integration pass for `[R11]` through `[R18]`, then normalize bibliography metadata without adding unsupported claims.
 
+## Manuscript v0.3 Reference Integration Plan
+
+[KORA First Paper Manuscript v0.3 Reference Integration Plan](kora-first-paper-manuscript-v0-3-reference-integration-plan.md) has been created.
+
+Status:
+
+- Integration of `[R11]` through `[R18]` remains planned but not yet executed.
+- The plan recommends integrating `[R11]`, `[R12]`, and `[R13]` in v0.3.
+- The plan keeps `[R14]`, `[R15]`, and `[R16]` optional depending on section expansion.
+- The plan defers `[R17]` and `[R18]` until target venue or artifact package planning.
+- BibTeX remains pending.
+- Final citation style remains pending.
+- Synthetic workload / benchmark-construction references remain pending.
+
 ## Target Citation Areas
 
 - LLM serving and inference systems.

--- a/docs/paper/kora-first-paper-manuscript-v0-3-reference-integration-plan.md
+++ b/docs/paper/kora-first-paper-manuscript-v0-3-reference-integration-plan.md
@@ -1,0 +1,86 @@
+# KORA First Paper Manuscript v0.3 Reference Integration Plan
+
+## Purpose
+
+This document plans the safe integration of [R11] through [R18] into a future manuscript v0.3. It does not create manuscript v0.3, does not add BibTeX, and does not make the paper submission-ready.
+
+## Current State
+
+- Manuscript v0.2 currently integrates [R01] through [R10].
+- References [R11] through [R18] are verified but tracker/audit-only.
+- The paper remains not submission-ready.
+- BibTeX and final citation style remain pending.
+- Final bibliography normalization and metadata audit remain pending.
+
+## Integration Principles
+
+- Integrate only references that strengthen required related-work context.
+- Avoid citation bloat.
+- Avoid using references as proof of KORA superiority.
+- Avoid using external references as production, API-cost, or energy evidence.
+- Keep KORA's 80/100 result mapped to KORA deterministic-heavy benchmark evidence.
+- Keep manuscript v0.3 complementary in tone.
+- Defer references that are useful for bibliography or artifact planning but not necessary in manuscript text.
+
+## Reference-by-Reference Integration Decision
+
+| ID | Reference | Current status | Proposed manuscript section | Decision | Rationale | Claim boundary |
+|---|---|---|---|---|---|---|
+| [R11] | ReAct | verified, tracker/audit-only | Background and Related Work / Agent/tool routing and programmatic AI workflows | integrate in v0.3 | Strengthens discussion of reasoning/action and agent tool-use context. | Use as background only; do not claim KORA outperforms ReAct or agent systems. |
+| [R12] | Toolformer | verified, tracker/audit-only | Background and Related Work / Agent/tool routing and programmatic AI workflows | integrate in v0.3 | Helps distinguish model-centered tool-use training from KORA's deterministic-first execution control. | Do not imply KORA uses Toolformer-style training or outperforms tool-use systems. |
+| [R13] | PAL / program-aided language models | verified, tracker/audit-only | Background and Related Work / Agent/tool routing and programmatic AI workflows | integrate in v0.3 | Strengthens programmatic AI workflow context near DSPy and KORA's deterministic routes. | Use as program-aided workflow context only; not as KORA model-call avoidance evidence. |
+| [R14] | GPTCache | verified, tracker/audit-only | Background and Related Work / Retrieval-augmented generation or caching contrast | optional if section expands | Useful if v0.3 adds explicit semantic-cache contrast, but not required if the manuscript keeps caching brief. | Do not use to support KORA production cost, real API-cost, or latency claims. |
+| [R15] | Ollama docs and official repo | verified, tracker/audit-only | Background and Related Work / Local model and runtime systems | optional if section expands | Useful if v0.3 expands local runtime future-work context. | Do not imply current KORA paper evidence includes Ollama integration. |
+| [R16] | NeurIPS reproducibility report | verified, tracker/audit-only | Reproducibility and Artifact Notes | optional if section expands | Useful for reproducibility framing and checklist discipline. | Does not make KORA formally reproducible by venue standards or submission-ready. |
+| [R17] | USENIX NSDI artifact guidance | verified, tracker/audit-only | Reproducibility and Artifact Notes / future artifact package planning | defer until target venue | Best used if a USENIX-style artifact strategy becomes relevant. | Do not imply KORA has artifact approval or formal artifact evaluation. |
+| [R18] | MLSys artifact evaluation guidance | verified, tracker/audit-only | Reproducibility and Artifact Notes / future artifact package planning | defer until target venue | Best used if an MLSys-style artifact strategy becomes relevant. | Do not imply KORA has artifact approval or formal artifact evaluation. |
+
+## Proposed v0.3 Manuscript Changes
+
+Background and Related Work:
+
+- Add agent/tool-use subsection details for [R11] and [R12].
+- Add programmatic AI workflow context for [R13].
+- Optionally mention semantic caching [R14] only if caching becomes more central.
+- Optionally mention local runtime [R15] only if the local runtime section needs more support.
+
+Reproducibility and Artifact Notes:
+
+- Optionally mention [R16] if the reproducibility section expands beyond the current ACM artifact-practice reference.
+- Defer [R17] and [R18] until venue or artifact package planning.
+
+Limitations:
+
+- Keep non-claims unchanged.
+- Preserve the statement that current evidence does not prove production behavior, real provider behavior, API-cost reduction, energy reduction, or broad workload superiority.
+
+References section:
+
+- Add only the references actually integrated into manuscript text.
+- Keep all added references clearly preliminary until final citation style and bibliography normalization are complete.
+- Do not add BibTeX in the manuscript.
+
+## References to Keep Tracker-Only for Now
+
+- [R14] GPTCache: keep tracker-only unless semantic caching receives more explicit treatment in v0.3.
+- [R15] Ollama: keep tracker-only unless the local runtime section expands beyond future-work context.
+- [R16] NeurIPS reproducibility report: keep tracker-only unless reproducibility notes expand.
+- [R17] USENIX NSDI artifact guidance: defer until target venue or artifact package planning.
+- [R18] MLSys artifact evaluation guidance: defer until target venue or artifact package planning.
+
+## Claim-Safety Checklist for v0.3
+
+- No "KORA outperforms X" claim.
+- No production cost reduction proof.
+- No real API-cost reduction proof.
+- No energy reduction evidence.
+- No broad workload superiority.
+- No formal artifact approval.
+- No submission-ready implication.
+- No use of external references to prove KORA's 80/100 result.
+- Keep the 80/100 result tied to KORA's deterministic-heavy benchmark evidence.
+
+## Next Step
+
+- Task 318C or later: create manuscript v0.3 with selected [R11] through [R18] integration.
+- Alternative: verify synthetic workload / benchmark-construction references before manuscript v0.3 if the evaluation-methodology section should be strengthened first.

--- a/docs/paper/kora-first-paper-missing-evidence-checklist.md
+++ b/docs/paper/kora-first-paper-missing-evidence-checklist.md
@@ -71,7 +71,7 @@ Additional reference verification pass 2:
 
 - 8 additional references verified and recorded as `[R11]` through `[R18]`.
 - Agent/tool-use, semantic caching, local-runtime, reproducibility-program, and venue artifact-guidance coverage improved.
-- Manuscript integration for `[R11]` through `[R18]` is still pending.
+- Manuscript integration for `[R11]` through `[R18]` is planned but not complete.
 - Final citation style, final bibliography, and BibTeX still pending.
 
 Additional reference categories still pending:
@@ -79,6 +79,7 @@ Additional reference categories still pending:
 - Synthetic workload and benchmark-construction references.
 - Optional additional semantic caching references if the manuscript discusses caching in more detail.
 - Target-venue-specific citation and artifact guidance after venue selection.
+- Manuscript v0.3 creation after reference integration decisions are accepted.
 
 ## Follow-Up Papers / Technical Reports
 

--- a/docs/paper/kora-first-paper-reference-plan.md
+++ b/docs/paper/kora-first-paper-reference-plan.md
@@ -55,6 +55,17 @@ Completed on 2026-05-11.
 - Remaining gaps: synthetic workload and benchmark-construction references, optional additional semantic-cache references, and final target-venue citation/artifact guidance.
 - Bibliography status: BibTeX not added in this pass; final citation style and bibliography normalization remain pending.
 
+### Manuscript v0.3 Reference Integration Plan
+
+Completed on 2026-05-11.
+
+- Manuscript v0.3 reference integration plan created.
+- References `[R11]` through `[R18]` mapped to candidate manuscript sections and integration decisions.
+- Selected references will be integrated later based on the plan.
+- Remaining gaps: synthetic workload / benchmark-construction references and final target-venue citation/artifact guidance.
+- Manuscript v0.3 has not been created.
+- BibTeX and final citation style remain pending.
+
 ## Reference Categories
 
 ### 1. LLM serving and inference systems

--- a/docs/paper/kora-first-paper-related-work-map.md
+++ b/docs/paper/kora-first-paper-related-work-map.md
@@ -114,3 +114,13 @@ The second verified reference pass collected 8 additional citation candidates:
 - Systems artifact evaluation practices: USENIX NSDI artifact guidance, MLSys artifact evaluation guidance.
 
 These references are not yet integrated into manuscript v0.2. They should be used in a later manuscript pass only as background, positioning, reproducibility, or future-work context. They should not support production, API-cost, energy, broad superiority, artifact approval, or submission-readiness claims.
+
+## Manuscript v0.3 Integration Planning
+
+The [manuscript v0.3 reference integration plan](kora-first-paper-manuscript-v0-3-reference-integration-plan.md) maps `[R11]` through `[R18]` to future manuscript decisions.
+
+Summary:
+
+- Integrate `[R11]`, `[R12]`, and `[R13]` if v0.3 expands agent/tool-use and programmatic workflow related work.
+- Keep `[R14]`, `[R15]`, and `[R16]` optional unless caching, local runtime, or reproducibility sections expand.
+- Defer `[R17]` and `[R18]` until target venue or artifact package planning.

--- a/docs/paper/kora-first-paper-submission-readiness.md
+++ b/docs/paper/kora-first-paper-submission-readiness.md
@@ -12,6 +12,8 @@ Citation audit v0.1 exists and maps preliminary references to manuscript use, tr
 
 Additional reference verification pass 2 has collected 8 more verified references for remaining bibliography gaps. These references are recorded in the tracker and audit, but manuscript integration is deferred.
 
+Manuscript v0.3 reference integration planning now exists for [R11] through [R18]. Manuscript v0.3 has not been created.
+
 ## Ready
 
 - Thesis.
@@ -27,10 +29,12 @@ Additional reference verification pass 2 has collected 8 more verified reference
 - First verified reference pass.
 - Additional reference verification pass 2.
 - Citation audit v0.1.
+- Manuscript v0.3 reference integration plan.
 
 ## Needed Before arXiv / Workshop Submission
 
 - More references collected and verified.
+- Manuscript v0.3 created if the selected reference integration plan is accepted.
 - Final citation style selected.
 - Final bibliography entries normalized.
 - Final citation audit review completed.
@@ -60,6 +64,6 @@ These are suggested formats only. This document does not claim acceptance, endor
 
 ## Reference Status
 
-The first verified reference pass is complete, manuscript v0.2 integrates the first-pass verified references as preliminary citation labels and a preliminary references section, citation audit v0.1 exists, and additional reference verification pass 2 has added 8 verified tracker entries. The paper is still not submission-ready because the new references are not yet integrated into the manuscript, the final bibliography style is not selected, final normalized bibliography entries are pending, and BibTeX has not been added.
+The first verified reference pass is complete, manuscript v0.2 integrates the first-pass verified references as preliminary citation labels and a preliminary references section, citation audit v0.1 exists, additional reference verification pass 2 has added 8 verified tracker entries, and a manuscript v0.3 reference integration plan exists. The paper is still not submission-ready because manuscript v0.3 has not been created, the new references are not yet integrated into the manuscript, the final bibliography style is not selected, final normalized bibliography entries are pending, and BibTeX has not been added.
 
 No fake citations were added. Future citation work should use only verified tracker entries and should not support production, API-cost, energy, production-validation, broad superiority, or cited-system superiority claims.


### PR DESCRIPTION
## Summary
- create manuscript v0.3 reference integration plan for [R11]-[R18]
- map each reference to a proposed manuscript section, integration decision, rationale, and claim boundary
- update bibliography, readiness, missing-evidence, reference-plan, and related-work docs

## Integration decisions
- integrate in v0.3: [R11] ReAct, [R12] Toolformer, [R13] PAL
- optional if sections expand: [R14] GPTCache, [R15] Ollama, [R16] NeurIPS reproducibility report
- defer until target venue/artifact planning: [R17] USENIX NSDI artifact guidance, [R18] MLSys artifact evaluation guidance

## Boundaries
- manuscript v0.3 not created
- manuscript v0.2 not changed
- no BibTeX added
- no fake citations
- no new claims
- no paper submission-ready claim

## Validation
- git diff --check
- python3 -m pytest
- python3 -m kora --help
- python3 -m kora examples list
- python3 -m kora run runtime_integrated_benchmark -- --offline
- python3 -m kora run customer_support_triage_fake_validation -- --offline
- python3 -m kora run direct_vs_kora -- --offline

## Remaining gaps
- synthetic workload / benchmark-construction references
- final target-venue citation/artifact guidance
- final citation style selection
- bibliography normalization
- BibTeX only after metadata is fully verified