### PR TITLE
Add KORA first paper manuscript v0.3

### DIFF
--- a/docs/paper/kora-first-paper-bibliography-notes.md
+++ b/docs/paper/kora-first-paper-bibliography-notes.md
@@ -86,6 +86,19 @@ Status:
 - Final citation style remains pending.
 - Synthetic workload / benchmark-construction references remain pending.
 
+## Manuscript v0.3 Integration
+
+[KORA First Paper Manuscript v0.3](kora-first-paper-manuscript-v0-3.md) has been created.
+
+Status:
+
+- `[R11]`, `[R12]`, and `[R13]` are integrated into manuscript v0.3 as agent/tool-use and programmatic workflow background.
+- `[R14]` through `[R18]` remain tracker/audit-only, optional, or deferred according to the v0.3 integration plan.
+- BibTeX remains pending.
+- Final citation style remains pending.
+- Final bibliography normalization remains pending.
+- Synthetic workload / benchmark-construction references remain pending.
+
 ## Target Citation Areas
 
 - LLM serving and inference systems.

--- a/docs/paper/kora-first-paper-citation-audit-v0-1.md
+++ b/docs/paper/kora-first-paper-citation-audit-v0-1.md
@@ -2,13 +2,14 @@
 
 ## Purpose
 
-This audit checks reference consistency, citation safety, and claim boundaries for manuscript v0.2. It is a bibliography-readiness document, not a final bibliography and not a submission-readiness claim.
+This audit checks reference consistency, citation safety, and claim boundaries for manuscript v0.2 and the selected manuscript v0.3 integration of [R11], [R12], and [R13]. It is a bibliography-readiness document, not a final bibliography and not a submission-readiness claim.
 
 ## Scope
 
 This audit covers:
 
 - manuscript v0.2
+- manuscript v0.3 selected reference integration
 - references [R01] through [R18]
 - preliminary references section
 - related work framing
@@ -30,9 +31,9 @@ It does not add BibTeX, final citation style, manuscript-integrated citations be
 | [R08] | Snakemake | Yes | Yes | verified | normalize later |
 | [R09] | llama.cpp | Yes | Yes | verified | needs citation style decision |
 | [R10] | ACM Artifact Review and Badging | Yes | Yes | verified | needs citation style decision |
-| [R11] | ReAct | No, future integration | No, future integration | verified | needs manuscript integration decision |
-| [R12] | Toolformer | No, future integration | No, future integration | verified | needs manuscript integration decision |
-| [R13] | PAL | No, future integration | No, future integration | verified | needs manuscript integration decision |
+| [R11] | ReAct | Yes, in manuscript v0.3 | Yes, in manuscript v0.3 | verified | normalize later |
+| [R12] | Toolformer | Yes, in manuscript v0.3 | Yes, in manuscript v0.3 | verified | normalize later |
+| [R13] | PAL | Yes, in manuscript v0.3 | Yes, in manuscript v0.3 | verified | normalize later |
 | [R14] | GPTCache | No, future integration | No, future integration | verified | needs manuscript integration decision |
 | [R15] | Ollama docs/repository | No, future integration | No, future integration | verified | needs manuscript integration decision |
 | [R16] | NeurIPS reproducibility program report | No, future integration | No, future integration | verified | needs manuscript integration decision |
@@ -178,7 +179,7 @@ It does not add BibTeX, final citation style, manuscript-integrated citations be
 | Local runtime context | [R03], [R09] | Future-work context for local model/runtime systems | Does not support current local runtime validation evidence. |
 | Benchmarking/reproducibility context | [R02] | Benchmark-methodology background | Does not support KORA production benchmark proof. |
 | Artifact evaluation context | [R10] | Artifact-practice and transparency background | Does not indicate formal artifact evaluation approval. |
-| Additional agent/tool-use context | [R11], [R12], [R13] | Future manuscript background on reasoning/action, API/tool-use, and program-aided execution | Does not support KORA outperforming agent or tool-use systems. |
+| Additional agent/tool-use context | [R11], [R12], [R13] | Manuscript v0.3 background on reasoning/action, API/tool-use, and program-aided execution | Does not support KORA outperforming agent or tool-use systems. |
 | Semantic caching context | [R14] | Future manuscript background on cache reuse for LLM applications | Does not support KORA production cost or real API-cost claims. |
 | Additional local runtime context | [R15] | Future manuscript background for local runtime systems | Does not support current KORA Ollama integration evidence. |
 | Additional reproducibility context | [R16] | Future manuscript background on reproducibility programs and checklists | Does not make KORA submission-ready or formally reproducible by venue standards. |
