### PR TITLE
Add KORA paper citation style decision

### DIFF
--- a/docs/paper/kora-first-paper-bibliography-notes.md
+++ b/docs/paper/kora-first-paper-bibliography-notes.md
@@ -134,7 +134,15 @@ Decide whether selected `[R19]` through `[R24]` references should be integrated 
 
 ## Citation Style
 
-Citation style is TBD and should be selected after the target venue or report format is chosen.
+The working citation style has been selected in [KORA First Paper Citation Style Decision](kora-first-paper-citation-style-decision.md).
+
+Status:
+
+- Stable `[Rxx]` labels remain the working manuscript citation strategy.
+- Metadata audit for `[R01]` through `[R24]` is the next bibliography task.
+- BibTeX remains pending until the metadata audit is complete.
+- Final bibliography normalization remains pending.
+- Venue-specific conversion remains possible after a target venue or report format is chosen.
 
 ## Claim Boundary
 

--- a/docs/paper/kora-first-paper-citation-audit-v0-1.md
+++ b/docs/paper/kora-first-paper-citation-audit-v0-1.md
@@ -17,6 +17,8 @@ This audit covers:
 
 It does not add BibTeX, final citation style, manuscript-integrated citations beyond the current manuscript, or new evidence claims.
 
+The working citation style strategy is recorded in [KORA First Paper Citation Style Decision](kora-first-paper-citation-style-decision.md). Stable `[Rxx]` labels remain the working style until metadata audit, bibliography normalization, and any later venue-specific conversion are complete.
+
 ## Citation Inventory
 
 | ID | Reference topic | Appears in manuscript | Appears in References section | Tracker status | Action |
@@ -331,5 +333,5 @@ Manuscript integration status:
 ## Next Step
 
 - Decide whether selected `[R19]` through `[R24]` references should be integrated into a future benchmark-methodology section.
-- Select final citation style before final bibliography normalization and BibTeX preparation.
+- Run metadata audit for `[R01]` through `[R24]` before final bibliography normalization and BibTeX preparation.
 - Manuscript v0.3 still requires final bibliography and claim-audit review before any submission-readiness claim.

--- a/docs/paper/kora-first-paper-citation-style-decision.md
+++ b/docs/paper/kora-first-paper-citation-style-decision.md
@@ -1,0 +1,97 @@
+# KORA First Paper Citation Style Decision
+
+## Purpose
+
+This document records the working citation style strategy before final bibliography normalization and BibTeX preparation for the KORA first paper.
+
+It is a planning and traceability document. It does not generate BibTeX, finalize venue-specific formatting, or make the paper submission-ready.
+
+## Current State
+
+- Manuscript v0.3 is the current latest draft.
+- References `[R01]` through `[R13]` are integrated into manuscript v0.3.
+- References `[R14]` through `[R18]` are tracker/audit-only, optional, or deferred.
+- References `[R19]` through `[R24]` are tracker/audit-only methodology/background references.
+- BibTeX remains pending.
+- Final bibliography normalization remains pending.
+- Metadata audit remains pending.
+- The paper remains not submission-ready.
+
+## Style Decision
+
+Use numbered references with stable bracketed IDs in manuscript text, for example `[R01]`, `[R02]`, and `[R13]`.
+
+Working strategy:
+
+- Keep stable `[Rxx]` labels in manuscript text and paper planning docs.
+- Normalize bibliography records in the reference tracker before generating BibTeX.
+- Generate BibTeX only after the metadata audit is complete.
+- Convert to a venue-specific citation style later if a target venue or report format requires it.
+
+Rationale:
+
+- The current manuscript and citation audit already use `[Rxx]` IDs.
+- Stable labels preserve traceability while references are still being audited.
+- Tracker-first normalization reduces the risk of fake or inferred BibTeX.
+- The strategy supports later conversion to ACM, IEEE, arXiv/report, or venue-specific formats without renumbering during active review.
+
+## Citation Label Rules
+
+- Keep `[Rxx]` labels stable once assigned.
+- Do not renumber references casually.
+- New verified references should append new IDs.
+- Manuscript references must map to tracker entries.
+- Tracker entries must record status and source URL or DOI.
+- Tracker-only references should not appear in the manuscript References section unless cited in text.
+- If a reference is rejected or superseded, keep its history clear in the tracker rather than reusing the ID for a different source.
+
+## Bibliography Normalization Rules
+
+For each tracker record, normalize:
+
+- title
+- authors or source organization
+- year or date
+- source URL or DOI
+- source type
+- verification status
+- intended paper use
+- claim boundary notes
+
+Normalization rules:
+
+- Mark missing metadata explicitly.
+- Do not invent missing metadata.
+- Prefer official source pages, DOI records, arXiv pages, ACL Anthology pages, ACM pages, USENIX pages, MLSys pages, or official documentation.
+- Distinguish peer-reviewed papers from official docs, policy pages, and repositories.
+- Keep official docs and repositories as organization-owned references when an individual author list is not appropriate.
+- Preserve access-date needs for official docs and repositories until final style is chosen.
+
+## BibTeX Rules
+
+- Do not add BibTeX until the metadata audit is complete.
+- Do not add fake BibTeX.
+- Do not infer venues.
+- Do not infer authors.
+- Do not infer years.
+- Do not infer DOI values.
+- BibTeX can be generated in a later task only from normalized tracker records.
+- Generated BibTeX must remain traceable to verified source URLs or DOI records.
+
+## Claim-Safety Rules
+
+- References do not prove KORA is superior.
+- Benchmark references do not prove production benchmark evidence.
+- References do not prove production cost reduction.
+- References do not prove real API-cost reduction.
+- References do not prove energy reduction.
+- References do not prove formal artifact approval.
+- KORA's 80/100 result remains supported by KORA deterministic-heavy benchmark evidence only.
+- External references may support background, related work, methodology, reproducibility framing, or future-work context only when their scope has been verified.
+
+## Next Steps
+
+1. Run a metadata audit for `[R01]` through `[R24]`.
+2. Update the normalized bibliography table from audited tracker records.
+3. Prepare BibTeX only after metadata audit is complete.
+4. Create manuscript v0.4 only after bibliography and claim audit are stable.

