### PR TITLE
Add KORA paper reference metadata audit

### DIFF
--- a/docs/paper/kora-first-paper-bibliography-notes.md
+++ b/docs/paper/kora-first-paper-bibliography-notes.md
@@ -144,6 +144,20 @@ Status:
 - Final bibliography normalization remains pending.
 - Venue-specific conversion remains possible after a target venue or report format is chosen.
 
+## Metadata Audit v0.1
+
+[KORA First Paper Reference Metadata Audit v0.1](kora-first-paper-reference-metadata-audit-v0-1.md) has been created.
+
+Status:
+
+- References `[R01]` through `[R24]` were reviewed for metadata completeness and traceability.
+- The audit separates paper references, official docs/repos, official artifact guidance, and benchmark-methodology references.
+- The audit identifies high-risk metadata items before BibTeX, including official docs/repos, artifact guidance pages, author-list handling, and venue/status normalization.
+- No BibTeX was added.
+- No manuscript changes were made.
+- Normalized bibliography table work is the next bibliography step.
+- The paper remains not submission-ready.
+
 ## Claim Boundary
 
 No citation should be used to support unsupported production, API-cost, or energy claims.

--- a/docs/paper/kora-first-paper-citation-audit-v0-1.md
+++ b/docs/paper/kora-first-paper-citation-audit-v0-1.md
@@ -19,6 +19,8 @@ It does not add BibTeX, final citation style, manuscript-integrated citations be
 
 The working citation style strategy is recorded in [KORA First Paper Citation Style Decision](kora-first-paper-citation-style-decision.md). Stable `[Rxx]` labels remain the working style until metadata audit, bibliography normalization, and any later venue-specific conversion are complete.
 
+Reference metadata readiness is recorded in [KORA First Paper Reference Metadata Audit v0.1](kora-first-paper-reference-metadata-audit-v0-1.md). That audit does not generate BibTeX and does not change manuscript claim support.
+
 ## Citation Inventory
 
 | ID | Reference topic | Appears in manuscript | Appears in References section | Tracker status | Action |
@@ -333,5 +335,5 @@ Manuscript integration status:
 ## Next Step
 
 - Decide whether selected `[R19]` through `[R24]` references should be integrated into a future benchmark-methodology section.
-- Run metadata audit for `[R01]` through `[R24]` before final bibliography normalization and BibTeX preparation.
+- Use metadata audit v0.1 to prepare a normalized bibliography table for `[R01]` through `[R24]`.
 - Manuscript v0.3 still requires final bibliography and claim-audit review before any submission-readiness claim.

--- a/docs/paper/kora-first-paper-missing-evidence-checklist.md
+++ b/docs/paper/kora-first-paper-missing-evidence-checklist.md
@@ -93,9 +93,10 @@ Benchmark-construction verification pass:
 Citation style decision:
 
 - Working citation style selected: stable `[Rxx]` labels.
-- Metadata audit for `[R01]` through `[R24]` is still pending.
+- Metadata audit v0.1 for `[R01]` through `[R24]` has been created.
 - Normalized bibliography table is still pending.
 - BibTeX is still pending.
+- Final claim/citation audit is still pending.
 - Paper is still not submission-ready.
 
 ## Follow-Up Papers / Technical Reports

