### PR TITLE
docs: prepare expanded BibTeX candidate subset

### DIFF
--- a/docs/paper/kora-first-paper-bibliography-notes.md
+++ b/docs/paper/kora-first-paper-bibliography-notes.md
@@ -213,7 +213,7 @@ Status:
 
 ## Final Ready-Subset BibTeX Audit
 
-[KORA First Paper Final BibTeX Audit — Ready Subset v0.1](kora-first-paper-final-bibtex-audit-ready-subset-v0-1.md) has been created.
+[KORA First Paper Final BibTeX Audit - Ready Subset v0.1](kora-first-paper-final-bibtex-audit-ready-subset-v0-1.md) has been created.
 
 Status:
 

--- a/docs/paper/kora-first-paper-bibliography-notes.md
+++ b/docs/paper/kora-first-paper-bibliography-notes.md
@@ -269,6 +269,19 @@ Status:
 - Final bibliography / claim audit remains pending.
 - The paper remains not submission-ready.
 
+## Expanded BibTeX Candidate Audit
+
+[KORA First Paper Expanded BibTeX Candidate Audit v0.1](kora-first-paper-expanded-bibtex-candidate-audit-v0-1.md) has been created.
+
+Status:
+
+- Expanded preliminary BibTeX now includes the candidate subset that passed final field check: `[R03]`, `[R04]`, `[R05]`, `[R07]`, `[R09]`, `[R10]`, `[R12]`, `[R13]`, `[R16]`.
+- Deferred records remain excluded: `[R17]`, `[R18]`.
+- Still-not-eligible records remain excluded: `[R02]`, `[R15]`, `[R19]`, `[R20]`, `[R22]`, `[R23]`.
+- Expanded BibTeX remains preliminary until final bibliography / claim audit.
+- No manuscript changes were made.
+- The paper remains not submission-ready.
+
 ## Claim Boundary
 
 No citation should be used to support unsupported production, API-cost, or energy claims.

--- a/docs/paper/kora-first-paper-citation-style-decision.md
+++ b/docs/paper/kora-first-paper-citation-style-decision.md
@@ -87,6 +87,8 @@ Normalization rules:
 - Artifact guidance style resolution v0.1 classifies `[R10]`, `[R17]`, and `[R18]` without adding BibTeX for those records.
 - Paper/preprint style resolution v0.1 classifies `[R02]`, `[R05]`, `[R12]`, `[R13]`, `[R16]`, `[R19]`, `[R20]`, `[R22]`, and `[R23]` without adding BibTeX for those records.
 - Final blocked metadata review v0.1 consolidates candidate, deferred, and still-blocked status without adding BibTeX for blocked records.
+- Expanded preliminary BibTeX v0.1 follows the stable `[Rxx]` strategy for candidate records `[R03]`, `[R04]`, `[R05]`, `[R07]`, `[R09]`, `[R10]`, `[R12]`, `[R13]`, and `[R16]`.
+- Venue-specific conversion remains deferred until the target venue or report format is chosen.
 - Stable `[Rxx]` labels remain canonical during audit.
 - Final venue-specific conversion remains deferred.
 

