### PR TITLE
docs: add final bibliography and claim audit

### DIFF
--- a/docs/paper/kora-first-paper-bibliography-notes.md
+++ b/docs/paper/kora-first-paper-bibliography-notes.md
@@ -282,6 +282,18 @@ Status:
 - No manuscript changes were made.
 - The paper remains not submission-ready.
 
+## Final Bibliography and Claim Audit
+
+[KORA First Paper Final Bibliography and Claim Audit v0.1](kora-first-paper-final-bibliography-claim-audit-v0-1.md) has been created.
+
+Status:
+
+- Ready and expanded preliminary BibTeX records are identified.
+- Deferred and still-not-eligible records remain excluded from preliminary BibTeX.
+- Remaining metadata blockers and claim boundaries are documented.
+- Full BibTeX remains incomplete.
+- The paper remains not submission-ready.
+
 ## Claim Boundary
 
 No citation should be used to support unsupported production, API-cost, or energy claims.

--- a/docs/paper/kora-first-paper-final-bibliography-claim-audit-v0-1.md
+++ b/docs/paper/kora-first-paper-final-bibliography-claim-audit-v0-1.md
@@ -1,0 +1,126 @@
+# KORA First Paper Final Bibliography and Claim Audit v0.1
+
+Audit date: 2026-05-13
+
+## Purpose
+
+This audit reviews bibliography readiness and claim safety after the expanded preliminary BibTeX candidate subset was prepared. It does not modify manuscript v0.3, does not complete full BibTeX, and does not make the paper submission-ready.
+
+## Source Files Reviewed
+
+- `docs/paper/kora-first-paper-manuscript-v0-3.md`
+- `docs/paper/kora-first-paper-citation-audit-v0-1.md`
+- `docs/paper/kora-first-paper-reference-metadata-audit-v0-1.md`
+- `docs/paper/kora-first-paper-normalized-bibliography-v0-1.md`
+- `docs/paper/kora-first-paper-metadata-gap-resolution-v0-1.md`
+- `docs/paper/kora-first-paper-preliminary-bibtex-v0-1.md`
+- `docs/paper/kora-first-paper-final-bibtex-audit-ready-subset-v0-1.md`
+- `docs/paper/kora-first-paper-expanded-bibtex-candidate-audit-v0-1.md`
+- `docs/paper/kora-first-paper-final-blocked-metadata-review-v0-1.md`
+- `docs/paper/kora-first-paper-bibliography-notes.md`
+- `docs/paper/kora-first-paper-reference-plan.md`
+- `docs/paper/kora-first-paper-missing-evidence-checklist.md`
+- `docs/paper/kora-first-paper-submission-readiness.md`
+- `docs/paper/kora-first-paper-citation-style-decision.md`
+- `docs/paper/kora-first-paper-docs-repo-reference-style-resolution-v0-1.md`
+- `docs/paper/kora-first-paper-artifact-guidance-reference-style-resolution-v0-1.md`
+- `docs/paper/kora-first-paper-paper-preprint-reference-style-resolution-v0-1.md`
+- `docs/paper/kora-first-paper-claim-boundary.md`
+
+## Bibliography Readiness Summary
+
+| Bucket | Records | Status |
+|---|---|---|
+| Ready subset | `[R01]`, `[R06]`, `[R08]`, `[R11]`, `[R14]`, `[R21]`, `[R24]` | Included in preliminary BibTeX; ready-subset audit exists; still preliminary before final venue formatting. |
+| Expanded candidate subset | `[R03]`, `[R04]`, `[R05]`, `[R07]`, `[R09]`, `[R10]`, `[R12]`, `[R13]`, `[R16]` | Included in expanded preliminary BibTeX after final field check; still preliminary before final venue formatting. |
+| Deferred records | `[R17]`, `[R18]` | Excluded from preliminary BibTeX until target venue selection confirms whether venue-specific guidance belongs in the final bibliography. |
+| Still-not-eligible records | `[R02]`, `[R15]`, `[R19]`, `[R20]`, `[R22]`, `[R23]` | Excluded from preliminary BibTeX until author-list, split, or venue/status decisions are resolved. |
+
+## Preliminary BibTeX Inclusion
+
+Preliminary BibTeX currently includes:
+
+- `[R01]`
+- `[R03]`
+- `[R04]`
+- `[R05]`
+- `[R06]`
+- `[R07]`
+- `[R08]`
+- `[R09]`
+- `[R10]`
+- `[R11]`
+- `[R12]`
+- `[R13]`
+- `[R14]`
+- `[R16]`
+- `[R21]`
+- `[R24]`
+
+Preliminary BibTeX excludes:
+
+- `[R02]`
+- `[R15]`
+- `[R17]`
+- `[R18]`
+- `[R19]`
+- `[R20]`
+- `[R22]`
+- `[R23]`
+
+No deferred or still-not-eligible record was found in preliminary BibTeX. No missing metadata was silently filled in this audit.
+
+## Remaining Metadata Blockers
+
+- `[R02]`: author-list handling and venue/status normalization remain unresolved.
+- `[R15]`: split-or-keep treatment for the combined docs/repo citation remains unresolved.
+- `[R17]`: target-venue-specific artifact guidance remains deferred.
+- `[R18]`: target-venue-specific artifact guidance remains deferred.
+- `[R19]`: author-list handling or approved `et al.` style remains unresolved.
+- `[R20]`: author-list handling or approved `et al.` style remains unresolved.
+- `[R22]`: author-list handling or approved `et al.` style remains unresolved.
+- `[R23]`: author-list handling or approved `et al.` style remains unresolved.
+- `[R19]` through `[R24]`: benchmark-methodology manuscript integration remains a future decision; these records do not provide KORA production benchmark evidence.
+
+## Claim and Evidence Alignment
+
+The current manuscript v0.3 remains aligned with the approved safe public claim:
+
+> KORA reduced model invocations by 80% in a reproducible deterministic-heavy benchmark workload.
+
+The manuscript constrains the 80/100 result to the documented deterministic-heavy benchmark and explicitly separates that evidence from production, provider, cost, energy, and broad generalization claims. The customer-support local/no-network validation remains framed as a synthetic workload that measures avoided model-call events, not as production evidence.
+
+References remain related-work, methodology, reproducibility, artifact-practice, or background support only. External references do not support the KORA 80/100 result; that result remains supported by KORA deterministic-heavy benchmark docs and evidence.
+
+## Explicit Non-Claims
+
+This audit does not support:
+
+- production cost reduction proof
+- real API-cost reduction proof
+- production benchmark proof
+- full runtime-integrated real-provider benchmark evidence
+- broad workload superiority proof
+- energy reduction evidence
+- formal government validation
+- signed partner validation
+- guaranteed adoption or funding
+- formal artifact approval
+- paper submission readiness
+
+## Submission-Readiness Blockers
+
+- Full BibTeX remains incomplete because `[R02]`, `[R15]`, `[R17]`, `[R18]`, `[R19]`, `[R20]`, `[R22]`, and `[R23]` remain excluded.
+- Final venue-specific bibliography formatting is not complete.
+- Final citation style conversion from stable `[Rxx]` labels remains deferred.
+- Benchmark-methodology references `[R19]` through `[R24]` are not fully integrated into manuscript methodology.
+- Final figures, tables, clean reproduction transcript, and final claim review remain pending.
+- Manuscript v0.4 should wait until bibliography and claim boundaries are stable.
+
+## Audit Result
+
+Bibliography readiness has advanced, but full BibTeX is still incomplete. The manuscript claim boundary remains safe and aligned with available evidence. The paper remains not submission-ready.
+
+## Next Recommended Step
+
+Resolve the remaining deferred and still-not-eligible bibliography records, then perform final BibTeX consistency and venue-format checks before any manuscript v0.4 or submission-preparation pass.

