### PR TITLE
fix: keep offline quickstart independent of requests

### DIFF
--- a/kora/adapters/openai_adapter.py
+++ b/kora/adapters/openai_adapter.py
@@ -9,8 +9,6 @@ import time
 from pathlib import Path
 from typing import Any
 
-import requests
-
 from .base import BaseAdapter
 
 
@@ -77,6 +75,17 @@ class OpenAIAdapter(BaseAdapter):
             return {
                 "ok": False,
                 "error": "OPENAI_API_KEY is missing",
+                "output": {},
+                "usage": {"time_ms": 0, "tokens_in": 0, "tokens_out": 0},
+                "meta": {"adapter": "openai", "model": self.model},
+            }
+
+        try:
+            import requests
+        except ImportError:
+            return {
+                "ok": False,
+                "error": "OpenAI adapter requires the optional dependency 'requests'. Install KORA with the openai extra.",
                 "output": {},
                 "usage": {"time_ms": 0, "tokens_in": 0, "tokens_out": 0},
                 "meta": {"adapter": "openai", "model": self.model},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,6 @@ classifiers = [
 dependencies = [
   "pydantic",
   "jsonschema",
-  "requests",
 ]
 
 [project.urls]
@@ -40,6 +39,9 @@ Issues = "https://github.com/Krako-Labs/KORA/issues"
 kora = "kora.cli:main"
 
 [project.optional-dependencies]
+openai = [
+  "requests",
+]
 dev = [
   "pytest",
 ]

--- a/tests/test_direct_vs_kora_cases.py
+++ b/tests/test_direct_vs_kora_cases.py
@@ -1,3 +1,4 @@
+import builtins
 import importlib.util
 from pathlib import Path
 
@@ -13,6 +14,23 @@ def _load_direct_vs_kora_module():
 
 
 def test_run_cases_offline_has_expected_short_and_long_llm_calls() -> None:
+    module = _load_direct_vs_kora_module()
+    result = module.run_cases(offline=True)
+
+    assert result["cases"]["short"]["kora"]["llm_calls"] == 0
+    assert result["cases"]["long"]["kora"]["llm_calls"] == 1
+
+
+def test_run_cases_offline_does_not_require_requests(monkeypatch) -> None:
+    real_import = builtins.__import__
+
+    def import_without_requests(name, globals=None, locals=None, fromlist=(), level=0):
+        if name == "requests":
+            raise ModuleNotFoundError("No module named 'requests'")
+        return real_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(builtins, "__import__", import_without_requests)
+
     module = _load_direct_vs_kora_module()
     result = module.run_cases(offline=True)
 


### PR DESCRIPTION
## Summary
- Make `requests` an optional `openai` extra instead of a default runtime dependency.
- Lazy-load `requests` only when the OpenAI adapter is actually making a network call.
- Add a regression test proving the offline `direct_vs_kora` path runs when `requests` cannot be imported.

## Root cause
The offline quickstart imported `kora.executor`, which eagerly imported the OpenAI adapter; that module imported `requests` at import time even though offline execution uses the mock adapter.

## Validation
- `git status --short`
- `git diff --check`
- Fresh venv: `python3 -m pip install -e ".[dev]"`
- Fresh venv confirmed `requests_installed=False`
- Fresh venv: `python3 -m kora run direct_vs_kora -- --offline`
- Fresh venv: `python3 -m pytest` -> 159 passed