--- a/docs/paper/kora-first-paper-missing-evidence-checklist.md
+++ b/docs/paper/kora-first-paper-missing-evidence-checklist.md
@@ -90,6 +90,14 @@ Benchmark-construction verification pass:
 - They do not provide production benchmark evidence for KORA.
 - Final citation style, final bibliography normalization, and BibTeX remain pending.
 
+Citation style decision:
+
+- Working citation style selected: stable `[Rxx]` labels.
+- Metadata audit for `[R01]` through `[R24]` is still pending.
+- Normalized bibliography table is still pending.
+- BibTeX is still pending.
+- Paper is still not submission-ready.
+
 ## Follow-Up Papers / Technical Reports
 
 - OpenAI/Claude API cost reduction technical report.

--- a/docs/paper/kora-first-paper-reference-plan.md
+++ b/docs/paper/kora-first-paper-reference-plan.md
@@ -87,6 +87,16 @@ Completed on 2026-05-11.
 - Remaining gaps: deterministic-heavy synthetic workload construction references specific to model-call routing systems, final target-venue guidance, final citation style, and bibliography normalization.
 - Bibliography status: BibTeX not added in this pass; final citation style and bibliography normalization remain pending.
 
+### Citation Style Decision
+
+Completed on 2026-05-11.
+
+- Citation style decision document created.
+- Stable `[Rxx]` label strategy selected for the working manuscript and paper planning docs.
+- Tracker-first bibliography normalization selected before BibTeX generation.
+- Next step: metadata audit and normalized bibliography table for `[R01]` through `[R24]`.
+- BibTeX remains pending until metadata audit is complete.
+
 ## Reference Categories
 
 ### 1. LLM serving and inference systems

--- a/docs/paper/kora-first-paper-submission-readiness.md
+++ b/docs/paper/kora-first-paper-submission-readiness.md
@@ -16,6 +16,8 @@ Manuscript v0.3 reference integration planning exists for [R11] through [R18]. M
 
 The benchmark-construction reference verification pass has added 6 verified tracker/audit entries as [R19] through [R24]. These entries cover benchmark-suite construction, holistic and multi-metric evaluation, software-engineering task benchmarks, agent benchmarks, dynamic benchmarking, and behavior-oriented test design. They are not integrated into manuscript v0.3 and do not provide production benchmark evidence for KORA.
 