--- a/docs/paper/kora-first-paper-missing-evidence-checklist.md
+++ b/docs/paper/kora-first-paper-missing-evidence-checklist.md
@@ -108,8 +108,8 @@ Citation style decision:
 - Final blocked metadata review v0.1 has been created across the remaining blocked records.
 - Expanded BibTeX candidate audit v0.1 has been created for `[R03]`, `[R04]`, `[R05]`, `[R07]`, `[R09]`, `[R10]`, `[R12]`, `[R13]`, and `[R16]`.
 - Deferred records `[R17]` and `[R18]` and still-not-eligible records `[R02]`, `[R15]`, `[R19]`, `[R20]`, `[R22]`, and `[R23]` remain excluded from BibTeX.
-- Expanded BibTeX remains preliminary because final bibliography / claim audit is still pending.
-- Final claim/citation audit is still pending.
+- Final bibliography and claim audit v0.1 has been created.
+- Expanded BibTeX remains preliminary, and full BibTeX is still incomplete until deferred and still-not-eligible records are resolved.
 - Paper is still not submission-ready.
 
 ## Follow-Up Papers / Technical Reports

--- a/docs/paper/kora-first-paper-reference-plan.md
+++ b/docs/paper/kora-first-paper-reference-plan.md
@@ -382,6 +382,17 @@ Status:
 - No manuscript changes were made.
 - Final bibliography / claim audit remains the next bibliography step.
 
