### PR TITLE
Add KORA paper preliminary BibTeX ready subset

### DIFF
--- a/docs/paper/kora-first-paper-bibliography-notes.md
+++ b/docs/paper/kora-first-paper-bibliography-notes.md
@@ -187,6 +187,18 @@ Status:
 - The next bibliography step is preliminary BibTeX preparation only for ready records, or a final metadata check for blocked records.
 - The paper remains not submission-ready.
 
+## Preliminary BibTeX v0.1
+
+[KORA First Paper Preliminary BibTeX v0.1](kora-first-paper-preliminary-bibtex-v0-1.md) has been created.
+
+Status:
+
+- Preliminary BibTeX exists only for the ready subset: `[R01]`, `[R06]`, `[R08]`, `[R11]`, `[R14]`, `[R21]`, `[R24]`.
+- Blocked records remain excluded: `[R02]`, `[R03]`, `[R04]`, `[R05]`, `[R07]`, `[R09]`, `[R10]`, `[R12]`, `[R13]`, `[R15]`, `[R16]`, `[R17]`, `[R18]`, `[R19]`, `[R20]`, `[R22]`, `[R23]`.
+- No manuscript changes were made.
+- Final BibTeX key normalization and venue-specific field style remain pending.
+- The paper remains not submission-ready.
+
 ## Claim Boundary
 
 No citation should be used to support unsupported production, API-cost, or energy claims.

--- a/docs/paper/kora-first-paper-citation-style-decision.md
+++ b/docs/paper/kora-first-paper-citation-style-decision.md
@@ -16,7 +16,8 @@ It is a planning and traceability document. It does not generate BibTeX, finaliz
 - Metadata audit v0.1 exists.
 - Normalized bibliography v0.1 exists.
 - Metadata gap resolution v0.1 exists at the planning/classification level.
-- Some metadata/style blockers remain before BibTeX.
+- Preliminary BibTeX v0.1 exists for ready records only.
+- Some metadata/style blockers remain before full BibTeX.
 - The paper remains not submission-ready.
 
 ## Style Decision
@@ -79,6 +80,9 @@ Normalization rules:
 - Do not infer DOI values.
 - BibTeX can be generated in a later task only from normalized tracker records.
 - Generated BibTeX must remain traceable to verified source URLs or DOI records.
+- Preliminary BibTeX v0.1 covers only `[R01]`, `[R06]`, `[R08]`, `[R11]`, `[R14]`, `[R21]`, and `[R24]`.
+- Stable `[Rxx]` labels remain canonical during audit.
+- Final venue-specific conversion remains deferred.
 
 ## Claim-Safety Rules
 
@@ -93,7 +97,7 @@ Normalization rules:
 
 ## Next Steps
 
-1. Prepare preliminary BibTeX only for records classified as ready after a final normalized-record check.
+1. Normalize preliminary BibTeX keys and fields for ready records after final style decisions.
 2. Defer blocked records until author-list, venue/status, docs/repo style, or venue-guidance style gaps are resolved.
 3. Run final bibliography and claim audit.
 4. Create manuscript v0.4 only after bibliography and claim audit are stable.

--- a/docs/paper/kora-first-paper-missing-evidence-checklist.md
+++ b/docs/paper/kora-first-paper-missing-evidence-checklist.md
@@ -96,7 +96,9 @@ Citation style decision:
 - Metadata audit v0.1 for `[R01]` through `[R24]` has been created.
 - Normalized bibliography table v0.1 has been created.
 - High-risk metadata gap resolution v0.1 has been created at the planning/classification level.
-- BibTeX is still pending.
+- Preliminary BibTeX v0.1 exists only for ready records `[R01]`, `[R06]`, `[R08]`, `[R11]`, `[R14]`, `[R21]`, `[R24]`.
+- Full BibTeX remains incomplete because blocked records are still excluded.
+- Blocked metadata/style records remain unresolved.
 - Final claim/citation audit is still pending.
 - Paper is still not submission-ready.
 

