### PR TITLE
Add KORA paper final BibTeX audit for ready subset

### DIFF
--- a/docs/paper/kora-first-paper-bibliography-notes.md
+++ b/docs/paper/kora-first-paper-bibliography-notes.md
@@ -211,6 +211,17 @@ Status:
 - Next step: resolve blocked metadata/style records or run a final BibTeX audit before any manuscript update.
 - The paper remains not submission-ready.
 
+## Final Ready-Subset BibTeX Audit
+
+[KORA First Paper Final BibTeX Audit — Ready Subset v0.1](kora-first-paper-final-bibtex-audit-ready-subset-v0-1.md) has been created.
+
+Status:
+
+- Ready-subset BibTeX remains preliminary.
+- Blocked records remain unresolved and excluded from BibTeX.
+- Next step: resolve metadata/style gaps for blocked records.
+- The paper remains not submission-ready.
+
 ## Claim Boundary
 
 No citation should be used to support unsupported production, API-cost, or energy claims.

--- a/docs/paper/kora-first-paper-citation-style-decision.md
+++ b/docs/paper/kora-first-paper-citation-style-decision.md
@@ -82,6 +82,7 @@ Normalization rules:
 - Generated BibTeX must remain traceable to verified source URLs or DOI records.
 - Preliminary BibTeX v0.1 covers only `[R01]`, `[R06]`, `[R08]`, `[R11]`, `[R14]`, `[R21]`, and `[R24]`.
 - Ready-subset BibTeX keys are normalized using verified author/year/topic metadata.
+- Final ready-subset BibTeX audit v0.1 checks only the ready records and does not add blocked-record BibTeX.
 - Stable `[Rxx]` labels remain canonical during audit.
 - Final venue-specific conversion remains deferred.
 

--- a/docs/paper/kora-first-paper-final-bibtex-audit-ready-subset-v0-1.md
+++ b/docs/paper/kora-first-paper-final-bibtex-audit-ready-subset-v0-1.md
@@ -1,0 +1,72 @@
+# KORA First Paper Final BibTeX Audit — Ready Subset v0.1
+
+## Purpose
+
+This audit checks the preliminary BibTeX entries and normalized keys for the ready subset before any broader bibliography work.
+
+It is a bibliography-quality and traceability audit. It does not add blocked-record BibTeX, does not modify manuscript v0.3, and does not make the paper submission-ready.
+
+## Scope
+
+This audit covers ready records only:
+
+- `[R01]`
+- `[R06]`
+- `[R08]`
+- `[R11]`
+- `[R14]`
+- `[R21]`
+- `[R24]`
+
+Blocked records remain excluded. No manuscript changes are made in this pass. This audit does not claim that the paper is submission-ready.
+
+## Audit Rules
+
+- Do not add BibTeX for blocked records.
+- Do not invent metadata.
+- Do not add fake DOI values.
+- Do not add fake venue fields.
+- Do not infer missing fields.
+- Preserve stable `[Rxx]` traceability.
+- Keep BibTeX preliminary until final bibliography and claim audit are complete.
+
+## Ready-Subset BibTeX Audit Table
+
+| ID | Key | Entry type | Required fields present | Risk status | Action |
+|---|---|---|---|---|---|
+| `[R01]` | `kwon2023pagedattention` | `@inproceedings` | author, title, booktitle, year, DOI, URL | needs final venue check | keep preliminary; normalize later if venue requires |
+| `[R06]` | `lewis2020rag` | `@inproceedings` | author, title, booktitle, year, DOI, URL | needs final venue check | keep preliminary; normalize later if venue requires |
+| `[R08]` | `koster2012snakemake` | `@article` | author, title, journal, volume, number, pages, year, DOI, URL | low risk | keep preliminary; review before final submission |
+| `[R11]` | `yao2023react` | `@inproceedings` | author, title, booktitle, year, DOI, URL | needs final venue check | keep preliminary; normalize later if venue requires |
+| `[R14]` | `bang2023gptcache` | `@inproceedings` | author, title, booktitle, pages, publisher, year, DOI, URL | preliminary only | keep preliminary; review before final submission |
+| `[R21]` | `jimenez2024swebench` | `@inproceedings` | author, title, booktitle, year, DOI, URL | needs final venue check | keep preliminary; normalize later if venue requires |
+| `[R24]` | `ribeiro2020checklist` | `@inproceedings` | author, title, booktitle, pages, year, DOI, URL | needs final venue check | keep preliminary; review before final submission |
+
+## Blocked Record Exclusion Check
+
+Blocked records:
+
+`[R02]`, `[R03]`, `[R04]`, `[R05]`, `[R07]`, `[R09]`, `[R10]`, `[R12]`, `[R13]`, `[R15]`, `[R16]`, `[R17]`, `[R18]`, `[R19]`, `[R20]`, `[R22]`, `[R23]`
+
+No BibTeX entries should exist for these records in preliminary BibTeX v0.1. These records remain deferred until metadata and style gaps are resolved.
+
+## Key Consistency Check
+
+All ready-subset keys are stable and collision-free within the current preliminary BibTeX document.
+
+The keys should remain stable until venue conversion. Any later key changes must be recorded in a key-change log so `[Rxx]` traceability remains clear.
+
+## Claim-Safety Note
+
+This final ready-subset BibTeX audit does not change claim support.
+
+External references remain related-work, methodology, reproducibility, benchmark-construction, or background support only. KORA's 80/100 result remains supported by KORA deterministic-heavy benchmark docs and evidence. BibTeX status does not support production cost reduction proof, real API-cost reduction proof, energy reduction evidence, production benchmark proof, or broad workload superiority.
+
+## Next Step
+
+Next steps:
+
+1. Resolve metadata and style gaps for blocked records.
+2. Expand BibTeX only after blocked records are resolved.
+3. Run final bibliography and claim audit before any submission-ready statement.
+4. Create manuscript v0.4 only after bibliography and claim audit are stable.