--- a/docs/paper/kora-first-paper-expanded-bibtex-candidate-audit-v0-1.md
+++ b/docs/paper/kora-first-paper-expanded-bibtex-candidate-audit-v0-1.md
@@ -1,0 +1,89 @@
+# KORA First Paper Expanded BibTeX Candidate Audit v0.1
+
+## Purpose
+
+This audit checks expanded preliminary BibTeX candidates before the final bibliography and claim audit.
+
+It prepares only the candidate records that pass final field check. It does not modify manuscript v0.3, does not complete full BibTeX, and does not make the paper submission-ready.
+
+## Scope
+
+Candidate set checked in this pass:
+
+- `[R03]`
+- `[R04]`
+- `[R05]`
+- `[R07]`
+- `[R09]`
+- `[R10]`
+- `[R12]`
+- `[R13]`
+- `[R16]`
+
+Ready subset already handled separately:
+
+- `[R01]`
+- `[R06]`
+- `[R08]`
+- `[R11]`
+- `[R14]`
+- `[R21]`
+- `[R24]`
+
+Deferred and still-not-eligible records are excluded. This pass makes no manuscript changes and makes no submission-ready claim.
+
+## Candidate Field Check Table
+
+| ID | Candidate status | Included in expanded BibTeX | Reason | Remaining risk |
+|---|---|---|---|---|
+| `[R03]` | pass | yes | Official docs source type, organization owner, title, URL, and access-date treatment are recorded in the tracker and normalized bibliography. | Final venue style may change access-date or entry-type formatting. |
+| `[R04]` | pass | yes | Official docs source type, organization owner, title, URL, and access-date treatment are recorded in the tracker and normalized bibliography. | Final venue style may change access-date or entry-type formatting. |
+| `[R05]` | pass | yes | Paper/preprint source type, full author list, title, arXiv URL, and year are recorded. | Venue/status conversion remains preliminary; keep as arXiv-style entry for now. |
+| `[R07]` | pass | yes | Official docs source type, organization owner, title, docs version, URL, and access-date treatment are recorded. | Final venue style may change access-date, version, or entry-type formatting. |
+| `[R09]` | pass | yes | Official repository source type, organization owner, title, URL, and access-date treatment are recorded. | Final venue style may change repository entry type or access-date formatting. |
+| `[R10]` | pass | yes | Official policy/artifact guidance source type, organization owner, title, version/year, and URL are recorded. | Final venue style may change policy-page entry type or access-date formatting. |
+| `[R12]` | pass | yes | Paper/preprint source type, full author list, title, arXiv URL, DOI, and year are recorded. | Venue/status conversion remains preliminary; keep as arXiv-style entry for now. |
+| `[R13]` | pass | yes | Paper/preprint source type, full author list, title, arXiv URL, DOI, year, and revision note are recorded. | Venue/status conversion remains preliminary; keep as arXiv-style entry for now. |
+| `[R16]` | pass | yes | Report/preprint source type, full author list, title, arXiv URL, DOI, and year are recorded. | Report/venue status conversion remains preliminary; does not imply formal artifact approval. |
+
+No candidate in this subset failed the final field check.
+
+## Excluded Records
+
+Deferred records:
+
+- `[R17]`
+- `[R18]`
+
+Still not eligible:
+
+- `[R02]`
+- `[R15]`
+- `[R19]`
+- `[R20]`
+- `[R22]`
+- `[R23]`
+
+No candidate record from `[R03]`, `[R04]`, `[R05]`, `[R07]`, `[R09]`, `[R10]`, `[R12]`, `[R13]`, and `[R16]` failed the final field check.
+
+## BibTeX Safety Note
+
+No BibTeX is generated for records that remain deferred or not eligible.
+
+This pass does not invent metadata. It uses only existing repository tracker, normalized bibliography, and style-resolution records. The expanded BibTeX remains preliminary and must be reviewed before submission.
+
+## Claim-Safety Note
+
+BibTeX status does not change claim support.
+
+References remain related-work, methodology, reproducibility, artifact-practice, or background only. KORA's 80/100 result remains supported by KORA deterministic-heavy benchmark docs and evidence.
+
+Expanded BibTeX status does not support production cost reduction proof, real API-cost reduction proof, energy reduction evidence, production benchmark proof, full runtime-integrated real-provider benchmark evidence, broad workload superiority, formal government validation, guaranteed adoption, guaranteed funding, or formal artifact approval.
+
+## Next Step
+
+Recommended next steps:
+
+1. Run final bibliography and claim audit.
+2. Run a final BibTeX consistency check.
+3. Create manuscript v0.4 only after bibliography and claim audit are stable.

