### PR TITLE
docs: add paper submission readiness gate

### DIFF
--- a/docs/paper/kora-first-paper-bibliography-notes.md
+++ b/docs/paper/kora-first-paper-bibliography-notes.md
@@ -266,7 +266,7 @@ Status:
 - `[R17]` and `[R18]` remain deferred until target venue selection.
 - `[R02]`, `[R15]`, `[R19]`, `[R20]`, `[R22]`, and `[R23]` remain not eligible until author-list, split, or venue/style decisions are resolved.
 - No BibTeX was generated.
-- Final bibliography / claim audit remains pending.
+- Final bibliography and claim audit v0.1 has been created.
 - The paper remains not submission-ready.
 
 ## Expanded BibTeX Candidate Audit
@@ -278,7 +278,7 @@ Status:
 - Expanded preliminary BibTeX now includes the candidate subset that passed final field check: `[R03]`, `[R04]`, `[R05]`, `[R07]`, `[R09]`, `[R10]`, `[R12]`, `[R13]`, `[R16]`.
 - Deferred records remain excluded: `[R17]`, `[R18]`.
 - Still-not-eligible records remain excluded: `[R02]`, `[R15]`, `[R19]`, `[R20]`, `[R22]`, `[R23]`.
-- Expanded BibTeX remains preliminary until final bibliography / claim audit.
+- Expanded BibTeX remains preliminary until final BibTeX consistency and venue-format checks.
 - No manuscript changes were made.
 - The paper remains not submission-ready.
 
@@ -292,6 +292,17 @@ Status:
 - Deferred and still-not-eligible records remain excluded from preliminary BibTeX.
 - Remaining metadata blockers and claim boundaries are documented.
 - Full BibTeX remains incomplete.
+- The paper remains not submission-ready.
+
+## Submission Readiness Gate
+
+[KORA First Paper Submission Readiness Gate v0.1](kora-first-paper-submission-readiness-gate-v0-1.md) has been created.
+
+Status:
+
+- Required blockers are grouped by bibliography, claim/evidence, formatting/export, artifact/reproducibility, and human review.
+- Optional blockers are separated from required submission blockers.
+- The next sequence starts with remaining bibliography blockers.
 - The paper remains not submission-ready.
 
 ## Claim Boundary

--- a/docs/paper/kora-first-paper-missing-evidence-checklist.md
+++ b/docs/paper/kora-first-paper-missing-evidence-checklist.md
@@ -110,6 +110,7 @@ Citation style decision:
 - Deferred records `[R17]` and `[R18]` and still-not-eligible records `[R02]`, `[R15]`, `[R19]`, `[R20]`, `[R22]`, and `[R23]` remain excluded from BibTeX.
 - Final bibliography and claim audit v0.1 has been created.
 - Expanded BibTeX remains preliminary, and full BibTeX is still incomplete until deferred and still-not-eligible records are resolved.
+- Submission readiness gate v0.1 has been created to separate required blockers from optional improvements.
 - Paper is still not submission-ready.
 
 ## Follow-Up Papers / Technical Reports

--- a/docs/paper/kora-first-paper-reference-plan.md
+++ b/docs/paper/kora-first-paper-reference-plan.md
@@ -393,6 +393,17 @@ Status:
 - Remaining blockers are author-list, split, venue/status, target-venue, final formatting, and final claim-review work.
 - The paper remains not submission-ready.
 
+## Submission Readiness Gate Status
+
+[KORA First Paper Submission Readiness Gate v0.1](kora-first-paper-submission-readiness-gate-v0-1.md) has been created.
+
+Status:
+
+- Required submission blockers are registered by category.
+- Optional improvements are explicitly separated from required blockers.
+- Bibliography blockers remain the first recommended sequence item.
+- The paper remains not submission-ready.
+
 ## Next Verification Procedure
 
 1. Search official sources first.