--- a/docs/paper/kora-first-paper-missing-evidence-checklist.md
+++ b/docs/paper/kora-first-paper-missing-evidence-checklist.md
@@ -98,6 +98,7 @@ Citation style decision:
 - High-risk metadata gap resolution v0.1 has been created at the planning/classification level.
 - Preliminary BibTeX v0.1 exists only for ready records `[R01]`, `[R06]`, `[R08]`, `[R11]`, `[R14]`, `[R21]`, `[R24]`.
 - Preliminary BibTeX key normalization is complete for the ready subset.
+- Ready-subset BibTeX has been audited in final ready-subset BibTeX audit v0.1.
 - Full BibTeX remains incomplete because blocked records are still excluded.
 - Blocked metadata/style records remain unresolved.
 - Final claim/citation audit is still pending.

--- a/docs/paper/kora-first-paper-preliminary-bibtex-v0-1.md
+++ b/docs/paper/kora-first-paper-preliminary-bibtex-v0-1.md
@@ -57,6 +57,17 @@ No ready-subset record was moved back to blocked in this pass.
 
 All ready-subset keys already followed the selected author/year/topic pattern and were kept unchanged. Final venue key review may still adjust capitalization, punctuation, or venue-specific style, but no blocked record receives a BibTeX key in this pass.
 
+## Final Ready-Subset BibTeX Audit
+
+[KORA First Paper Final BibTeX Audit — Ready Subset v0.1](kora-first-paper-final-bibtex-audit-ready-subset-v0-1.md) has been created.
+
+Status:
+
+- Current BibTeX remains preliminary.
+- Blocked records remain excluded.
+- Ready-subset keys remain stable until venue conversion.
+- Final bibliography and claim audit are still pending.
+
 ## Preliminary BibTeX Entries
 
 ```bibtex

--- a/docs/paper/kora-first-paper-reference-plan.md
+++ b/docs/paper/kora-first-paper-reference-plan.md
@@ -318,6 +318,16 @@ Status:
 - Ready-subset BibTeX key normalization is complete for the included records.
 - Next step: metadata/style resolution for blocked records or final BibTeX audit.
 
+## Final Ready-Subset BibTeX Audit Status
+
+[KORA First Paper Final BibTeX Audit — Ready Subset v0.1](kora-first-paper-final-bibtex-audit-ready-subset-v0-1.md) has been created.
+
+Status:
+
+- Ready-subset BibTeX entries and normalized keys have been audited.
+- Blocked records remain excluded.
+- Next step: blocked metadata/style resolution.
+
 ## Next Verification Procedure
 
 1. Search official sources first.

--- a/docs/paper/kora-first-paper-submission-readiness.md
+++ b/docs/paper/kora-first-paper-submission-readiness.md
@@ -28,6 +28,8 @@ Preliminary BibTeX v0.1 exists for the ready subset only: [R01], [R06], [R08], [
 
 Ready-subset BibTeX key normalization is complete. Full BibTeX and blocked metadata/style resolution are still pending, and the paper remains not submission-ready.
 
+Final ready-subset BibTeX audit v0.1 exists. Full BibTeX and blocked metadata/style resolution are still pending, and the paper remains not submission-ready.
+
 ## Ready
 
 - Thesis.
@@ -50,6 +52,7 @@ Ready-subset BibTeX key normalization is complete. Full BibTeX and blocked metad
 - Metadata gap resolution v0.1.
 - Preliminary BibTeX v0.1 for ready records only.
 - Ready-subset BibTeX key normalization.
+- Final ready-subset BibTeX audit v0.1.
 - Citation audit v0.1.
 - Manuscript v0.3 reference integration plan.
 


### PR DESCRIPTION
## Summary
- Adds the final ready-subset BibTeX audit document for [R01], [R06], [R08], [R11], [R14], [R21], and [R24].
- Audits normalized keys, entry types, required fields, risk status, and remaining action for ready records only.
- Updates bibliography/readiness planning docs to record that the ready-subset audit exists.

## Scope and Boundaries
- Blocked records remain excluded: [R02], [R03], [R04], [R05], [R07], [R09], [R10], [R12], [R13], [R15], [R16], [R17], [R18], [R19], [R20], [R22], [R23].
- No manuscript changes.
- No new BibTeX for blocked records.
- No fake metadata and no new claims.
- Paper remains not submission-ready.

## Validation
- git diff --check
- git diff --cached --check
- python3 -m pytest
- python3 -m kora --help
- python3 -m kora examples list
- python3 -m kora run runtime_integrated_benchmark -- --offline
- python3 -m kora run customer_support_triage_fake_validation -- --offline
- python3 -m kora run direct_vs_kora -- --offline
- Public/private and secret scan
- BibTeX safety scan
- Reference and claim quality scan

## Remaining Gaps
- Metadata/style resolution for blocked records remains pending.
- Full BibTeX remains incomplete until blocked records are resolved.
- Final bibliography / claim audit remains pending before any manuscript v0.4 or submission-ready statement.