--- a/docs/paper/kora-first-paper-missing-evidence-checklist.md
+++ b/docs/paper/kora-first-paper-missing-evidence-checklist.md
@@ -106,8 +106,9 @@ Citation style decision:
 - Paper/preprint metadata-style classification has been created for `[R02]`, `[R05]`, `[R12]`, `[R13]`, `[R16]`, `[R19]`, `[R20]`, `[R22]`, and `[R23]`.
 - BibTeX for paper/preprint blocked records is still pending.
 - Final blocked metadata review v0.1 has been created across the remaining blocked records.
-- Expanded BibTeX remains pending and should be limited to candidate records after final field check.
-- Full BibTeX remains incomplete because blocked records are still excluded.
+- Expanded BibTeX candidate audit v0.1 has been created for `[R03]`, `[R04]`, `[R05]`, `[R07]`, `[R09]`, `[R10]`, `[R12]`, `[R13]`, and `[R16]`.
+- Deferred records `[R17]` and `[R18]` and still-not-eligible records `[R02]`, `[R15]`, `[R19]`, `[R20]`, `[R22]`, and `[R23]` remain excluded from BibTeX.
+- Expanded BibTeX remains preliminary because final bibliography / claim audit is still pending.
 - Final claim/citation audit is still pending.
 - Paper is still not submission-ready.
 

--- a/docs/paper/kora-first-paper-preliminary-bibtex-v0-1.md
+++ b/docs/paper/kora-first-paper-preliminary-bibtex-v0-1.md
@@ -59,7 +59,7 @@ All ready-subset keys already followed the selected author/year/topic pattern an
 
 ## Final Ready-Subset BibTeX Audit
 
-[KORA First Paper Final BibTeX Audit — Ready Subset v0.1](kora-first-paper-final-bibtex-audit-ready-subset-v0-1.md) has been created.
+[KORA First Paper Final BibTeX Audit - Ready Subset v0.1](kora-first-paper-final-bibtex-audit-ready-subset-v0-1.md) has been created.
 
 Status:
 