+## Final Bibliography and Claim Audit Status
+
+[KORA First Paper Final Bibliography and Claim Audit v0.1](kora-first-paper-final-bibliography-claim-audit-v0-1.md) has been created.
+
+Status:
+
+- Preliminary BibTeX includes the ready subset and expanded candidate subset only.
+- Deferred and still-not-eligible records remain excluded.
+- Remaining blockers are author-list, split, venue/status, target-venue, final formatting, and final claim-review work.
+- The paper remains not submission-ready.
+
 ## Next Verification Procedure
 
 1. Search official sources first.

--- a/docs/paper/kora-first-paper-reference-tracker.md
+++ b/docs/paper/kora-first-paper-reference-tracker.md
@@ -61,3 +61,15 @@ Status:
 - No new references were added.
 - No BibTeX was generated.
 - BibTeX remains pending until ready records are selected from verified normalized fields.
+
+## Final Bibliography and Claim Audit Status
+
+[KORA First Paper Final Bibliography and Claim Audit v0.1](kora-first-paper-final-bibliography-claim-audit-v0-1.md) records bibliography readiness and claim-safety status after the expanded preliminary BibTeX candidate subset.
+
+Status:
+
+- Preliminary BibTeX includes `[R01]`, `[R03]`, `[R04]`, `[R05]`, `[R06]`, `[R07]`, `[R08]`, `[R09]`, `[R10]`, `[R11]`, `[R12]`, `[R13]`, `[R14]`, `[R16]`, `[R21]`, and `[R24]`.
+- Deferred records `[R17]` and `[R18]` remain excluded.
+- Still-not-eligible records `[R02]`, `[R15]`, `[R19]`, `[R20]`, `[R22]`, and `[R23]` remain excluded.
+- Claim support remains limited to documented benchmark and local/no-network validation evidence.
+- Full BibTeX remains incomplete, and the paper remains not submission-ready.