@@ -228,12 +229,27 @@ Categories still missing:
 
 Manuscript integration status:
 
-- References [R11] through [R18] are verified tracker entries only in this pass.
-- They are not yet integrated into manuscript v0.2 text or the manuscript References section.
-- They should be integrated only in a later manuscript pass that preserves claim boundaries and final citation-style decisions.
+- References [R11] through [R18] were verified tracker entries only in this pass.
+- References [R11], [R12], and [R13] were later integrated into manuscript v0.3 text and its preliminary References section.
+- References [R14] through [R18] remain tracker/audit-only, optional, or deferred according to the v0.3 integration plan.
+- This does not complete final citation style, BibTeX, or final bibliography normalization.
+
+## Manuscript v0.3 Integration Status
+
+Manuscript v0.3 integrates selected pass-2 references.
+
+Status:
+
+- [R11] ReAct appears in manuscript v0.3 related work and the preliminary References section.
+- [R12] Toolformer appears in manuscript v0.3 related work and the preliminary References section.
+- [R13] PAL appears in manuscript v0.3 related work and the preliminary References section.
+- [R14] through [R18] remain tracker/audit-only, optional, or deferred.
+- Final citation audit is not complete.
+- BibTeX remains pending.
+- Final citation style remains pending.
 
 ## Next Step
 
-- Task 317B or later: review and merge the additional reference pass if safe.
-- Task 318 or later: select final citation style or perform a narrow manuscript integration pass for [R11] through [R18].
-- Manuscript v0.3 only after bibliography and claim audit are stable.
+- Task 319B or later: review manuscript v0.3 if safe.
+- Later: select final citation style or verify synthetic workload / benchmark-construction references.
+- Manuscript v0.3 still requires final bibliography and claim-audit review before any submission-readiness claim.

