### PR TITLE
Normalize KORA paper preliminary BibTeX keys

### DIFF
--- a/docs/paper/kora-first-paper-bibliography-notes.md
+++ b/docs/paper/kora-first-paper-bibliography-notes.md
@@ -199,6 +199,18 @@ Status:
 - Final BibTeX key normalization and venue-specific field style remain pending.
 - The paper remains not submission-ready.
 
+## Ready-Subset BibTeX Key Normalization
+
+BibTeX key normalization is complete for the ready subset in [KORA First Paper Preliminary BibTeX v0.1](kora-first-paper-preliminary-bibtex-v0-1.md).
+
+Status:
+
+- Normalized ready-subset keys cover only `[R01]`, `[R06]`, `[R08]`, `[R11]`, `[R14]`, `[R21]`, and `[R24]`.
+- Existing author/year/topic keys were kept because their author, year, and topic metadata are verified in the public bibliography records.
+- Blocked records remain excluded from BibTeX.
+- Next step: resolve blocked metadata/style records or run a final BibTeX audit before any manuscript update.
+- The paper remains not submission-ready.
+
 ## Claim Boundary
 
 No citation should be used to support unsupported production, API-cost, or energy claims.

--- a/docs/paper/kora-first-paper-citation-style-decision.md
+++ b/docs/paper/kora-first-paper-citation-style-decision.md
@@ -81,6 +81,7 @@ Normalization rules:
 - BibTeX can be generated in a later task only from normalized tracker records.
 - Generated BibTeX must remain traceable to verified source URLs or DOI records.
 - Preliminary BibTeX v0.1 covers only `[R01]`, `[R06]`, `[R08]`, `[R11]`, `[R14]`, `[R21]`, and `[R24]`.
+- Ready-subset BibTeX keys are normalized using verified author/year/topic metadata.
 - Stable `[Rxx]` labels remain canonical during audit.
 - Final venue-specific conversion remains deferred.
 

--- a/docs/paper/kora-first-paper-missing-evidence-checklist.md
+++ b/docs/paper/kora-first-paper-missing-evidence-checklist.md
@@ -97,6 +97,7 @@ Citation style decision:
 - Normalized bibliography table v0.1 has been created.
 - High-risk metadata gap resolution v0.1 has been created at the planning/classification level.
 - Preliminary BibTeX v0.1 exists only for ready records `[R01]`, `[R06]`, `[R08]`, `[R11]`, `[R14]`, `[R21]`, `[R24]`.
+- Preliminary BibTeX key normalization is complete for the ready subset.
 - Full BibTeX remains incomplete because blocked records are still excluded.
 - Blocked metadata/style records remain unresolved.
 - Final claim/citation audit is still pending.

--- a/docs/paper/kora-first-paper-preliminary-bibtex-v0-1.md
+++ b/docs/paper/kora-first-paper-preliminary-bibtex-v0-1.md
@@ -43,6 +43,20 @@ Blocked records are excluded. Manuscript v0.3 is unchanged. The paper remains no
 
 No ready-subset record was moved back to blocked in this pass.
 