--- a/docs/paper/kora-first-paper-reference-metadata-audit-v0-1.md
+++ b/docs/paper/kora-first-paper-reference-metadata-audit-v0-1.md
@@ -1,0 +1,116 @@
+# KORA First Paper Reference Metadata Audit v0.1
+
+## Purpose
+
+This audit checks metadata completeness and traceability for `[R01]` through `[R24]` before bibliography normalization and BibTeX preparation.
+
+It is a metadata-readiness pass. It does not generate BibTeX, does not change manuscript text, and does not make the paper submission-ready.
+
+## Scope
+
+This audit covers:
+
+- references `[R01]` through `[R24]`
+- the current reference tracker
+- the citation style decision
+- citation audit v0.1
+- metadata completeness before normalized bibliography work
+- traceability from each stable `[Rxx]` label to a source URL or DOI
+
+This pass does not generate BibTeX. This pass does not modify manuscript v0.3.
+
+## Audit Rules
+
+- Do not invent metadata.
+- Do not infer missing authors, venues, years, dates, DOIs, or URLs.
+- Use official source pages, DOI pages, arXiv pages, ACL Anthology, ACM, USENIX, MLSys, official documentation, or official repositories.
+- Distinguish paper references from official docs, official repositories, policy pages, and venue guidance pages.
+- Mark metadata status explicitly before normalization.
+- Keep `[Rxx]` labels stable.
+- Treat official docs and repositories as organization-owned references when an individual author list is not appropriate.
+- Preserve access-date needs for official docs, repositories, and living policy or venue pages until final style conversion.
+
+## Metadata Completeness Table
+
+| ID | Topic | Source type | Title status | Author/org status | Year/date status | URL/DOI status | Venue/status | Metadata status | Action |
+|---|---|---|---|---|---|---|---|---|---|
+| `[R01]` | vLLM / PagedAttention | paper / arXiv / DOI | title recorded | full author list recorded | year and venue recorded | arXiv URL and DOI recorded | SOSP 2023 recorded from tracker | complete enough for normalized bibliography | normalize next |
+| `[R02]` | MLPerf Inference | paper / arXiv | title recorded | author lead with `et al.` in tracker | year and revision note recorded | arXiv URL recorded | arXiv status recorded; venue normalization still needed | needs metadata normalization | review before BibTeX |
+| `[R03]` | ONNX Runtime docs | official docs | title recorded | organization owner recorded | date unavailable; access date recorded | official docs URL recorded | documentation reference | official docs/repo reference | keep as official docs reference |
+| `[R04]` | LangGraph Graph API docs | official docs | title recorded | organization owner recorded | date unavailable; access date recorded | official docs URL recorded | documentation reference | official docs/repo reference | keep as official docs reference |
+| `[R05]` | DSPy | paper / arXiv | title recorded | full author list recorded | year recorded | arXiv URL recorded | arXiv status recorded; venue normalization still needed | needs metadata normalization | review before BibTeX |
+| `[R06]` | Retrieval-Augmented Generation | paper / arXiv / DOI | title recorded | full author list recorded | year and venue recorded | arXiv URL and DOI recorded | NeurIPS 2020 recorded | complete enough for normalized bibliography | normalize next |
+| `[R07]` | Apache Airflow DAG docs | official docs | title recorded | organization owner recorded | docs version and access date recorded | official docs URL recorded | documentation reference | official docs/repo reference | keep as official docs reference |
+| `[R08]` | Snakemake | paper / DOI | title recorded | full author list recorded | year recorded | DOI recorded | journal metadata recorded | complete enough for normalized bibliography | normalize next |
+| `[R09]` | llama.cpp | official repo | title recorded | organization owner recorded | date unavailable; access date recorded | official repo URL recorded | repository reference | official docs/repo reference | keep as official docs reference |
+| `[R10]` | ACM Artifact Review and Badging | official policy | title recorded | organization owner recorded | version/year recorded | official policy URL recorded | policy page | official artifact/evaluation guidance | review before BibTeX |
+| `[R11]` | ReAct | paper / arXiv / DOI | title recorded | full author list recorded | year and venue recorded | arXiv URL and DOI recorded | ICLR 2023 recorded | complete enough for normalized bibliography | normalize next |
+| `[R12]` | Toolformer | paper / arXiv / DOI | title recorded | full author list recorded | year recorded | arXiv URL and DOI recorded | arXiv status recorded; venue normalization still needed | needs metadata normalization | review before BibTeX |
+| `[R13]` | PAL | paper / arXiv / DOI | title recorded | full author list recorded | year and revision note recorded | arXiv URL and DOI recorded | arXiv status recorded; venue normalization still needed | needs metadata normalization | review before BibTeX |
+| `[R14]` | GPTCache | paper / ACL Anthology / DOI | title recorded | author recorded | year, venue, and pages recorded | ACL Anthology URL and DOI recorded | NLP-OSS 2023 recorded | complete enough for normalized bibliography | normalize next |
+| `[R15]` | Ollama docs and repo | official docs / official repo | title recorded | organization owner recorded | date unavailable; access date recorded | docs URL and repo URL recorded | documentation and repository reference | official docs/repo reference | keep as official docs reference |
+| `[R16]` | NeurIPS reproducibility report | paper / arXiv / DOI | title recorded | full author list recorded | year recorded | arXiv URL and DOI recorded | report status recorded; venue normalization still needed | needs metadata normalization | review before BibTeX |
+| `[R17]` | USENIX NSDI artifact guidance | official venue guidance | title recorded | organization owner recorded | conference year range recorded | official USENIX URL recorded | venue guidance page | official artifact/evaluation guidance | defer until venue style selected |
+| `[R18]` | MLSys artifact evaluation guidance | official venue guidance | title recorded | organization owner recorded | conference year recorded | official MLSys URL recorded | venue guidance page | official artifact/evaluation guidance | defer until venue style selected |
+| `[R19]` | BIG-bench | benchmark suite paper / arXiv / DOI | title recorded | author lead with `et al.` in tracker | year and journal reference recorded | arXiv URL and DOI recorded | TMLR recorded | needs metadata normalization | review before BibTeX |
+| `[R20]` | HELM | benchmark suite paper / arXiv / DOI | title recorded | author lead with `et al.` in tracker | year and journal reference recorded | arXiv URL and DOI recorded | TMLR recorded | needs metadata normalization | review before BibTeX |
+| `[R21]` | SWE-bench | benchmark paper / arXiv / DOI | title recorded | full author list recorded | year and venue recorded | arXiv URL and DOI recorded | ICLR 2024 recorded | complete enough for normalized bibliography | normalize next |
+| `[R22]` | AgentBench | benchmark paper / arXiv / DOI | title recorded | author lead with `et al.` in tracker | year and venue recorded | arXiv URL and DOI recorded | ICLR 2024 recorded | needs metadata normalization | review before BibTeX |
+| `[R23]` | Dynabench | benchmark paper / arXiv / DOI | title recorded | author lead with `et al.` in tracker | year and venue recorded | arXiv URL and DOI recorded | NAACL 2021 recorded | needs metadata normalization | review before BibTeX |
+| `[R24]` | CheckList | benchmark/test-design paper / ACL Anthology / DOI | title recorded | full author list recorded | year, venue, and pages recorded | ACL Anthology URL and DOI recorded | ACL 2020 recorded | complete enough for normalized bibliography | normalize next |
+
+## Source-Type Summary
+
+Counts by source type in this audit:
+
+- peer-reviewed or preprint paper: 16
+- official docs: 4
+- official repo: 2
+- official artifact/evaluation guidance or policy: 3
+- benchmark suite paper/report: 6
+- other: 0
+
+Some references belong to more than one practical category. For example, `[R19]` through `[R24]` are counted as benchmark suite paper/report references and also as paper references where applicable. The summary is intended for bibliography planning, not a mutually exclusive taxonomy.
+
+## High-Risk Metadata Items
+
+References requiring extra caution before BibTeX:
+
+- `[R03]`, `[R04]`, `[R07]`, `[R09]`, and `[R15]`: official docs or repositories need organization-owner handling and access-date formatting.
+- `[R10]`, `[R17]`, and `[R18]`: artifact policy or venue guidance pages need careful treatment as guidance pages, not formal artifact approval.
+- `[R02]`, `[R05]`, `[R12]`, `[R13]`, `[R16]`, `[R19]`, `[R20]`, `[R22]`, and `[R23]`: tracker entries need final author-list or venue/status normalization before BibTeX.
+- `[R17]` and `[R18]`: venue-specific guidance should remain deferred until target venue strategy is selected.
+- `[R14]`: the source title includes cost-related wording; citation use must not imply KORA production cost or real API-cost evidence.
+- `[R19]` through `[R24]`: benchmark references are methodology/background only and must not be used as KORA production benchmark evidence.
+
+## BibTeX Readiness
+
+| ID range | BibTeX readiness | Reason |
+|---|---|---|
+| `[R01]`, `[R06]`, `[R08]`, `[R11]`, `[R14]`, `[R21]`, `[R24]` | likely ready after normalized bibliography pass | Core title, author, year/date, source URL/DOI, and venue/source details are already present in the tracker. Final formatting still needs normalization. |
+| `[R02]`, `[R05]`, `[R12]`, `[R13]`, `[R16]`, `[R19]`, `[R20]`, `[R22]`, `[R23]` | needs extra review before BibTeX | These entries need author-list handling, venue/status normalization, or source-page cross-checking before BibTeX fields are generated. |
+| `[R03]`, `[R04]`, `[R07]`, `[R09]`, `[R15]` | official docs/repo BibTeX requires style decision | Organization owner, access date, and documentation/repository entry type need final style treatment. |
+| `[R10]`, `[R17]`, `[R18]` | defer until venue style selected | Policy and venue-guidance pages need careful type, owner, date, and access-date formatting. |
+
+BibTeX is not generated in this task. BibTeX should be generated later only from normalized and verified fields.
+
+## Claim-Safety Note
+
+This metadata audit does not change claim support.
+
+- External references remain background, related-work, methodology, reproducibility, artifact-practice, or future-work support only.
+- KORA's 80/100 result remains supported by KORA deterministic-heavy benchmark docs and evidence.
+- These references do not support production cost reduction proof.
+- These references do not support real API-cost reduction proof.
+- These references do not support energy reduction evidence.
+- These references do not support production benchmark proof.
+- These references do not support broad workload superiority.
+- Artifact guidance references do not imply formal artifact approval.
+
+## Next Step
+
+Next steps:
+
+1. Update a normalized bibliography table for `[R01]` through `[R24]`.
+2. Generate BibTeX only after normalized fields are verified.
+3. Keep the paper not submission-ready until bibliography normalization, BibTeX, and final claim audit are stable.