--- a/docs/paper/kora-first-paper-manuscript-v0-3.md
+++ b/docs/paper/kora-first-paper-manuscript-v0-3.md
@@ -1,0 +1,237 @@
+# KORA: Deterministic-First Execution Control for AI Workloads
+
+## Abstract
+
+Model-first AI systems often call models too early: every request becomes a prompt even when the work is structured, deterministic, policy-driven, or validation-oriented. KORA introduces deterministic-first execution control, an execution-control layer placed before inference. Requests are represented as structured task paths, deterministic and structured routes are attempted first, validation checks confirm expected outcomes, and model escalation is used only when a request cannot be handled safely without inference. This manuscript v0.3 integrates the first verified reference pass and selected agent/tool-use references from the second verified reference pass. It evaluates KORA through the current public evidence: a reproducible deterministic-heavy benchmark and a synthetic customer-support local/no-network validation workload. In the deterministic-heavy benchmark, KORA-controlled execution avoided 80 of 100 simulated model invocations versus a naive direct baseline, with zero mismatches. The customer-support workload shows that KORA can measure avoided model-call events in synthetic local/no-network validation. These results support model invocation reduction and validation/reporting visibility in documented workloads. They are not production cost proof, real API-cost proof, energy evidence, production validation, or broad workload superiority evidence.
+
+## 1. Introduction
+
+Many AI systems treat every request as a model invocation. A request enters the application, the application builds a prompt, the model produces a response, and downstream logic validates or formats the result. This model-first pattern is easy to adopt, but it makes inference the default execution path even when the requested work does not require open-ended model reasoning.
+
+This default is unnecessary for many deterministic, structured, validation, policy, and routing tasks. Password reset instructions, policy lookups, report formatting, schema validation, routing decisions, and budget checks often have known rules or expected output properties. A model may still be needed for ambiguous, context-heavy, generative, or policy-sensitive cases, but those cases should be explicit escalations rather than the default for the entire workload.
+
+KORA inserts an execution-control layer before inference. Instead of treating the model as the first stop, KORA represents requests as task paths, attempts deterministic or structured handling when appropriate, validates the route outcome, records counters, and escalates only when deterministic handling is insufficient.
+
+Structure first. Inference second.
+
+This paper draft makes four contributions:
+
+- It defines KORA's deterministic-first execution-control model for routing AI work before inference.
+- It distinguishes KORA from related systems that optimize model serving, orchestrate workflows, structure agent execution, retrieve context, or provide local inference runtimes.
+- It reports the current reproducible deterministic-heavy benchmark result: an 80% model invocation reduction with zero mismatches in the documented workload.
+- It summarizes a synthetic customer-support local/no-network validation workload that measures avoided model-call events, deterministic routes, and model escalations without external providers, API keys, private data, or network calls.
+
+## 2. Background and Related Work
+
+KORA is related to model-serving systems, workflow orchestration systems, agent and programmatic AI frameworks, retrieval-augmented generation, local runtime systems, and artifact-evaluation practices. The relationship is complementary: KORA focuses on deciding whether inference is needed for a request before model invocation, while many related systems optimize or organize execution once a model, workflow, or retrieval path is already selected.
+
+### 2.1 LLM Serving and Inference Systems
+
+LLM serving systems optimize the execution of model inference. vLLM and PagedAttention address efficient memory management for large language model serving [R01]. MLPerf Inference provides benchmark framing for inference performance and comparability [R02]. ONNX Runtime provides an official inference runtime and optimization stack [R03].
+
+KORA does not claim to improve serving internals, scheduler design, batching, memory management, kernel performance, or model runtime efficiency. Those systems matter after a model invocation is needed. KORA focuses on the preceding control question: whether a request should reach inference at all.
+
+### 2.2 Workflow and DAG Orchestration
+
+Workflow systems such as Apache Airflow describe computation in DAG-oriented workflows [R07]. Snakemake provides a workflow-engine model for reproducible pipelines [R08]. These systems show the value of explicit execution structure, dependency ordering, and reproducible task paths.
+
+KORA borrows the discipline of explicit execution paths, but its scope is narrower and AI-specific. It applies task-path structure to model-call boundaries, deterministic route validation, model escalation, and aggregate counters. KORA is not a general-purpose workflow scheduler and does not claim to replace workflow or DAG systems.
+
+### 2.3 Agent/Tool Routing and Programmatic AI Workflows
+
+Graph-based and agent-oriented frameworks can coordinate state, tools, and execution graphs. LangGraph documents graph-based agent execution primitives [R04]. DSPy describes declarative language-model pipelines and programmatic composition around model calls [R05].
+
+Agentic and tool-using language model systems provide further context. ReAct combines reasoning traces with actions to let language models interact with external environments and tools [R11]. Toolformer studies how language models can learn to use external tools through a model-centered training procedure [R12]. These systems help frame the broader space of model-mediated reasoning, actions, and tool use.
+
+Program-aided language model workflows provide another adjacent pattern. PAL uses language models to generate programs that are executed by an interpreter, separating some reasoning work into executable program structure [R13]. This is relevant background for programmatic AI workflows, but it is not evidence for KORA's model-call avoidance result.
+
+KORA is adjacent to this space but emphasizes a different default. Agent and programmatic AI systems often organize model-centered workflows, generated programs, or tool-use behavior. KORA's central concern is deterministic-first execution control: using task structure, deterministic handlers, policy checks, and validation boundaries before deciding whether model inference is needed. KORA is complementary to these approaches: rather than teaching a model to reason through actions, use tools, or generate programs, KORA controls the execution path around the model and routes deterministic work before inference when possible. This paper does not claim that KORA replaces or outperforms agent frameworks, tool-use systems, or program-aided language model workflows.
+
+### 2.4 Retrieval-Augmented Generation
+
+Retrieval-augmented generation grounds model outputs by retrieving external knowledge before generation [R06]. RAG is useful when a model still needs to generate or reason with retrieved context.
+
+KORA is not a RAG replacement. RAG improves context selection for model use. KORA decides whether a task needs inference at all. A future system could use both: KORA could route deterministic work without inference and escalate retrieval-grounded questions to a RAG path when model reasoning is required.
+
+### 2.5 Local Model and Runtime Systems
+
+Local runtime systems make it possible to run inference locally. The llama.cpp project provides local LLM inference in C/C++ [R09]. ONNX Runtime is also relevant as an inference runtime [R03].
+
+This paper uses local/no-network validation for current public evidence, but it does not present local model runtime validation as complete. Local runtime references are included as future-work context only. KORA does not currently claim measured local model performance, local runtime superiority, or integration evidence from llama.cpp, ONNX Runtime, Ollama, or other local runtimes.
+
+### 2.6 Benchmarking and Artifact Evaluation
+
+Benchmark and artifact practices matter because KORA's current evidence depends on reproducible commands, synthetic workloads, aggregate counters, and explicit claim boundaries. MLPerf Inference is relevant as benchmark-methodology context [R02]. ACM Artifact Review and Badging provides a public framework for artifact and reproducibility expectations [R10].
+
+KORA has not undergone formal artifact evaluation or external validation. This paper uses those references only to motivate transparent reporting: reproducible commands, clear workload boundaries, local/no-network labels, and explicit non-claims.
+
+## 3. KORA Execution Model
+
+KORA is an execution-control layer between request intake and model invocation. Its current public design uses a small set of concepts:
+
+- task graph: the structured representation of possible work paths
+- deterministic route: a path resolved through known logic, rules, templates, or validation checks
+- structured lookup: a path that maps to a known lookup or backend placeholder
+- policy/validation: checks that confirm the route and output properties are acceptable
+- model escalation: the boundary used when deterministic handling is not sufficient
+- telemetry/reporting: counters and reports that summarize route decisions and validation outcomes
+
+The high-level flow is:
+
+```text
+Request -> Task Graph -> Deterministic/Structured Route -> Validation -> Output
+                         -> Model Escalation -> Validation -> Output
+```
+
+KORA is not a claim that every task can be handled deterministically. It is a control layer for deciding which tasks should be handled deterministically and which tasks should escalate to inference.
+
+The direct baseline path sends every request to the model:
+
+```text
+request -> model -> output
+```
+
+The KORA-controlled path routes through execution control before inference:
+
+```text
+request -> task graph -> deterministic route or model escalation -> validation -> telemetry
+```
+
+An avoided model-call event occurs when the baseline would count a model call for a request, but the KORA-controlled path handles the request through a deterministic or structured route without model escalation.
+
+Current route classes include:
+
+- deterministic route: known logic, templates, rules, or validations handle the request
+- structured lookup: the request maps to a known structured handler or lookup placeholder
+- policy route: explicit policy logic or policy tables handle the request
+- `model_required` route: deterministic handling is not sufficient, so the request escalates
+
+The main metrics are:
+
+- `baseline_model_calls`: model-call events counted by the direct baseline path
+- `kora_model_calls`: model-call events counted by the KORA-controlled path
+- `avoided_model_calls`: `baseline_model_calls - kora_model_calls`
+- `avoided_model_call_rate`: `avoided_model_calls / baseline_model_calls`
+- `deterministic_routes`: requests handled through deterministic routing
+- `model_escalations`: requests escalated to the model-call path
+- `mismatch_count`: benchmark outputs that did not match expected results
+
+These metrics separate two questions: whether KORA reduced model-call events, and whether validation outcomes remained expected for the workload under test.
+
+## 4. Evaluation Methodology
+
+This manuscript v0.3 uses two current public workloads.
+
+The deterministic-heavy benchmark contains 100 tasks. The direct baseline counts one model call for each task. The KORA-controlled path routes deterministic work before inference and records model calls only for the remaining model-candidate routes. This benchmark is appropriate first evidence because it isolates the central hypothesis: deterministic-heavy workloads should not require a model call for every request.
+
+The synthetic customer-support triage workload contains 12 synthetic requests across deterministic FAQ, deterministic policy, structured lookup, and model-required route classes. It is evaluated through local/no-network validation. This means it uses synthetic data, deterministic local validation paths, aggregate counters, and no external providers, API keys, private data, network calls, raw provider responses, or production traffic.
+
+The workloads show different levels of evidence. The deterministic-heavy benchmark supports the current approved benchmark claim. The customer-support workload shows an application-shaped local/no-network validation path and demonstrates how KORA records avoided model-call events, deterministic routes, and model escalations. Neither workload proves production behavior, real provider behavior, real API-cost reduction, energy reduction, or broad workload superiority.
+
+## 5. Results
+
+### 5.1 Deterministic-heavy benchmark
+
+| Metric | Value |
+|---|---:|
+| Total tasks | 100 |
+| Baseline model calls | 100 |
+| KORA-controlled model calls | 20 |
+| Avoided model calls | 80 |
+| Avoided model-call rate | 80% |
+| Mismatches | 0 |
+
+This result supports the current approved public claim:
+
+> KORA reduced model invocations by 80% in a reproducible deterministic-heavy benchmark workload.
+
+The interpretation is intentionally narrow. In this benchmark, KORA-controlled execution avoided 80 of 100 simulated model invocations versus a naive direct baseline while preserving expected benchmark outputs with zero mismatches. This is benchmark evidence for the documented deterministic-heavy workload. It is not production evidence, not real provider validation, and not a cost or energy claim.
+
+### 5.2 Customer-support triage synthetic workload
+
+| Metric | Value |
+|---|---:|
+| Total requests | 12 |
+| Baseline model calls | 12 |
+| KORA-controlled model calls | 4 |
+| Avoided model calls | 8 |
+| Avoided model-call rate | 66.67% |
+| Deterministic routes | 8 |
+| Model escalations | 4 |
+
+This is local/no-network validation only and not real provider validation. The workload uses synthetic customer-support requests to exercise deterministic FAQ, policy, structured lookup, and model-required route classes. The current example shows that KORA can measure avoided model-call events in a synthetic application-shaped workload without API keys, external providers, private data, or network calls.
+
+### 5.3 Latency direction
+
+This manuscript does not include measured latency evidence yet. The expected direction is route-dependent:
+
+- deterministic fast paths can reduce latency by avoiding inference
+- structured lookup and policy routes can avoid model wait time when validation succeeds
+- model escalation paths may add orchestration overhead before inference
+
+Measured p50/p95 latency remains future work. Until those measurements exist, KORA should not be described as universally faster across all workloads.
+
+## 6. Limitations
+
+Current limitations include:
+
+- synthetic workloads
+- limited workload diversity
+- no production traffic
+- no real provider validation
+- no real API-cost proof
+- no production benchmark proof
+- no full runtime-integrated real-provider benchmark evidence
+- no energy measurement
+- no user study
+- no broad workload superiority claim
+- preliminary reference integration only
+- final citation style and BibTeX still pending
+
+The deterministic-heavy benchmark and customer-support triage workload are useful early evidence, but they are not sufficient for production, cost, energy, or broad generalization claims. They show that KORA can reduce model-call events in documented deterministic-heavy and synthetic local/no-network validation contexts.
+
+The related-work references integrated in this draft provide background and positioning. They do not prove KORA's claims, do not establish superiority over cited systems, and do not replace final bibliography review.
+
+## 7. Reproducibility and Artifact Notes
+
+KORA's current public evidence is organized around reproducible commands, local/no-network examples, aggregate counters, and claim-safe reports. This aligns with systems-paper artifact discipline but does not constitute formal artifact evaluation. ACM artifact review and badging guidance is cited only as a reference point for transparent artifact practices [R10].
+
+Current reproduction expectations for this draft are:
+
+- run the deterministic-heavy benchmark in offline mode
+- run the customer-support triage local/no-network validation example
+- inspect aggregate counters and claim-boundary text
+- avoid committing generated raw reports unless explicitly selected for review
+- keep raw provider responses, credentials, private data, and production traffic out of public artifacts
+
+The paper still needs a final clean command transcript, final bibliography normalization, final figure/table review, and a final claim audit before submission.
+
+## 8. Conclusion
+
+Model-first execution is not always necessary. Many AI workloads include structured, deterministic, policy-driven, or validation-oriented tasks that can be routed before inference.
+
+KORA introduces deterministic-first execution control: it represents requests as structured task paths, attempts deterministic handling before inference, validates route outcomes, records counters, and escalates to a model only when needed. Current evidence shows model invocation reduction in a reproducible deterministic-heavy benchmark and measurable avoided model-call events in a synthetic customer-support local/no-network validation workload.
+
+KORA is complementary to model serving systems, workflow orchestrators, agent frameworks, RAG systems, and local runtimes. Future work should expand runtime validation, latency measurement, local model evaluation, real provider experiments, and visualization without weakening claim boundaries.
+
+## References
+
+This preliminary references section uses only verified entries from the first reference pass plus selected verified entries [R11], [R12], and [R13] from the second reference pass. Citation style and BibTeX are not final. See [KORA First Paper Citation Audit v0.1](kora-first-paper-citation-audit-v0-1.md) for citation consistency, traceability, and claim-boundary notes.
+
+- [R01] Woosuk Kwon, Zhuohan Li, Siyuan Zhuang, Ying Sheng, Lianmin Zheng, Cody Hao Yu, Joseph E. Gonzalez, Hao Zhang, and Ion Stoica. "Efficient Memory Management for Large Language Model Serving with PagedAttention." SOSP 2023; arXiv:2309.06180. Source: https://arxiv.org/abs/2309.06180; https://doi.org/10.48550/arXiv.2309.06180
+- [R02] Vijay Janapa Reddi et al. "MLPerf Inference Benchmark." arXiv:1911.02549, 2019; revised 2020. Source: https://arxiv.org/abs/1911.02549
+- [R03] ONNX Runtime project. "ONNX Runtime" official documentation. Source owner: ONNX Runtime project / Microsoft. Date unavailable; accessed 2026-05-11. Source: https://onnxruntime.ai/docs/
+- [R04] LangChain. "LangGraph Graph API overview." Official LangGraph documentation. Date unavailable; accessed 2026-05-11. Source: https://docs.langchain.com/oss/python/langgraph/graph-api
+- [R05] Omar Khattab, Arnav Singhvi, Paridhi Maheshwari, Zhiyuan Zhang, Keshav Santhanam, Sri Vardhamanan, Saiful Haq, Ashutosh Sharma, Thomas T. Joshi, Hanna Moazam, Heather Miller, Matei Zaharia, and Christopher Potts. "DSPy: Compiling Declarative Language Model Calls into Self-Improving Pipelines." arXiv:2310.03714, 2023. Source: https://arxiv.org/abs/2310.03714
+- [R06] Patrick Lewis, Ethan Perez, Aleksandra Piktus, Fabio Petroni, Vladimir Karpukhin, Naman Goyal, Heinrich Kuttler, Mike Lewis, Wen-tau Yih, Tim Rocktaschel, Sebastian Riedel, and Douwe Kiela. "Retrieval-Augmented Generation for Knowledge-Intensive NLP Tasks." NeurIPS 2020; arXiv:2005.11401. Source: https://arxiv.org/abs/2005.11401; https://doi.org/10.48550/arXiv.2005.11401
+- [R07] Apache Airflow project. "Dags." Apache Airflow 3.2.1 documentation. Source owner: Apache Software Foundation. Date unavailable; accessed 2026-05-11. Source: https://airflow.apache.org/docs/apache-airflow/stable/core-concepts/dags.html
+- [R08] Johannes Koster and Sven Rahmann. "Snakemake-a scalable bioinformatics workflow engine." Bioinformatics 28(19), 2520-2522, 2012. Source: https://doi.org/10.1093/bioinformatics/bts480
+- [R09] ggml-org. "llama.cpp: LLM inference in C/C++." Official GitHub repository. Date unavailable; accessed 2026-05-11. Source: https://github.com/ggml-org/llama.cpp
+- [R10] Association for Computing Machinery. "Artifact Review and Badging - Current." Version 1.1, 2020. Source: https://www.acm.org/publications/policies/artifact-review-and-badging-current
+- [R11] Shunyu Yao, Jeffrey Zhao, Dian Yu, Nan Du, Izhak Shafran, Karthik Narasimhan, and Yuan Cao. "ReAct: Synergizing Reasoning and Acting in Language Models." ICLR 2023; arXiv:2210.03629. Source: https://arxiv.org/abs/2210.03629; https://doi.org/10.48550/arXiv.2210.03629
+- [R12] Timo Schick, Jane Dwivedi-Yu, Roberto Dessi, Roberta Raileanu, Maria Lomeli, Luke Zettlemoyer, Nicola Cancedda, and Thomas Scialom. "Toolformer: Language Models Can Teach Themselves to Use Tools." arXiv:2302.04761, 2023. Source: https://arxiv.org/abs/2302.04761; https://doi.org/10.48550/arXiv.2302.04761
+- [R13] Luyu Gao, Aman Madaan, Shuyan Zhou, Uri Alon, Pengfei Liu, Yiming Yang, Jamie Callan, and Graham Neubig. "PAL: Program-aided Language Models." arXiv:2211.10435, 2022; revised 2023. Source: https://arxiv.org/abs/2211.10435; https://doi.org/10.48550/arXiv.2211.10435
+
+## Claim Boundary Note
+
+This manuscript draft is based on reproducible benchmark and local/no-network validation evidence. It does not claim production cost reduction, real API-cost reduction, energy reduction, production validation, broad workload superiority, formal artifact evaluation, or superiority over cited systems.