--- a/docs/paper/kora-first-paper-preliminary-bibtex-v0-1.md
+++ b/docs/paper/kora-first-paper-preliminary-bibtex-v0-1.md
@@ -1,0 +1,140 @@
+# KORA First Paper Preliminary BibTeX v0.1
+
+## Purpose
+
+This document contains preliminary BibTeX only for reference records that passed the ready-record check after metadata audit v0.1, normalized bibliography v0.1, and metadata gap resolution v0.1.
+
+It is a bibliography-preparation document. It does not modify manuscript v0.3, does not include blocked records, and does not make the paper submission-ready.
+
+## Scope
+
+Included ready subset:
+
+- `[R01]`
+- `[R06]`
+- `[R08]`
+- `[R11]`
+- `[R14]`
+- `[R21]`
+- `[R24]`
+
+Blocked records are excluded. Manuscript v0.3 is unchanged. The paper remains not submission-ready.
+
+## Rules
+
+- Do not generate BibTeX for blocked records.
+- Do not invent metadata.
+- Do not infer venues, authors, years, DOI values, or source URLs.
+- Treat these entries as preliminary and recheck them before submission.
+- Keep stable `[Rxx]` labels as canonical while the audit is active.
+- Defer venue-specific style conversion until the target venue or report format is chosen.
+
+## Ready-Record Check
+
+| ID | Topic | Ready for preliminary BibTeX | Reason | Notes |
+|---|---|---|---|---|
+| `[R01]` | vLLM / PagedAttention | yes | Title, full author list, year, arXiv URL, DOI, and SOSP 2023 status are present in normalized records. | Related-work context only; does not support KORA superiority over serving systems. |
+| `[R06]` | Retrieval-Augmented Generation | yes | Title, full author list, year, arXiv URL, DOI, and NeurIPS 2020 status are present in normalized records. | RAG contrast only; does not imply KORA replaces retrieval-grounded generation. |
+| `[R08]` | Snakemake | yes | Title, author list, year, journal/volume/pages, and DOI are present in normalized records. | Reproducible workflow background only. |
+| `[R11]` | ReAct | yes | Title, full author list, year, arXiv URL, DOI, and ICLR 2023 status are present in normalized records. | Agent/tool-use context only; no KORA outperformance claim. |
+| `[R14]` | GPTCache | yes | Title, author, year, ACL Anthology URL, DOI, workshop venue, publisher, and pages are present in normalized records. | Title includes cost-related wording; do not use as KORA production cost or real API-cost evidence. |
+| `[R21]` | SWE-bench | yes | Title, full author list, year, arXiv URL, DOI, and ICLR 2024 status are present in normalized records. | Benchmark-construction example only; no KORA comparison against SWE-bench. |
+| `[R24]` | CheckList | yes | Title, full author list, year, ACL Anthology URL, DOI, venue, and pages are present in normalized records. | Behavior-oriented evaluation design context only; does not imply broad KORA behavioral testing. |
+
+No ready-subset record was moved back to blocked in this pass.
+
+## Preliminary BibTeX Entries
+
+```bibtex
+@inproceedings{kwon2023pagedattention,
+  author = {Kwon, Woosuk and Li, Zhuohan and Zhuang, Siyuan and Sheng, Ying and Zheng, Lianmin and Yu, Cody Hao and Gonzalez, Joseph E. and Zhang, Hao and Stoica, Ion},
+  title = {Efficient Memory Management for Large Language Model Serving with PagedAttention},
+  booktitle = {SOSP 2023},
+  year = {2023},
+  doi = {10.48550/arXiv.2309.06180},
+  url = {https://arxiv.org/abs/2309.06180}
+}
+
+@inproceedings{lewis2020rag,
+  author = {Lewis, Patrick and Perez, Ethan and Piktus, Aleksandra and Petroni, Fabio and Karpukhin, Vladimir and Goyal, Naman and Kuttler, Heinrich and Lewis, Mike and Yih, Wen-tau and Rocktaschel, Tim and Riedel, Sebastian and Kiela, Douwe},
+  title = {Retrieval-Augmented Generation for Knowledge-Intensive NLP Tasks},
+  booktitle = {NeurIPS 2020},
+  year = {2020},
+  doi = {10.48550/arXiv.2005.11401},
+  url = {https://arxiv.org/abs/2005.11401}
+}
+
+@article{koster2012snakemake,
+  author = {Koster, Johannes and Rahmann, Sven},
+  title = {Snakemake-a scalable bioinformatics workflow engine},
+  journal = {Bioinformatics},
+  volume = {28},
+  number = {19},
+  pages = {2520--2522},
+  year = {2012},
+  doi = {10.1093/bioinformatics/bts480},
+  url = {https://doi.org/10.1093/bioinformatics/bts480}
+}
+
+@inproceedings{yao2023react,
+  author = {Yao, Shunyu and Zhao, Jeffrey and Yu, Dian and Du, Nan and Shafran, Izhak and Narasimhan, Karthik and Cao, Yuan},
+  title = {ReAct: Synergizing Reasoning and Acting in Language Models},
+  booktitle = {ICLR 2023},
+  year = {2023},
+  doi = {10.48550/arXiv.2210.03629},
+  url = {https://arxiv.org/abs/2210.03629}
+}
+
+@inproceedings{bang2023gptcache,
+  author = {Bang, Fu},
+  title = {GPTCache: An Open-Source Semantic Cache for LLM Applications Enabling Faster Answers and Cost Savings},
+  booktitle = {Proceedings of the 3rd Workshop for Natural Language Processing Open Source Software},
+  pages = {212--218},
+  publisher = {Association for Computational Linguistics},
+  year = {2023},
+  doi = {10.18653/v1/2023.nlposs-1.24},
+  url = {https://aclanthology.org/2023.nlposs-1.24/}
+}
+
+@inproceedings{jimenez2024swebench,
+  author = {Jimenez, Carlos E. and Yang, John and Wettig, Alexander and Yao, Shunyu and Pei, Kexin and Press, Ofir and Narasimhan, Karthik},
+  title = {SWE-bench: Can Language Models Resolve Real-World GitHub Issues?},
+  booktitle = {ICLR 2024},
+  year = {2024},
+  doi = {10.48550/arXiv.2310.06770},
+  url = {https://arxiv.org/abs/2310.06770}
+}
+
+@inproceedings{ribeiro2020checklist,
+  author = {Ribeiro, Marco Tulio and Wu, Tongshuang and Guestrin, Carlos and Singh, Sameer},
+  title = {Beyond Accuracy: Behavioral Testing of NLP Models with CheckList},
+  booktitle = {Proceedings of the 58th Annual Meeting of the Association for Computational Linguistics},
+  pages = {4902--4912},
+  year = {2020},
+  doi = {10.18653/v1/2020.acl-main.442},
+  url = {https://aclanthology.org/2020.acl-main.442/}
+}
+```
+
+## Excluded Records
+
+Blocked records excluded from BibTeX:
+
+- `[R02]`, `[R05]`, `[R12]`, `[R13]`, `[R16]`, `[R19]`, `[R20]`, `[R22]`, `[R23]`: blocked due to author-list handling, venue/status normalization, or both.
+- `[R03]`, `[R04]`, `[R07]`, `[R09]`, `[R15]`: blocked due to official docs/repo style and access-date decisions.
+- `[R10]`, `[R17]`, `[R18]`: blocked due to artifact, policy, or venue-guidance style decisions.
+
+These records should not receive BibTeX until their metadata/style blockers are resolved.
+
+## Claim-Safety Note
+
+Preliminary BibTeX does not change claim support.
+
+External references remain related-work, methodology, reproducibility, benchmark-construction, or background support only. KORA's 80/100 result remains supported by KORA deterministic-heavy benchmark docs and evidence. These references do not support production cost reduction proof, real API-cost reduction proof, energy reduction evidence, production benchmark proof, broad workload superiority, or formal artifact approval.
+
+## Next Step
+
+1. Normalize BibTeX keys and field style after the target venue or report format is chosen.
+2. Resolve blocked-record metadata and style gaps.
+3. Run final bibliography and claim audit.
+4. Create manuscript v0.4 only after bibliography and claim audit are stable.