--- a/docs/paper/kora-first-paper-reference-plan.md
+++ b/docs/paper/kora-first-paper-reference-plan.md
@@ -97,6 +97,17 @@ Completed on 2026-05-11.
 - Next step: metadata audit and normalized bibliography table for `[R01]` through `[R24]`.
 - BibTeX remains pending until metadata audit is complete.
 
+### Metadata Audit v0.1
+
+Completed on 2026-05-11.
+
+- Metadata audit v0.1 created for `[R01]` through `[R24]`.
+- The audit checks title, author or organization owner, year/date, URL/DOI, source type, and venue/status readiness.
+- No new references were added.
+- No BibTeX was generated.
+- No manuscript changes were made.
+- Next step: normalized bibliography table for `[R01]` through `[R24]`.
+
 ## Reference Categories
 
 ### 1. LLM serving and inference systems

--- a/docs/paper/kora-first-paper-reference-tracker.md
+++ b/docs/paper/kora-first-paper-reference-tracker.md
@@ -26,3 +26,15 @@
 | R22 | Benchmarking and reproducibility | Xiao Liu et al. "AgentBench: Evaluating LLMs as Agents." ICLR 2024; arXiv:2308.03688. | https://arxiv.org/abs/2308.03688; https://doi.org/10.48550/arXiv.2308.03688 | verified | Future evaluation methodology / agent benchmark context | Verified from arXiv title, author lead, submission/revision dates, ICLR 2024 publication note, and DOI. Useful as agent-benchmark background only. Do not use to claim KORA outperforms agent systems. |
 | R23 | Benchmarking and reproducibility | Douwe Kiela et al. "Dynabench: Rethinking Benchmarking in NLP." NAACL 2021; arXiv:2104.14337. | https://arxiv.org/abs/2104.14337; https://doi.org/10.48550/arXiv.2104.14337 | verified | Future evaluation methodology / dynamic benchmark context | Verified from arXiv title, author lead, submission date, NAACL 2021 comment, and DOI. Useful for benchmark design and dynamic evaluation context. Do not use as KORA production evidence. |
 | R24 | Benchmarking and reproducibility | Marco Tulio Ribeiro, Tongshuang Wu, Carlos Guestrin, and Sameer Singh. "Beyond Accuracy: Behavioral Testing of NLP Models with CheckList." Proceedings of the 58th Annual Meeting of the Association for Computational Linguistics, pages 4902-4912, 2020. | https://aclanthology.org/2020.acl-main.442/; https://doi.org/10.18653/v1/2020.acl-main.442 | verified | Future evaluation methodology / behavioral test design context | Verified from ACL Anthology title, authors, venue, pages, year, URL, and DOI. Useful for behavior-oriented evaluation design. Do not use to imply KORA has completed broad behavioral testing. |