--- a/docs/paper/kora-first-paper-missing-evidence-checklist.md
+++ b/docs/paper/kora-first-paper-missing-evidence-checklist.md
@@ -71,7 +71,8 @@ Additional reference verification pass 2:
 
 - 8 additional references verified and recorded as `[R11]` through `[R18]`.
 - Agent/tool-use, semantic caching, local-runtime, reproducibility-program, and venue artifact-guidance coverage improved.
-- Manuscript integration for `[R11]` through `[R18]` is planned but not complete.
+- Manuscript integration for `[R11]` through `[R13]` is complete in manuscript v0.3.
+- `[R14]` through `[R18]` remain optional/deferred or tracker/audit-only.
 - Final citation style, final bibliography, and BibTeX still pending.
 
 Additional reference categories still pending:
@@ -79,7 +80,7 @@ Additional reference categories still pending:
 - Synthetic workload and benchmark-construction references.
 - Optional additional semantic caching references if the manuscript discusses caching in more detail.
 - Target-venue-specific citation and artifact guidance after venue selection.
-- Manuscript v0.3 creation after reference integration decisions are accepted.
+- Final citation style and BibTeX.
 
 ## Follow-Up Papers / Technical Reports
 

--- a/docs/paper/kora-first-paper-reference-plan.md
+++ b/docs/paper/kora-first-paper-reference-plan.md
@@ -63,7 +63,17 @@ Completed on 2026-05-11.
 - References `[R11]` through `[R18]` mapped to candidate manuscript sections and integration decisions.
 - Selected references will be integrated later based on the plan.
 - Remaining gaps: synthetic workload / benchmark-construction references and final target-venue citation/artifact guidance.