--- a/docs/paper/kora-first-paper-reference-plan.md
+++ b/docs/paper/kora-first-paper-reference-plan.md
@@ -306,6 +306,17 @@ Partially verified. See [KORA first paper reference tracker](kora-first-paper-re
 | R24 | Benchmarking and reproducibility | CheckList | Paper / ACL Anthology | Behavior-oriented evaluation and test-design context | Verified in benchmark-construction pass | Do not imply KORA has completed broad behavioral testing. |
 | R25 | Benchmarking and reproducibility | Deterministic-heavy synthetic workload construction reference | Paper or technical report | More direct context for local/no-network synthetic workload design | Pending | Keep claim language narrow. |
 
+## Preliminary BibTeX Status
+
+[KORA First Paper Preliminary BibTeX v0.1](kora-first-paper-preliminary-bibtex-v0-1.md) has been created for the ready subset only.
+
+Status:
+
+- Included ready records: `[R01]`, `[R06]`, `[R08]`, `[R11]`, `[R14]`, `[R21]`, `[R24]`.
+- Excluded blocked records: `[R02]`, `[R03]`, `[R04]`, `[R05]`, `[R07]`, `[R09]`, `[R10]`, `[R12]`, `[R13]`, `[R15]`, `[R16]`, `[R17]`, `[R18]`, `[R19]`, `[R20]`, `[R22]`, `[R23]`.
+- No manuscript changes were made.
+- Next step: final BibTeX key normalization for included records and metadata/style resolution for blocked records.
+
 ## Next Verification Procedure
 
 1. Search official sources first.

--- a/docs/paper/kora-first-paper-submission-readiness.md
+++ b/docs/paper/kora-first-paper-submission-readiness.md
@@ -24,6 +24,8 @@ Normalized bibliography v0.1 exists for [R01] through [R24]. High-risk metadata 
 
 Metadata gap resolution v0.1 exists. It classifies high-risk metadata blockers before BibTeX preparation. BibTeX and final bibliography review are still pending.
 
+Preliminary BibTeX v0.1 exists for the ready subset only: [R01], [R06], [R08], [R11], [R14], [R21], and [R24]. Full BibTeX and final bibliography review are still pending because blocked records remain excluded.
+
 ## Ready
 
 - Thesis.
@@ -44,6 +46,7 @@ Metadata gap resolution v0.1 exists. It classifies high-risk metadata blockers b
 - Metadata audit v0.1.
 - Normalized bibliography v0.1.
 - Metadata gap resolution v0.1.
+- Preliminary BibTeX v0.1 for ready records only.
 - Citation audit v0.1.
 - Manuscript v0.3 reference integration plan.
 
@@ -52,10 +55,10 @@ Metadata gap resolution v0.1 exists. It classifies high-risk metadata blockers b
 - More references collected and verified.
 - Decide whether selected benchmark-construction references should be integrated if the evaluation-methodology section is expanded.
 - More direct deterministic-heavy synthetic workload construction references if needed.
-- Preliminary BibTeX preparation for ready records only, after final metadata check.
+- Final BibTeX key normalization for ready records.
 - Remaining metadata/style gap resolution for blocked records.
 - Final bibliography entries normalized.
-- BibTeX preparation after metadata audit.
+- Full BibTeX completion after blocked records are resolved.
 - Final citation audit review completed.
 - Figure drafts created.
 - Tables finalized.
@@ -83,6 +86,6 @@ These are suggested formats only. This document does not claim acceptance, endor
 
 ## Reference Status
 
-The first verified reference pass is complete, manuscript v0.2 integrates the first-pass verified references as preliminary citation labels and a preliminary references section, citation audit v0.1 exists, additional reference verification pass 2 has added 8 verified tracker entries, manuscript v0.3 integrates [R11], [R12], and [R13] as preliminary related-work references, the benchmark-construction reference pass has added [R19] through [R24] as tracker/audit entries, the working citation style decision selects stable [Rxx] labels, metadata audit v0.1 exists, normalized bibliography v0.1 exists, and metadata gap resolution v0.1 exists. The paper is still not submission-ready because [R14] through [R18] remain optional/deferred or tracker/audit-only, [R19] through [R24] are not yet integrated into manuscript methodology, more direct deterministic-heavy synthetic workload references may still be needed, production benchmark evidence is still not available, some metadata/style blockers remain before BibTeX, and BibTeX has not been added.
+The first verified reference pass is complete, manuscript v0.2 integrates the first-pass verified references as preliminary citation labels and a preliminary references section, citation audit v0.1 exists, additional reference verification pass 2 has added 8 verified tracker entries, manuscript v0.3 integrates [R11], [R12], and [R13] as preliminary related-work references, the benchmark-construction reference pass has added [R19] through [R24] as tracker/audit entries, the working citation style decision selects stable [Rxx] labels, metadata audit v0.1 exists, normalized bibliography v0.1 exists, metadata gap resolution v0.1 exists, and preliminary BibTeX v0.1 exists for ready records only. The paper is still not submission-ready because [R14] through [R18] remain optional/deferred or tracker/audit-only, [R19] through [R24] are not yet integrated into manuscript methodology, more direct deterministic-heavy synthetic workload references may still be needed, production benchmark evidence is still not available, blocked records remain excluded from BibTeX, and final bibliography and claim audit are not complete.
 
 No fake citations were added. Future citation work should use only verified tracker entries and should not support production, API-cost, energy, production-validation, broad superiority, or cited-system superiority claims.


### PR DESCRIPTION
## Summary
- Adds preliminary BibTeX v0.1 for the ready subset only: [R01], [R06], [R08], [R11], [R14], [R21], [R24].
- Excludes blocked records: [R02], [R03], [R04], [R05], [R07], [R09], [R10], [R12], [R13], [R15], [R16], [R17], [R18], [R19], [R20], [R22], [R23].
- Updates bibliography/readiness planning docs to reflect preliminary BibTeX status.

## Boundaries
- No manuscript changes.
- No BibTeX for blocked records.
- No fake citations or invented metadata.
- No new claims.
- Paper remains not submission-ready.

## Validation
- git diff --check
- python3 -m pytest
- python3 -m kora --help
- python3 -m kora examples list
- python3 -m kora run runtime_integrated_benchmark -- --offline
- python3 -m kora run customer_support_triage_fake_validation -- --offline
- python3 -m kora run direct_vs_kora -- --offline

## Remaining gaps
- Final BibTeX key normalization.
- Metadata/style resolution for blocked records.
- Final bibliography / claim audit.
- Manuscript v0.4 only after bibliography and claim audit are stable.