+
+## Metadata Audit Status
+
+[KORA First Paper Reference Metadata Audit v0.1](kora-first-paper-reference-metadata-audit-v0-1.md) audits `[R01]` through `[R24]` for metadata completeness and source traceability before normalized bibliography work.
+
+Status:
+
+- Stable `[Rxx]` labels remain unchanged.
+- No new references were added in the metadata audit.
+- No BibTeX was generated.
+- Next step: create a normalized bibliography table for `[R01]` through `[R24]` from verified tracker and audit fields.
+- BibTeX remains pending until normalized fields are verified.

--- a/docs/paper/kora-first-paper-submission-readiness.md
+++ b/docs/paper/kora-first-paper-submission-readiness.md
@@ -18,6 +18,8 @@ The benchmark-construction reference verification pass has added 6 verified trac
 
 The citation style decision exists. The working strategy keeps stable [Rxx] labels, requires metadata audit before normalized bibliography work, and defers BibTeX until metadata fields are verified.
 
+Metadata audit v0.1 exists for [R01] through [R24]. It checks metadata completeness and source traceability before normalized bibliography work. Normalized bibliography entries and BibTeX are still pending.
+
 ## Ready
 
 - Thesis.
@@ -35,6 +37,7 @@ The citation style decision exists. The working strategy keeps stable [Rxx] labe
 - Additional reference verification pass 2.
 - Benchmark-construction reference verification pass.
 - Citation style decision.