-- Manuscript v0.3 has not been created.
+- At plan creation time, manuscript v0.3 had not yet been created.
+- BibTeX and final citation style remain pending.
+
+### Manuscript Integration Pass 2
+
+Completed on 2026-05-11.
+
+- Manuscript v0.3 created.
+- References `[R11]`, `[R12]`, and `[R13]` integrated into v0.3 as agent/tool-use and programmatic workflow background.
+- References `[R14]` through `[R18]` remain optional, deferred, or tracker/audit-only according to the v0.3 integration plan.
+- Remaining gaps: synthetic workload / benchmark-construction references and final target-venue citation/artifact guidance.
 - BibTeX and final citation style remain pending.
 
 ## Reference Categories

--- a/docs/paper/kora-first-paper-related-work-map.md
+++ b/docs/paper/kora-first-paper-related-work-map.md
@@ -124,3 +124,9 @@ Summary:
 - Integrate `[R11]`, `[R12]`, and `[R13]` if v0.3 expands agent/tool-use and programmatic workflow related work.
 - Keep `[R14]`, `[R15]`, and `[R16]` optional unless caching, local runtime, or reproducibility sections expand.
 - Defer `[R17]` and `[R18]` until target venue or artifact package planning.
+
+## Manuscript v0.3 Integration Status
+
+Manuscript v0.3 now integrates `[R11]`, `[R12]`, and `[R13]` as related-work background for agent/tool-use and program-aided language-model workflows.
+
+`[R14]` through `[R18]` remain tracker/audit-only, optional, or deferred. They should not be used to support production, API-cost, energy, broad superiority, artifact approval, or submission-readiness claims.