--- a/docs/paper/kora-first-paper-submission-readiness.md
+++ b/docs/paper/kora-first-paper-submission-readiness.md
@@ -38,7 +38,9 @@ Paper/preprint style resolution v0.1 exists for `[R02]`, `[R05]`, `[R12]`, `[R13
 
 Final blocked metadata review v0.1 exists. It consolidates remaining blocked records and identifies the later expanded-BibTeX candidate subset, deferred records, and still-not-eligible records. Full BibTeX and final bibliography review are still pending, and the paper remains not submission-ready.
 
-Expanded preliminary BibTeX candidate audit v0.1 exists for `[R03]`, `[R04]`, `[R05]`, `[R07]`, `[R09]`, `[R10]`, `[R12]`, `[R13]`, and `[R16]`. Final bibliography / claim audit is still pending, expanded BibTeX remains preliminary, and the paper remains not submission-ready.
+Expanded preliminary BibTeX candidate audit v0.1 exists for `[R03]`, `[R04]`, `[R05]`, `[R07]`, `[R09]`, `[R10]`, `[R12]`, `[R13]`, and `[R16]`. Expanded BibTeX remains preliminary, and the paper remains not submission-ready.
+
+Final bibliography and claim audit v0.1 exists. It confirms that preliminary BibTeX includes only the ready subset and expanded candidate subset, deferred and still-not-eligible records remain excluded, full BibTeX remains incomplete, and the paper remains not submission-ready.
 
 ## Ready
 
@@ -68,6 +70,7 @@ Expanded preliminary BibTeX candidate audit v0.1 exists for `[R03]`, `[R04]`, `[
 - Paper/preprint style resolution v0.1.
 - Final blocked metadata review v0.1.
 - Expanded preliminary BibTeX candidate audit v0.1.
+- Final bibliography and claim audit v0.1.
 - Citation audit v0.1.
 - Manuscript v0.3 reference integration plan.
 
@@ -76,7 +79,7 @@ Expanded preliminary BibTeX candidate audit v0.1 exists for `[R03]`, `[R04]`, `[
 - More references collected and verified.
 - Decide whether selected benchmark-construction references should be integrated if the evaluation-methodology section is expanded.
 - More direct deterministic-heavy synthetic workload construction references if needed.
-- Final bibliography / claim audit for expanded preliminary BibTeX.
+- Resolve deferred and still-not-eligible bibliography records.
 - Final bibliography entries normalized.
 - Full BibTeX completion after blocked records are resolved.
 - Final citation audit review completed.
@@ -106,6 +109,6 @@ These are suggested formats only. This document does not claim acceptance, endor
 
 ## Reference Status
 
-The first verified reference pass is complete, manuscript v0.2 integrates the first-pass verified references as preliminary citation labels and a preliminary references section, citation audit v0.1 exists, additional reference verification pass 2 has added 8 verified tracker entries, manuscript v0.3 integrates [R11], [R12], and [R13] as preliminary related-work references, the benchmark-construction reference pass has added [R19] through [R24] as tracker/audit entries, the working citation style decision selects stable [Rxx] labels, metadata audit v0.1 exists, normalized bibliography v0.1 exists, metadata gap resolution v0.1 exists, preliminary BibTeX v0.1 exists for ready records, ready-subset BibTeX keys are normalized, and expanded preliminary BibTeX exists for the candidate subset that passed final field check. The paper is still not submission-ready because [R17] and [R18] remain deferred, [R02], [R15], [R19], [R20], [R22], and [R23] remain excluded from BibTeX, [R19] through [R24] are not yet integrated into manuscript methodology, more direct deterministic-heavy synthetic workload references may still be needed, production benchmark evidence is still not available, and final bibliography and claim audit are not complete.
+The first verified reference pass is complete, manuscript v0.2 integrates the first-pass verified references as preliminary citation labels and a preliminary references section, citation audit v0.1 exists, additional reference verification pass 2 has added 8 verified tracker entries, manuscript v0.3 integrates [R11], [R12], and [R13] as preliminary related-work references, the benchmark-construction reference pass has added [R19] through [R24] as tracker/audit entries, the working citation style decision selects stable [Rxx] labels, metadata audit v0.1 exists, normalized bibliography v0.1 exists, metadata gap resolution v0.1 exists, preliminary BibTeX v0.1 exists for ready records, ready-subset BibTeX keys are normalized, expanded preliminary BibTeX exists for the candidate subset that passed final field check, and final bibliography and claim audit v0.1 exists. The paper is still not submission-ready because [R17] and [R18] remain deferred, [R02], [R15], [R19], [R20], [R22], and [R23] remain excluded from BibTeX, [R19] through [R24] are not yet integrated into manuscript methodology, more direct deterministic-heavy synthetic workload references may still be needed, production benchmark evidence is still not available, and final bibliography entries are not complete.
 
 No fake citations were added. Future citation work should use only verified tracker entries and should not support production, API-cost, energy, production-validation, broad superiority, or cited-system superiority claims.


### PR DESCRIPTION
## Summary
- Adds the Paper Track final bibliography and claim audit artifact.
- Updates bibliography/status index docs to reference the new audit.
- Keeps manuscript v0.3 unchanged and preserves submission-readiness boundaries.

## Records
- Ready subset: [R01], [R06], [R08], [R11], [R14], [R21], [R24].
- Expanded candidate subset: [R03], [R04], [R05], [R07], [R09], [R10], [R12], [R13], [R16].
- Deferred records: [R17], [R18].
- Still-not-eligible records: [R02], [R15], [R19], [R20], [R22], [R23].

## Claim and readiness boundaries
- Confirms the safe claim remains bounded to the reproducible deterministic-heavy benchmark workload.
- Confirms preliminary BibTeX excludes deferred and still-not-eligible records.
- Confirms full BibTeX remains incomplete.
- Confirms the paper remains not submission-ready.
- Adds no manuscript, source code, README, Studio, dependency, CI, or benchmark artifact changes.

## Validation
- git status --short: clean before commit
- git diff --check: passed
- python3 -m pytest: 159 passed
- Unicode scan over changed files: clean
- Preliminary BibTeX exclusion check: 16 entries, no deferred/still-not-eligible entries
- Targeted claim/internal text scan: only expected non-claim/status language found