--- a/docs/paper/kora-first-paper-submission-readiness-gate-v0-1.md
+++ b/docs/paper/kora-first-paper-submission-readiness-gate-v0-1.md
@@ -1,0 +1,136 @@
+# KORA First Paper Submission Readiness Gate v0.1
+
+Gate date: 2026-05-13
+
+## Purpose
+
+This gate records what remains before the KORA first paper can be treated as submission-ready. It is a blocker register and sequencing guide. It does not modify manuscript v0.3, does not complete the bibliography, and does not mark the paper as submission-ready.
+
+## Source Files Reviewed
+
+- `docs/paper/kora-first-paper-manuscript-v0-3.md`
+- `docs/paper/kora-first-paper-citation-audit-v0-1.md`
+- `docs/paper/kora-first-paper-reference-metadata-audit-v0-1.md`
+- `docs/paper/kora-first-paper-normalized-bibliography-v0-1.md`
+- `docs/paper/kora-first-paper-metadata-gap-resolution-v0-1.md`
+- `docs/paper/kora-first-paper-preliminary-bibtex-v0-1.md`
+- `docs/paper/kora-first-paper-final-bibtex-audit-ready-subset-v0-1.md`
+- `docs/paper/kora-first-paper-expanded-bibtex-candidate-audit-v0-1.md`
+- `docs/paper/kora-first-paper-final-bibliography-claim-audit-v0-1.md`
+- `docs/paper/kora-first-paper-final-blocked-metadata-review-v0-1.md`
+- `docs/paper/kora-first-paper-bibliography-notes.md`
+- `docs/paper/kora-first-paper-reference-plan.md`
+- `docs/paper/kora-first-paper-missing-evidence-checklist.md`
+- `docs/paper/kora-first-paper-submission-readiness.md`
+- `docs/paper/kora-first-paper-citation-style-decision.md`
+- `docs/paper/kora-first-paper-docs-repo-reference-style-resolution-v0-1.md`
+- `docs/paper/kora-first-paper-artifact-guidance-reference-style-resolution-v0-1.md`
+- `docs/paper/kora-first-paper-paper-preprint-reference-style-resolution-v0-1.md`
+
+## Current State
+
+- Current manuscript version: manuscript v0.3.
+- Current bibliography state: preliminary BibTeX v0.1 has 16 entries.
+- Ready records in preliminary BibTeX: `[R01]`, `[R06]`, `[R08]`, `[R11]`, `[R14]`, `[R21]`, `[R24]`.
+- Expanded candidate records in preliminary BibTeX: `[R03]`, `[R04]`, `[R05]`, `[R07]`, `[R09]`, `[R10]`, `[R12]`, `[R13]`, `[R16]`.
+- Deferred records excluded from preliminary BibTeX: `[R17]`, `[R18]`.
+- Still-not-eligible records excluded from preliminary BibTeX: `[R02]`, `[R15]`, `[R19]`, `[R20]`, `[R22]`, `[R23]`.
+- Current claim/evidence state: the bounded 80% deterministic-heavy benchmark claim remains the only approved public quantitative claim.
+
+## Required Blockers Before Submission
+
+| Blocker ID | Category | Required blocker | Required resolution |
+|---|---|---|---|
+| BIB-1 | Bibliography | Full BibTeX remains incomplete. | Resolve deferred and still-not-eligible records or document an intentional final exclusion policy. |
+| BIB-2 | Bibliography | Deferred records `[R17]` and `[R18]` remain target-venue dependent. | Select target venue or decide these artifact-guidance references stay out of final bibliography. |
+| BIB-3 | Bibliography | Still-not-eligible records `[R02]`, `[R15]`, `[R19]`, `[R20]`, `[R22]`, and `[R23]` have unresolved author-list, split, or venue/status handling. | Complete metadata/style decisions before final BibTeX. |
+| BIB-4 | Bibliography | Manuscript references and preliminary BibTeX are not yet synchronized as final bibliography entries. | Run final manuscript-to-BibTeX consistency check after full BibTeX decisions. |
+| CLAIM-1 | Claim/evidence | Final claim-to-evidence pass against the manuscript body is not complete after bibliography closure. | Re-check every quantitative and evidence-bearing statement against public evidence. |
+| CLAIM-2 | Claim/evidence | Benchmark-methodology references `[R19]` through `[R24]` are tracker/audit-only or partially integrated. | Decide whether methodology integration is needed, and keep them out of KORA production benchmark evidence. |
+| FORMAT-1 | Formatting/export | Final venue format is not selected. | Select target format or produce an arXiv/workshop technical-report package. |
+| FORMAT-2 | Formatting/export | Final export package is not prepared. | Generate final manuscript export, bibliography, figures, and tables for the target package. |
+| ART-1 | Artifact/reproducibility | Clean reproduction transcript is not captured. | Run and record clean checkout validation commands for the submission package. |
+| ART-2 | Artifact/reproducibility | Submission-context artifact package has not been reviewed. | Review public artifact instructions, command reproducibility, and no-network labels. |
+| REVIEW-1 | Human review | Final human review is not complete. | Perform final paper readthrough for claims, references, figures, tables, and submission instructions. |
+
+## Optional Before Submission
+
+These items are useful but can remain deferred if the first submission scope stays narrow:
+
+- Expanded workload beyond the deterministic-heavy benchmark and synthetic customer-support validation.
+- Latency p50/p95 reporting.
+- Additional direct deterministic-heavy synthetic workload construction references.
+- Additional semantic caching references if the manuscript expands caching discussion.
+- OpenAI or Claude API-cost study.
+- Production traffic study.
+- Energy measurement study.
+- KORA Studio implementation discussion.
+- Real customer-data validation.
+
+## Blocker Categories
+
+### Bibliography Blockers
+
+- Full BibTeX remains incomplete.
+- Deferred and still-not-eligible records remain unresolved or intentionally excluded.
+- Final venue-specific bibliography formatting is not complete.
+- Final citation style conversion from stable `[Rxx]` labels remains deferred.
+- Final manuscript and bibliography synchronization is not complete.
+
+### Claim and Evidence Blockers
+
+- Final claim-to-evidence pass must be repeated after bibliography and manuscript updates are stable.
+- The approved safe claim remains: KORA reduced model invocations by 80% in a reproducible deterministic-heavy benchmark workload.
+- The customer-support local/no-network validation remains synthetic validation of avoided model-call event measurement, not production evidence.
+- External references remain related-work, methodology, reproducibility, artifact-practice, or background support only.
+
+### Formatting and Export Blockers
+
+- Target venue or report format is not selected.
+- Final bibliography style and citation rendering are not complete.
+- Final figures and tables are not locked.
+- Final manuscript export and package assembly are not complete.
+
+### Artifact and Reproducibility Blockers
+
+- Clean command transcript is pending.
+- Clean checkout reproduction instructions are not yet package-reviewed.
+- Raw benchmark artifacts must not be uploaded.
+- Artifact guidance references do not imply formal artifact approval.
+
+### Repository and Documentation Blockers
+
+- Public paper docs must remain free of private paths, internal workflow references, secrets, raw provider responses, proprietary datasets, and private campaign material.
+- Public docs must preserve explicit non-claim boundaries.
+- Any final submission package should be reviewed against repository public-safety rules.
+
+## Explicit Non-Claims
+
+This gate does not support:
+
+- production cost reduction proof
+- real API-cost reduction proof
+- production benchmark proof
+- full runtime-integrated real-provider benchmark evidence
+- broad workload superiority proof
+- energy reduction evidence
+- formal government validation
+- signed partner validation
+- guaranteed adoption or funding
+- formal artifact approval
+- paper submission readiness
+
+## Recommended Next Task Sequence
+
+1. Resolve or intentionally exclude `[R17]` and `[R18]` after target venue direction is clear.
+2. Resolve `[R02]`, `[R15]`, `[R19]`, `[R20]`, `[R22]`, and `[R23]` metadata/style blockers.
+3. Complete final BibTeX consistency and venue-format checks.
+4. Synchronize manuscript references and final bibliography.
+5. Run final claim-to-evidence audit against manuscript v0.3 or a later manuscript draft.
+6. Prepare figures, tables, and final export package.
+7. Capture clean reproduction transcript and artifact package review.
+8. Complete final human review before any submission or preprint action.
+
+## Gate Conclusion
+
+The paper is not submission-ready. The next required focus is resolving remaining bibliography blockers before final manuscript synchronization, final claim review, and submission-package preparation.