--- a/docs/paper/kora-first-paper-submission-readiness.md
+++ b/docs/paper/kora-first-paper-submission-readiness.md
@@ -2,9 +2,9 @@
 
 ## Current Status
 
-Manuscript v0.2 exists but is not submission-ready.
+Manuscript v0.3 exists but is not submission-ready.
 
-The current paper track has a thesis, manuscript v0.2, claim-boundary docs, reviewer questions, evidence summaries, and local/no-network validation context. It still needs final bibliography normalization, final figures, finalized tables, and a clean reproduction transcript before arXiv or workshop-style release.
+The current paper track has a thesis, manuscript v0.3, claim-boundary docs, reviewer questions, evidence summaries, and local/no-network validation context. It still needs final bibliography normalization, final figures, finalized tables, and a clean reproduction transcript before arXiv or workshop-style release.
 
 The reference scaffold now exists, and the first verified reference pass has collected 10 citation candidates across the major related-work categories. Manuscript v0.2 integrates those verified references as preliminary citation labels. No fake citations or unverified BibTeX entries have been added.
 
@@ -12,13 +12,14 @@ Citation audit v0.1 exists and maps preliminary references to manuscript use, tr
 
 Additional reference verification pass 2 has collected 8 more verified references for remaining bibliography gaps. These references are recorded in the tracker and audit, but manuscript integration is deferred.
 