--- a/docs/paper/kora-first-paper-preliminary-bibtex-v0-1.md
+++ b/docs/paper/kora-first-paper-preliminary-bibtex-v0-1.md
@@ -141,15 +141,100 @@ Status:
 }
 ```
 
+## Expanded Preliminary BibTeX Candidate Subset
+
+[KORA First Paper Expanded BibTeX Candidate Audit v0.1](kora-first-paper-expanded-bibtex-candidate-audit-v0-1.md) checked the candidate subset `[R03]`, `[R04]`, `[R05]`, `[R07]`, `[R09]`, `[R10]`, `[R12]`, `[R13]`, and `[R16]`.
+
+All nine candidates pass the final field check for preliminary BibTeX using existing repository metadata. The entries below remain preliminary. They do not complete full BibTeX, do not modify manuscript v0.3, and do not make the paper submission-ready.
+
+No candidate from this subset was excluded by the final field check.
+
+```bibtex
+@misc{onnxruntime_docs_accessed2026,
+  author = {{ONNX Runtime project / Microsoft}},
+  title = {ONNX Runtime},
+  howpublished = {ONNX Runtime official documentation},
+  url = {https://onnxruntime.ai/docs/},
+  note = {Accessed 2026-05-11}
+}
+
+@misc{langchain_langgraph_graph_api_accessed2026,
+  author = {{LangChain}},
+  title = {LangGraph Graph API overview},
+  howpublished = {LangGraph official documentation},
+  url = {https://docs.langchain.com/oss/python/langgraph/graph-api},
+  note = {Accessed 2026-05-11}
+}
+
+@misc{khattab2023dspy,
+  author = {Khattab, Omar and Singhvi, Arnav and Maheshwari, Paridhi and Zhang, Zhiyuan and Santhanam, Keshav and Vardhamanan, Sri and Haq, Saiful and Sharma, Ashutosh and Joshi, Thomas T. and Moazam, Hanna and Miller, Heather and Zaharia, Matei and Potts, Christopher},
+  title = {DSPy: Compiling Declarative Language Model Calls into Self-Improving Pipelines},
+  howpublished = {arXiv:2310.03714},
+  year = {2023},
+  url = {https://arxiv.org/abs/2310.03714}
+}
+
+@misc{apacheairflow_dags_accessed2026,
+  author = {{Apache Software Foundation / Apache Airflow project}},
+  title = {Dags},
+  howpublished = {Apache Airflow 3.2.1 documentation},
+  url = {https://airflow.apache.org/docs/apache-airflow/stable/core-concepts/dags.html},
+  note = {Accessed 2026-05-11}
+}
+
+@misc{ggmlorg_llamacpp_accessed2026,
+  author = {{ggml-org}},
+  title = {llama.cpp: LLM inference in C/C++},
+  howpublished = {GitHub repository},
+  url = {https://github.com/ggml-org/llama.cpp},
+  note = {Accessed 2026-05-11}
+}
+
+@misc{acm2020artifactreviewbadging,
+  author = {{Association for Computing Machinery}},
+  title = {Artifact Review and Badging - Current},
+  howpublished = {ACM policy page, Version 1.1},
+  year = {2020},
+  url = {https://www.acm.org/publications/policies/artifact-review-and-badging-current}
+}
+
+@misc{schick2023toolformer,
+  author = {Schick, Timo and Dwivedi-Yu, Jane and Dessi, Roberto and Raileanu, Roberta and Lomeli, Maria and Zettlemoyer, Luke and Cancedda, Nicola and Scialom, Thomas},
+  title = {Toolformer: Language Models Can Teach Themselves to Use Tools},
+  howpublished = {arXiv:2302.04761},
+  year = {2023},
+  doi = {10.48550/arXiv.2302.04761},
+  url = {https://arxiv.org/abs/2302.04761}
+}
+
+@misc{gao2022pal,
+  author = {Gao, Luyu and Madaan, Aman and Zhou, Shuyan and Alon, Uri and Liu, Pengfei and Yang, Yiming and Callan, Jamie and Neubig, Graham},
+  title = {PAL: Program-aided Language Models},
+  howpublished = {arXiv:2211.10435},
+  year = {2022},
+  doi = {10.48550/arXiv.2211.10435},
+  url = {https://arxiv.org/abs/2211.10435},
+  note = {Revised 2023}
+}
+
+@misc{pineau2020reproducibility,
+  author = {Pineau, Joelle and Vincent-Lamarre, Philippe and Sinha, Koustuv and Lariviere, Vincent and Beygelzimer, Alina and d'Alche-Buc, Florence and Fox, Emily and Larochelle, Hugo},
+  title = {Improving Reproducibility in Machine Learning Research (A Report from the NeurIPS 2019 Reproducibility Program)},
+  howpublished = {arXiv:2003.12206},
+  year = {2020},
+  doi = {10.48550/arXiv.2003.12206},
+  url = {https://arxiv.org/abs/2003.12206}
+}
+```
+
 ## Excluded Records
 
-Blocked records excluded from BibTeX:
+Records still excluded from BibTeX after this expanded candidate pass:
 
-- `[R02]`, `[R05]`, `[R12]`, `[R13]`, `[R16]`, `[R19]`, `[R20]`, `[R22]`, `[R23]`: blocked due to author-list handling, venue/status normalization, or both.
-- `[R03]`, `[R04]`, `[R07]`, `[R09]`, `[R15]`: blocked due to official docs/repo style and access-date decisions.
-- `[R10]`, `[R17]`, `[R18]`: blocked due to artifact, policy, or venue-guidance style decisions.
+- `[R17]`, `[R18]`: deferred until target-venue selection.
+- `[R02]`, `[R15]`, `[R19]`, `[R20]`, `[R22]`, `[R23]`: still not eligible because author-list, split, or venue/style decisions remain unresolved.
 
-These records should not receive BibTeX until their metadata/style blockers are resolved.
+No BibTeX is generated for deferred or still-not-eligible records in this document.
 
 ## Claim-Safety Note
 

--- a/docs/paper/kora-first-paper-reference-plan.md
+++ b/docs/paper/kora-first-paper-reference-plan.md
@@ -333,7 +333,7 @@ Status:
 
 ## Final Ready-Subset BibTeX Audit Status
 
-[KORA First Paper Final BibTeX Audit — Ready Subset v0.1](kora-first-paper-final-bibtex-audit-ready-subset-v0-1.md) has been created.
+[KORA First Paper Final BibTeX Audit - Ready Subset v0.1](kora-first-paper-final-bibtex-audit-ready-subset-v0-1.md) has been created.
 
 Status:
 

--- a/docs/paper/kora-first-paper-reference-plan.md
+++ b/docs/paper/kora-first-paper-reference-plan.md
@@ -371,6 +371,17 @@ Status:
 - No BibTeX was added for paper/preprint blocked records.
 - Next step: final metadata review for blocked records, or expanded BibTeX preparation only after author-list and venue/status fields are verified.
 
+## Expanded BibTeX Candidate Subset Status
+
+[KORA First Paper Expanded BibTeX Candidate Audit v0.1](kora-first-paper-expanded-bibtex-candidate-audit-v0-1.md) has been created.
+
+Status:
+
+- Expanded preliminary BibTeX is prepared for `[R03]`, `[R04]`, `[R05]`, `[R07]`, `[R09]`, `[R10]`, `[R12]`, `[R13]`, and `[R16]`.
+- Deferred and still-not-eligible records remain excluded from BibTeX.
+- No manuscript changes were made.
+- Final bibliography / claim audit remains the next bibliography step.
+
 ## Next Verification Procedure
 
 1. Search official sources first.

--- a/docs/paper/kora-first-paper-submission-readiness.md
+++ b/docs/paper/kora-first-paper-submission-readiness.md
@@ -38,6 +38,8 @@ Paper/preprint style resolution v0.1 exists for `[R02]`, `[R05]`, `[R12]`, `[R13
 
 Final blocked metadata review v0.1 exists. It consolidates remaining blocked records and identifies the later expanded-BibTeX candidate subset, deferred records, and still-not-eligible records. Full BibTeX and final bibliography review are still pending, and the paper remains not submission-ready.
 
+Expanded preliminary BibTeX candidate audit v0.1 exists for `[R03]`, `[R04]`, `[R05]`, `[R07]`, `[R09]`, `[R10]`, `[R12]`, `[R13]`, and `[R16]`. Final bibliography / claim audit is still pending, expanded BibTeX remains preliminary, and the paper remains not submission-ready.
+
 ## Ready
 
 - Thesis.
@@ -65,6 +67,7 @@ Final blocked metadata review v0.1 exists. It consolidates remaining blocked rec
 - Artifact guidance style resolution v0.1.
 - Paper/preprint style resolution v0.1.
 - Final blocked metadata review v0.1.
+- Expanded preliminary BibTeX candidate audit v0.1.
 - Citation audit v0.1.
 - Manuscript v0.3 reference integration plan.
 
@@ -73,7 +76,7 @@ Final blocked metadata review v0.1 exists. It consolidates remaining blocked rec
 - More references collected and verified.
 - Decide whether selected benchmark-construction references should be integrated if the evaluation-methodology section is expanded.
 - More direct deterministic-heavy synthetic workload construction references if needed.
-- Expanded BibTeX candidate subset final field check.
+- Final bibliography / claim audit for expanded preliminary BibTeX.
 - Final bibliography entries normalized.
 - Full BibTeX completion after blocked records are resolved.
 - Final citation audit review completed.
@@ -103,6 +106,6 @@ These are suggested formats only. This document does not claim acceptance, endor
 
 ## Reference Status
 
-The first verified reference pass is complete, manuscript v0.2 integrates the first-pass verified references as preliminary citation labels and a preliminary references section, citation audit v0.1 exists, additional reference verification pass 2 has added 8 verified tracker entries, manuscript v0.3 integrates [R11], [R12], and [R13] as preliminary related-work references, the benchmark-construction reference pass has added [R19] through [R24] as tracker/audit entries, the working citation style decision selects stable [Rxx] labels, metadata audit v0.1 exists, normalized bibliography v0.1 exists, metadata gap resolution v0.1 exists, preliminary BibTeX v0.1 exists for ready records only, and ready-subset BibTeX keys are normalized. The paper is still not submission-ready because [R14] through [R18] remain optional/deferred or tracker/audit-only, [R19] through [R24] are not yet integrated into manuscript methodology, more direct deterministic-heavy synthetic workload references may still be needed, production benchmark evidence is still not available, blocked records remain excluded from BibTeX, and final bibliography and claim audit are not complete.
+The first verified reference pass is complete, manuscript v0.2 integrates the first-pass verified references as preliminary citation labels and a preliminary references section, citation audit v0.1 exists, additional reference verification pass 2 has added 8 verified tracker entries, manuscript v0.3 integrates [R11], [R12], and [R13] as preliminary related-work references, the benchmark-construction reference pass has added [R19] through [R24] as tracker/audit entries, the working citation style decision selects stable [Rxx] labels, metadata audit v0.1 exists, normalized bibliography v0.1 exists, metadata gap resolution v0.1 exists, preliminary BibTeX v0.1 exists for ready records, ready-subset BibTeX keys are normalized, and expanded preliminary BibTeX exists for the candidate subset that passed final field check. The paper is still not submission-ready because [R17] and [R18] remain deferred, [R02], [R15], [R19], [R20], [R22], and [R23] remain excluded from BibTeX, [R19] through [R24] are not yet integrated into manuscript methodology, more direct deterministic-heavy synthetic workload references may still be needed, production benchmark evidence is still not available, and final bibliography and claim audit are not complete.
 
 No fake citations were added. Future citation work should use only verified tracker entries and should not support production, API-cost, energy, production-validation, broad superiority, or cited-system superiority claims.


### PR DESCRIPTION
## Summary
- Prepares the Paper Track expanded BibTeX candidate subset artifact.
- Adds preliminary BibTeX only for candidate records that pass the final field check.
- Updates related Paper Track bibliography/status docs to preserve current readiness boundaries.

## Files changed
- docs/paper/kora-first-paper-expanded-bibtex-candidate-audit-v0-1.md
- docs/paper/kora-first-paper-preliminary-bibtex-v0-1.md
- docs/paper/kora-first-paper-bibliography-notes.md
- docs/paper/kora-first-paper-reference-plan.md
- docs/paper/kora-first-paper-missing-evidence-checklist.md
- docs/paper/kora-first-paper-submission-readiness.md
- docs/paper/kora-first-paper-citation-style-decision.md

## Candidate records handled
- Included expanded BibTeX candidates: [R03], [R04], [R05], [R07], [R09], [R10], [R12], [R13], [R16].
- Deferred records remain excluded: [R17], [R18].
- Still-not-eligible records remain excluded: [R02], [R15], [R19], [R20], [R22], [R23].

## Boundaries
- No manuscript changes.
- No KORA Studio or source-code changes.
- No BibTeX for deferred or still-not-eligible records.
- No fake citations or invented metadata.
- No new benchmark, production, API-cost, energy, superiority, formal approval, or submission-readiness claims.
- Full BibTeX remains incomplete and the paper remains not submission-ready.

## Validation
- git status --short: clean
- git diff --check: passed
- python3 -m pytest: 159 passed
- Targeted text scans over changed files: only expected boundary/status language found.