+The citation style decision exists. The working strategy keeps stable [Rxx] labels, requires metadata audit before normalized bibliography work, and defers BibTeX until metadata fields are verified.
+
 ## Ready
 
 - Thesis.
@@ -32,6 +34,7 @@ The benchmark-construction reference verification pass has added 6 verified trac
 - First verified reference pass.
 - Additional reference verification pass 2.
 - Benchmark-construction reference verification pass.
+- Citation style decision.
 - Citation audit v0.1.
 - Manuscript v0.3 reference integration plan.
 
@@ -40,8 +43,9 @@ The benchmark-construction reference verification pass has added 6 verified trac
 - More references collected and verified.
 - Decide whether selected benchmark-construction references should be integrated if the evaluation-methodology section is expanded.
 - More direct deterministic-heavy synthetic workload construction references if needed.
-- Final citation style selected.
+- Metadata audit for [R01] through [R24].
 - Final bibliography entries normalized.
+- BibTeX preparation after metadata audit.
 - Final citation audit review completed.
 - Figure drafts created.
 - Tables finalized.
@@ -69,6 +73,6 @@ These are suggested formats only. This document does not claim acceptance, endor
 
 ## Reference Status
 
-The first verified reference pass is complete, manuscript v0.2 integrates the first-pass verified references as preliminary citation labels and a preliminary references section, citation audit v0.1 exists, additional reference verification pass 2 has added 8 verified tracker entries, manuscript v0.3 integrates [R11], [R12], and [R13] as preliminary related-work references, and the benchmark-construction reference pass has added [R19] through [R24] as tracker/audit entries. The paper is still not submission-ready because [R14] through [R18] remain optional/deferred or tracker/audit-only, [R19] through [R24] are not yet integrated into manuscript methodology, more direct deterministic-heavy synthetic workload references may still be needed, production benchmark evidence is still not available, the final bibliography style is not selected, final normalized bibliography entries are pending, and BibTeX has not been added.
+The first verified reference pass is complete, manuscript v0.2 integrates the first-pass verified references as preliminary citation labels and a preliminary references section, citation audit v0.1 exists, additional reference verification pass 2 has added 8 verified tracker entries, manuscript v0.3 integrates [R11], [R12], and [R13] as preliminary related-work references, the benchmark-construction reference pass has added [R19] through [R24] as tracker/audit entries, and the working citation style decision selects stable [Rxx] labels. The paper is still not submission-ready because [R14] through [R18] remain optional/deferred or tracker/audit-only, [R19] through [R24] are not yet integrated into manuscript methodology, more direct deterministic-heavy synthetic workload references may still be needed, production benchmark evidence is still not available, metadata audit is pending, final normalized bibliography entries are pending, and BibTeX has not been added.
 
 No fake citations were added. Future citation work should use only verified tracker entries and should not support production, API-cost, energy, production-validation, broad superiority, or cited-system superiority claims.


### PR DESCRIPTION
## Summary
- Created the KORA first paper citation style decision document.
- Selected stable [Rxx] labels as the working manuscript citation strategy.
- Documented tracker-first bibliography normalization before BibTeX generation.
- Updated bibliography, reference-plan, citation-audit, missing-evidence, and submission-readiness docs.

## Boundaries
- No BibTeX added.
- No fake citations added.
- No new reference metadata added or invented.
- No new claims added.
- Paper remains not submission-ready.

## Next Bibliography Steps
- Run metadata audit for [R01] through [R24].
- Update normalized bibliography records from audited tracker entries.
- Prepare BibTeX only after metadata audit is complete and fields are verified.
- Consider manuscript v0.4 only after bibliography and claim audit are stable.

## Validation
- git diff --check
- git diff --cached --check
- python3 -m pytest
- python3 -m kora --help
- python3 -m kora examples list
- python3 -m kora run runtime_integrated_benchmark -- --offline
- python3 -m kora run customer_support_triage_fake_validation -- --offline
- python3 -m kora run direct_vs_kora -- --offline