-Manuscript v0.3 reference integration planning now exists for [R11] through [R18]. Manuscript v0.3 has not been created.
+Manuscript v0.3 reference integration planning exists for [R11] through [R18]. Manuscript v0.3 has been created with [R11], [R12], and [R13] integrated. [R14] through [R18] remain optional, deferred, or tracker/audit-only according to the integration plan.
 
 ## Ready
 
 - Thesis.
 - Initial manuscript skeleton.
 - Manuscript v0.2 with first verified reference integration.
+- Manuscript v0.3 with selected [R11] through [R13] integration.
 - Deterministic-heavy benchmark evidence.
 - Customer-support local/no-network validation evidence.
 - Claim boundary docs.
@@ -34,7 +35,7 @@ Manuscript v0.3 reference integration planning now exists for [R11] through [R18
 ## Needed Before arXiv / Workshop Submission
 
 - More references collected and verified.
-- Manuscript v0.3 created if the selected reference integration plan is accepted.
+- Synthetic workload / benchmark-construction references collected if the evaluation-methodology section is expanded.
 - Final citation style selected.
 - Final bibliography entries normalized.
 - Final citation audit review completed.
@@ -64,6 +65,6 @@ These are suggested formats only. This document does not claim acceptance, endor
 
 ## Reference Status
 
-The first verified reference pass is complete, manuscript v0.2 integrates the first-pass verified references as preliminary citation labels and a preliminary references section, citation audit v0.1 exists, additional reference verification pass 2 has added 8 verified tracker entries, and a manuscript v0.3 reference integration plan exists. The paper is still not submission-ready because manuscript v0.3 has not been created, the new references are not yet integrated into the manuscript, the final bibliography style is not selected, final normalized bibliography entries are pending, and BibTeX has not been added.
+The first verified reference pass is complete, manuscript v0.2 integrates the first-pass verified references as preliminary citation labels and a preliminary references section, citation audit v0.1 exists, additional reference verification pass 2 has added 8 verified tracker entries, and manuscript v0.3 integrates [R11], [R12], and [R13] as preliminary related-work references. The paper is still not submission-ready because [R14] through [R18] remain optional/deferred or tracker/audit-only, synthetic workload / benchmark-construction references remain pending, the final bibliography style is not selected, final normalized bibliography entries are pending, and BibTeX has not been added.
 
 No fake citations were added. Future citation work should use only verified tracker entries and should not support production, API-cost, energy, production-validation, broad superiority, or cited-system superiority claims.


### PR DESCRIPTION
## Summary

- created manuscript v0.3 without overwriting manuscript v0.2
- integrated [R11], [R12], and [R13] into related work with complementary framing
- kept [R14] through [R18] optional/deferred or tracker/audit-only
- updated bibliography, citation audit, reference plan, missing-evidence, related-work, and submission-readiness docs

## Boundaries

- no BibTeX added
- final citation style remains pending
- paper remains not submission-ready
- no fake citations
- no new claims
- no KORA Studio or source code changes

## Validation

- git diff --check
- python3 -m pytest
- python3 -m kora --help
- python3 -m kora examples list
- python3 -m kora run runtime_integrated_benchmark -- --offline
- python3 -m kora run customer_support_triage_fake_validation -- --offline
- python3 -m kora run direct_vs_kora -- --offline

## Remaining gaps

- final citation style
- BibTeX
- final bibliography normalization
- synthetic workload / benchmark-construction references
- final target-venue guidance