--- a/docs/paper/kora-first-paper-submission-readiness.md
+++ b/docs/paper/kora-first-paper-submission-readiness.md
@@ -42,6 +42,8 @@ Expanded preliminary BibTeX candidate audit v0.1 exists for `[R03]`, `[R04]`, `[
 
 Final bibliography and claim audit v0.1 exists. It confirms that preliminary BibTeX includes only the ready subset and expanded candidate subset, deferred and still-not-eligible records remain excluded, full BibTeX remains incomplete, and the paper remains not submission-ready.
 
+Submission readiness gate v0.1 exists. It records required and optional blockers before any submission package and confirms the paper remains not submission-ready.
+
 ## Ready
 
 - Thesis.
@@ -71,6 +73,7 @@ Final bibliography and claim audit v0.1 exists. It confirms that preliminary Bib
 - Final blocked metadata review v0.1.
 - Expanded preliminary BibTeX candidate audit v0.1.
 - Final bibliography and claim audit v0.1.
+- Submission readiness gate v0.1.
 - Citation audit v0.1.
 - Manuscript v0.3 reference integration plan.
 
@@ -79,7 +82,7 @@ Final bibliography and claim audit v0.1 exists. It confirms that preliminary Bib
 - More references collected and verified.
 - Decide whether selected benchmark-construction references should be integrated if the evaluation-methodology section is expanded.
 - More direct deterministic-heavy synthetic workload construction references if needed.
-- Resolve deferred and still-not-eligible bibliography records.
+- Resolve submission readiness gate required blockers, starting with deferred and still-not-eligible bibliography records.
 - Final bibliography entries normalized.
 - Full BibTeX completion after blocked records are resolved.
 - Final citation audit review completed.
@@ -109,6 +112,6 @@ These are suggested formats only. This document does not claim acceptance, endor
 
 ## Reference Status
 
-The first verified reference pass is complete, manuscript v0.2 integrates the first-pass verified references as preliminary citation labels and a preliminary references section, citation audit v0.1 exists, additional reference verification pass 2 has added 8 verified tracker entries, manuscript v0.3 integrates [R11], [R12], and [R13] as preliminary related-work references, the benchmark-construction reference pass has added [R19] through [R24] as tracker/audit entries, the working citation style decision selects stable [Rxx] labels, metadata audit v0.1 exists, normalized bibliography v0.1 exists, metadata gap resolution v0.1 exists, preliminary BibTeX v0.1 exists for ready records, ready-subset BibTeX keys are normalized, expanded preliminary BibTeX exists for the candidate subset that passed final field check, and final bibliography and claim audit v0.1 exists. The paper is still not submission-ready because [R17] and [R18] remain deferred, [R02], [R15], [R19], [R20], [R22], and [R23] remain excluded from BibTeX, [R19] through [R24] are not yet integrated into manuscript methodology, more direct deterministic-heavy synthetic workload references may still be needed, production benchmark evidence is still not available, and final bibliography entries are not complete.
+The first verified reference pass is complete, manuscript v0.2 integrates the first-pass verified references as preliminary citation labels and a preliminary references section, citation audit v0.1 exists, additional reference verification pass 2 has added 8 verified tracker entries, manuscript v0.3 integrates [R11], [R12], and [R13] as preliminary related-work references, the benchmark-construction reference pass has added [R19] through [R24] as tracker/audit entries, the working citation style decision selects stable [Rxx] labels, metadata audit v0.1 exists, normalized bibliography v0.1 exists, metadata gap resolution v0.1 exists, preliminary BibTeX v0.1 exists for ready records, ready-subset BibTeX keys are normalized, expanded preliminary BibTeX exists for the candidate subset that passed final field check, final bibliography and claim audit v0.1 exists, and submission readiness gate v0.1 exists. The paper is still not submission-ready because [R17] and [R18] remain deferred, [R02], [R15], [R19], [R20], [R22], and [R23] remain excluded from BibTeX, [R19] through [R24] are not yet integrated into manuscript methodology, more direct deterministic-heavy synthetic workload references may still be needed, production benchmark evidence is still not available, final bibliography entries are not complete, and submission-package blockers remain unresolved.
 
 No fake citations were added. Future citation work should use only verified tracker entries and should not support production, API-cost, energy, production-validation, broad superiority, or cited-system superiority claims.


### PR DESCRIPTION
## Summary
- Adds a Paper Track submission-readiness gate and blocker register.
- Groups required blockers by bibliography, claim/evidence, formatting/export, artifact/reproducibility, repository/docs, and human review.
- Separates optional improvements from required submission blockers.
- Updates related Paper Track status docs to reference the new gate.

## Files changed
- docs/paper/kora-first-paper-submission-readiness-gate-v0-1.md
- docs/paper/kora-first-paper-submission-readiness.md
- docs/paper/kora-first-paper-bibliography-notes.md
- docs/paper/kora-first-paper-reference-plan.md
- docs/paper/kora-first-paper-missing-evidence-checklist.md

## Claim and readiness boundaries
- Preserves the bounded 80% deterministic-heavy benchmark claim.
- Adds no production, API-cost, energy, broad superiority, formal approval, or submission-readiness claims.
- Confirms full BibTeX remains incomplete.
- Confirms the paper remains not submission-ready.

## Validation
- git status --short: clean before commit
- git diff --check: passed
- python3 -m pytest: 159 passed
- Unicode scan over changed files: clean
- Preliminary BibTeX exclusion check: 16 entries, no deferred/still-not-eligible entries
- Targeted claim/internal text scan: only expected non-claim/status language found