### PR TITLE
docs: add editable install troubleshooting

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,6 +46,18 @@ source .venv/bin/activate
 python3 -m pip install -e ".[dev]"
 ```
 
+If editable install reports that `setup.py`, `setup.cfg`, or install metadata is missing, verify that your checkout is current:
+
+```bash
+git remote -v
+git fetch origin
+git checkout main
+git pull origin main
+ls pyproject.toml
+```
+
+If `pyproject.toml` is still missing after pulling, re-clone from `https://github.com/Krako-Labs/KORA.git`.
+
 The editable install should install KORA and its development dependencies into the virtual environment.
 
 ## First verification commands

--- a/README.md
+++ b/README.md
@@ -36,6 +36,18 @@ source .venv/bin/activate
 python3 -m pip install -e ".[dev]"
 ```
 
+If editable install reports that `setup.py`, `setup.cfg`, or install metadata is missing, verify that your checkout is current:
+
+```bash
+git remote -v
+git fetch origin
+git checkout main
+git pull origin main
+ls pyproject.toml
+```
+
+If `pyproject.toml` is still missing after pulling, re-clone from `https://github.com/Krako-Labs/KORA.git`.
+
 Run the CLI and first offline demo:
 
 ```bash


### PR DESCRIPTION
## Summary
- Add concise troubleshooting guidance near the editable install command in README.md and CONTRIBUTING.md.
- Direct contributors to verify their remote, update main, confirm pyproject.toml exists, and re-clone from the canonical repo if needed.

## Root cause
Current origin/main already has installable project metadata. A missing setup.py/setup.cfg/install metadata error points to a stale checkout, wrong remote, old fork, or pre-migration clone where pyproject.toml is absent.

## Validation
- git status --short
- git diff --check
- fresh temporary venv: python3 -m pip install -e ".[dev]"
- python3 -m pytest: 158 passed