+## BibTeX Key Normalization
+
+| ID | Topic | Previous key | Normalized key | Key status | Reason |
+|---|---|---|---|---|---|
+| `[R01]` | vLLM / PagedAttention | `kwon2023pagedattention` | `kwon2023pagedattention` | normalized | First author, year, and topic are verified in the normalized bibliography and tracker; key is readable and collision-resistant enough for the current ready subset. |
+| `[R06]` | Retrieval-Augmented Generation | `lewis2020rag` | `lewis2020rag` | normalized | First author, year, and RAG topic are verified; key is concise and stable. |
+| `[R08]` | Snakemake | `koster2012snakemake` | `koster2012snakemake` | normalized | First author, year, and topic are verified from DOI-backed metadata; key is clear and stable. |
+| `[R11]` | ReAct | `yao2023react` | `yao2023react` | normalized | First author, year, and topic are verified from the recorded arXiv/DOI metadata; key is clear and stable. |
+| `[R14]` | GPTCache | `bang2023gptcache` | `bang2023gptcache` | normalized | Sole author, year, and topic are verified from ACL Anthology metadata; key is clear and stable. |
+| `[R21]` | SWE-bench | `jimenez2024swebench` | `jimenez2024swebench` | normalized | First author, year, and benchmark topic are verified; key avoids punctuation while preserving the SWE-bench topic. |
+| `[R24]` | CheckList | `ribeiro2020checklist` | `ribeiro2020checklist` | normalized | First author, year, and CheckList topic are verified from ACL Anthology metadata; key is clear and stable. |
+
+All ready-subset keys already followed the selected author/year/topic pattern and were kept unchanged. Final venue key review may still adjust capitalization, punctuation, or venue-specific style, but no blocked record receives a BibTeX key in this pass.
+
 ## Preliminary BibTeX Entries
 
 ```bibtex

--- a/docs/paper/kora-first-paper-reference-plan.md
+++ b/docs/paper/kora-first-paper-reference-plan.md
@@ -315,7 +315,8 @@ Status:
 - Included ready records: `[R01]`, `[R06]`, `[R08]`, `[R11]`, `[R14]`, `[R21]`, `[R24]`.
 - Excluded blocked records: `[R02]`, `[R03]`, `[R04]`, `[R05]`, `[R07]`, `[R09]`, `[R10]`, `[R12]`, `[R13]`, `[R15]`, `[R16]`, `[R17]`, `[R18]`, `[R19]`, `[R20]`, `[R22]`, `[R23]`.
 - No manuscript changes were made.
-- Next step: final BibTeX key normalization for included records and metadata/style resolution for blocked records.
+- Ready-subset BibTeX key normalization is complete for the included records.
+- Next step: metadata/style resolution for blocked records or final BibTeX audit.
 
 ## Next Verification Procedure
 

--- a/docs/paper/kora-first-paper-submission-readiness.md
+++ b/docs/paper/kora-first-paper-submission-readiness.md
@@ -26,6 +26,8 @@ Metadata gap resolution v0.1 exists. It classifies high-risk metadata blockers b
 
 Preliminary BibTeX v0.1 exists for the ready subset only: [R01], [R06], [R08], [R11], [R14], [R21], and [R24]. Full BibTeX and final bibliography review are still pending because blocked records remain excluded.
 
+Ready-subset BibTeX key normalization is complete. Full BibTeX and blocked metadata/style resolution are still pending, and the paper remains not submission-ready.
+
 ## Ready
 
 - Thesis.
@@ -47,6 +49,7 @@ Preliminary BibTeX v0.1 exists for the ready subset only: [R01], [R06], [R08], [
 - Normalized bibliography v0.1.
 - Metadata gap resolution v0.1.
 - Preliminary BibTeX v0.1 for ready records only.
+- Ready-subset BibTeX key normalization.
 - Citation audit v0.1.
 - Manuscript v0.3 reference integration plan.
 
@@ -55,7 +58,6 @@ Preliminary BibTeX v0.1 exists for the ready subset only: [R01], [R06], [R08], [
 - More references collected and verified.
 - Decide whether selected benchmark-construction references should be integrated if the evaluation-methodology section is expanded.
 - More direct deterministic-heavy synthetic workload construction references if needed.
-- Final BibTeX key normalization for ready records.
 - Remaining metadata/style gap resolution for blocked records.
 - Final bibliography entries normalized.
 - Full BibTeX completion after blocked records are resolved.
@@ -86,6 +88,6 @@ These are suggested formats only. This document does not claim acceptance, endor
 
 ## Reference Status
 
-The first verified reference pass is complete, manuscript v0.2 integrates the first-pass verified references as preliminary citation labels and a preliminary references section, citation audit v0.1 exists, additional reference verification pass 2 has added 8 verified tracker entries, manuscript v0.3 integrates [R11], [R12], and [R13] as preliminary related-work references, the benchmark-construction reference pass has added [R19] through [R24] as tracker/audit entries, the working citation style decision selects stable [Rxx] labels, metadata audit v0.1 exists, normalized bibliography v0.1 exists, metadata gap resolution v0.1 exists, and preliminary BibTeX v0.1 exists for ready records only. The paper is still not submission-ready because [R14] through [R18] remain optional/deferred or tracker/audit-only, [R19] through [R24] are not yet integrated into manuscript methodology, more direct deterministic-heavy synthetic workload references may still be needed, production benchmark evidence is still not available, blocked records remain excluded from BibTeX, and final bibliography and claim audit are not complete.
+The first verified reference pass is complete, manuscript v0.2 integrates the first-pass verified references as preliminary citation labels and a preliminary references section, citation audit v0.1 exists, additional reference verification pass 2 has added 8 verified tracker entries, manuscript v0.3 integrates [R11], [R12], and [R13] as preliminary related-work references, the benchmark-construction reference pass has added [R19] through [R24] as tracker/audit entries, the working citation style decision selects stable [Rxx] labels, metadata audit v0.1 exists, normalized bibliography v0.1 exists, metadata gap resolution v0.1 exists, preliminary BibTeX v0.1 exists for ready records only, and ready-subset BibTeX keys are normalized. The paper is still not submission-ready because [R14] through [R18] remain optional/deferred or tracker/audit-only, [R19] through [R24] are not yet integrated into manuscript methodology, more direct deterministic-heavy synthetic workload references may still be needed, production benchmark evidence is still not available, blocked records remain excluded from BibTeX, and final bibliography and claim audit are not complete.
 
 No fake citations were added. Future citation work should use only verified tracker entries and should not support production, API-cost, energy, production-validation, broad superiority, or cited-system superiority claims.


### PR DESCRIPTION
## Summary
- Normalizes and documents preliminary BibTeX keys for the ready subset only: [R01], [R06], [R08], [R11], [R14], [R21], [R24].
- Keeps existing verified author/year/topic keys because they already follow the selected stable convention.
- Documents key status in the preliminary BibTeX notes and updates bibliography/readiness planning docs.

## Scope and Boundaries
- No manuscript changes.
- No new BibTeX for blocked records.
- Blocked records remain excluded: [R02], [R03], [R04], [R05], [R07], [R09], [R10], [R12], [R13], [R15], [R16], [R17], [R18], [R19], [R20], [R22], [R23].
- No fake metadata and no new claims.

## Validation
- git diff --check
- python3 -m pytest
- python3 -m kora --help
- python3 -m kora examples list
- python3 -m kora run runtime_integrated_benchmark -- --offline
- python3 -m kora run customer_support_triage_fake_validation -- --offline
- python3 -m kora run direct_vs_kora -- --offline
- Public/private and secret scan
- BibTeX safety scan
- Reference and claim quality scan

## Remaining Gaps
- Blocked metadata/style records still need resolution before full BibTeX is complete.
- Final bibliography and claim audit remain pending.
- Paper remains not submission-ready.