+- Metadata audit v0.1.
 - Citation audit v0.1.
 - Manuscript v0.3 reference integration plan.
 
@@ -43,7 +46,7 @@ The citation style decision exists. The working strategy keeps stable [Rxx] labe
 - More references collected and verified.
 - Decide whether selected benchmark-construction references should be integrated if the evaluation-methodology section is expanded.
 - More direct deterministic-heavy synthetic workload construction references if needed.
-- Metadata audit for [R01] through [R24].
+- Normalized bibliography table for [R01] through [R24].
 - Final bibliography entries normalized.
 - BibTeX preparation after metadata audit.
 - Final citation audit review completed.
@@ -73,6 +76,6 @@ These are suggested formats only. This document does not claim acceptance, endor
 
 ## Reference Status
 
-The first verified reference pass is complete, manuscript v0.2 integrates the first-pass verified references as preliminary citation labels and a preliminary references section, citation audit v0.1 exists, additional reference verification pass 2 has added 8 verified tracker entries, manuscript v0.3 integrates [R11], [R12], and [R13] as preliminary related-work references, the benchmark-construction reference pass has added [R19] through [R24] as tracker/audit entries, and the working citation style decision selects stable [Rxx] labels. The paper is still not submission-ready because [R14] through [R18] remain optional/deferred or tracker/audit-only, [R19] through [R24] are not yet integrated into manuscript methodology, more direct deterministic-heavy synthetic workload references may still be needed, production benchmark evidence is still not available, metadata audit is pending, final normalized bibliography entries are pending, and BibTeX has not been added.
+The first verified reference pass is complete, manuscript v0.2 integrates the first-pass verified references as preliminary citation labels and a preliminary references section, citation audit v0.1 exists, additional reference verification pass 2 has added 8 verified tracker entries, manuscript v0.3 integrates [R11], [R12], and [R13] as preliminary related-work references, the benchmark-construction reference pass has added [R19] through [R24] as tracker/audit entries, the working citation style decision selects stable [Rxx] labels, and metadata audit v0.1 exists. The paper is still not submission-ready because [R14] through [R18] remain optional/deferred or tracker/audit-only, [R19] through [R24] are not yet integrated into manuscript methodology, more direct deterministic-heavy synthetic workload references may still be needed, production benchmark evidence is still not available, final normalized bibliography entries are pending, and BibTeX has not been added.
 
 No fake citations were added. Future citation work should use only verified tracker entries and should not support production, API-cost, energy, production-validation, broad superiority, or cited-system superiority claims.


### PR DESCRIPTION
## Summary
- Adds metadata audit v0.1 for KORA first paper references [R01] through [R24].
- Audits metadata completeness and traceability before normalized bibliography and BibTeX work.
- Updates tracker, citation audit, bibliography notes, reference plan, missing evidence checklist, and submission readiness docs.

## Scope
- No BibTeX added.
- No manuscript changes.
- No new references added.
- No fake citations or invented metadata.
- No new claims.

## Metadata audit notes
- Flags official docs/repos for organization-owner and access-date treatment.
- Flags artifact guidance pages for venue-style handling.
- Flags author-list and venue/status normalization needs before BibTeX.
- Keeps KORA 80/100 support mapped to KORA deterministic-heavy benchmark evidence.

## Validation
- git diff --check
- python3 -m pytest
- python3 -m kora --help
- python3 -m kora examples list
- python3 -m kora run runtime_integrated_benchmark -- --offline
- python3 -m kora run customer_support_triage_fake_validation -- --offline
- python3 -m kora run direct_vs_kora -- --offline
- public/private and reference-quality scans completed; matches were allowed claim-boundary, bibliography-pending, DOI/URL, or existing citation metadata contexts.

## Remaining gaps
- Normalized bibliography table for [R01] through [R24].
- BibTeX only after normalized fields are verified.
- Final claim/citation audit before any submission-readiness claim.