### PR TITLE
docs: sync manuscript and claim evidence for paper candidate

### DIFF
--- a/docs/paper/kora-first-paper-bibliography-notes.md
+++ b/docs/paper/kora-first-paper-bibliography-notes.md
@@ -305,6 +305,18 @@ Status:
 - The next sequence starts with remaining bibliography blockers.
 - The paper remains not submission-ready.
 
+## Manuscript Bibliography Sync
+
+[KORA First Paper Manuscript Bibliography Sync v0.1](kora-first-paper-manuscript-bibliography-sync-v0-1.md) has been created.
+
+Status:
+
+- Manuscript v0.3 cited `[R02]`, which remains still-not-eligible and absent from preliminary BibTeX.
+- Manuscript v0.4 removes `[R02]` from background-only text and now cites only records present in preliminary BibTeX.
+- Preliminary BibTeX still has 16 entries.
+- Full BibTeX remains incomplete.
+- The paper remains not submission-ready.
+
 ## Claim Boundary
 
 No citation should be used to support unsupported production, API-cost, or energy claims.

--- a/docs/paper/kora-first-paper-manuscript-bibliography-sync-v0-1.md
+++ b/docs/paper/kora-first-paper-manuscript-bibliography-sync-v0-1.md
@@ -1,0 +1,112 @@
+# KORA First Paper Manuscript Bibliography Sync v0.1
+
+Sync date: 2026-05-13
+
+## Purpose
+
+This sync checks manuscript references against the current preliminary BibTeX state before preparing a submission-candidate manuscript draft. It does not complete full BibTeX and does not make the paper submission-ready.
+
+## Source Files Reviewed
+
+- `docs/paper/kora-first-paper-manuscript-v0-3.md`
+- `docs/paper/kora-first-paper-preliminary-bibtex-v0-1.md`
+- `docs/paper/kora-first-paper-final-bibliography-claim-audit-v0-1.md`
+- `docs/paper/kora-first-paper-submission-readiness-gate-v0-1.md`
+- `docs/paper/kora-first-paper-final-blocked-metadata-review-v0-1.md`
+- `docs/paper/kora-first-paper-citation-audit-v0-1.md`
+
+## Manuscript Version Reviewed
+
+- Reviewed manuscript: manuscript v0.3.
+- Submission-candidate draft created from it: manuscript v0.4.
+
+## Preliminary BibTeX State
+
+- Preliminary BibTeX entries count: 16.
+- Included ready records: `[R01]`, `[R06]`, `[R08]`, `[R11]`, `[R14]`, `[R21]`, `[R24]`.
+- Included expanded candidate records: `[R03]`, `[R04]`, `[R05]`, `[R07]`, `[R09]`, `[R10]`, `[R12]`, `[R13]`, `[R16]`.
+- Deferred records excluded: `[R17]`, `[R18]`.
+- Still-not-eligible records excluded: `[R02]`, `[R15]`, `[R19]`, `[R20]`, `[R22]`, `[R23]`.
+
+## Manuscript v0.3 Citation Scan
+
+Manuscript v0.3 cites:
+
+- `[R01]`
+- `[R02]`
+- `[R03]`
+- `[R04]`
+- `[R05]`
+- `[R06]`
+- `[R07]`
+- `[R08]`
+- `[R09]`
+- `[R10]`
+- `[R11]`
+- `[R12]`
+- `[R13]`
+
+Records cited in manuscript v0.3 and present in preliminary BibTeX:
+
+- `[R01]`, `[R03]`, `[R04]`, `[R05]`, `[R06]`, `[R07]`, `[R08]`, `[R09]`, `[R10]`, `[R11]`, `[R12]`, `[R13]`
+
+Records cited in manuscript v0.3 and missing from preliminary BibTeX:
+
+- `[R02]`
+
+Preliminary BibTeX records unused in manuscript v0.3:
+
+- `[R14]`, `[R16]`, `[R21]`, `[R24]`
+
+Deferred or still-not-eligible records used in manuscript v0.3:
+
+- `[R02]`
+
+No BibTeX citation keys are used directly in manuscript v0.3.
+
+## Mechanical Fixes Applied in Manuscript v0.4
+
+- Removed `[R02]` related-work sentence from the LLM serving and inference systems section.
+- Removed `[R02]` benchmark-methodology sentence from the benchmarking and artifact evaluation section.
+- Removed the `[R02]` entry from the preliminary references section.
+- Updated the manuscript version wording from v0.3 to v0.4 where the draft describes itself.
+- Added wording that v0.4 is a submission-candidate draft synchronized to the current preliminary BibTeX state.
+- Preserved the bounded 80% deterministic-heavy benchmark claim and all non-claim boundaries.
+
+## Manuscript v0.4 Citation Scan
+
+Manuscript v0.4 cites:
+
+- `[R01]`
+- `[R03]`
+- `[R04]`
+- `[R05]`
+- `[R06]`
+- `[R07]`
+- `[R08]`
+- `[R09]`
+- `[R10]`
+- `[R11]`
+- `[R12]`
+- `[R13]`
+
+All manuscript v0.4 citations are present in preliminary BibTeX.
+
+Preliminary BibTeX records unused in manuscript v0.4:
+
+- `[R14]`, `[R16]`, `[R21]`, `[R24]`
+
+Unused preliminary BibTeX records are not errors. They remain available for future manuscript integration or final bibliography decisions.
+
+## Unresolved Blockers
+
+- Full BibTeX remains incomplete.
+- `[R02]` remains still-not-eligible until author-list and venue/status handling is resolved.
+- `[R15]`, `[R19]`, `[R20]`, `[R22]`, and `[R23]` remain still-not-eligible.
+- `[R17]` and `[R18]` remain deferred.
+- Final citation style conversion from stable `[Rxx]` labels remains pending.
+- Final manuscript-to-final-BibTeX synchronization remains pending after full BibTeX decisions.
+
+## Status
+
+Manuscript v0.4 is synchronized with current preliminary BibTeX for cited records. Full BibTeX remains incomplete, and the paper remains not submission-ready.

--- a/docs/paper/kora-first-paper-manuscript-claim-to-evidence-audit-v0-1.md
+++ b/docs/paper/kora-first-paper-manuscript-claim-to-evidence-audit-v0-1.md
@@ -1,0 +1,94 @@
+# KORA First Paper Manuscript Claim-to-Evidence Audit v0.1
+
+Audit date: 2026-05-13
+
+## Purpose
+
+This audit checks manuscript claim safety while preparing manuscript v0.4 as a submission-candidate draft. It does not create production evidence, does not complete artifact approval, and does not make the paper submission-ready.
+
+## Source Files Reviewed
+
+- `docs/paper/kora-first-paper-manuscript-v0-3.md`
+- `docs/paper/kora-first-paper-manuscript-v0-4.md`
+- `docs/paper/kora-first-paper-claim-boundary.md`
+- `docs/paper/kora-first-paper-final-bibliography-claim-audit-v0-1.md`
+- `docs/paper/kora-first-paper-submission-readiness-gate-v0-1.md`
+- `docs/paper/kora-first-paper-evidence-summary.md`
+
+## Claim Categories Checked
+
+- production cost reduction proof
+- real API-cost reduction proof
+- production benchmark proof
+- full runtime-integrated real-provider benchmark evidence
+- broad workload superiority proof
+- energy reduction evidence
+- formal government validation
+- signed partner validation
+- guaranteed adoption or funding
+- formal artifact approval
+- paper submission readiness
+
+## Bounded Claim
+
+The bounded claim remains:
+
+> KORA reduced model invocations by 80% in a reproducible deterministic-heavy benchmark workload.
+
+## Evidence Path
+
+The bounded claim remains tied to:
+
+- the deterministic-heavy benchmark workload;
+- 100 total tasks;
+- 100 baseline model calls;
+- 20 KORA-controlled model calls;
+- 80 avoided simulated model invocations;
+- zero mismatches;
+- local public benchmark documentation and validation commands.
+
+The synthetic customer-support local/no-network validation remains evidence that KORA can measure avoided model-call events in synthetic workloads. It is not production evidence.
+
+## Unsafe Wording Found and Corrected
+
+No unsupported production, API-cost, energy, broad superiority, formal approval, or submission-readiness claim was found in manuscript v0.3.
+
+Mechanical tightening in manuscript v0.4:
+
+- The manuscript now states that v0.4 synchronizes references with the current preliminary BibTeX state.
+- `[R02]` background references were removed because `[R02]` remains still-not-eligible for preliminary BibTeX.
+- Limitations now state that full BibTeX remains incomplete.
+
+## Non-Claims That Must Remain
+
+The manuscript must continue to state or preserve:
+
+- no production cost proof;
+- no real API-cost proof;
+- no production benchmark proof;
+- no full runtime-integrated real-provider benchmark evidence;
+- no energy measurement;
+- no broad workload superiority claim;
+- no formal artifact evaluation or approval;
+- no production validation;
+- no superiority over cited systems.
+
+## Limitations That Must Stay in Manuscript
+
+- synthetic workloads;
+- limited workload diversity;
+- no production traffic;
+- no real provider validation;
+- no real API-cost proof;
+- no production benchmark proof;
+- no full runtime-integrated real-provider benchmark evidence;
+- no energy measurement;
+- no user study;
+- no broad workload superiority claim;
+- preliminary reference integration;
+- full BibTeX remains incomplete;
+- final citation style remains pending.
+
+## Status
+
+Manuscript v0.4 preserves the current claim boundary. The paper remains not submission-ready because bibliography, formatting/export, artifact/reproducibility, and final human-review blockers remain open.

--- a/docs/paper/kora-first-paper-manuscript-v0-4.md
+++ b/docs/paper/kora-first-paper-manuscript-v0-4.md
@@ -1,0 +1,237 @@
+# KORA: Deterministic-First Execution Control for AI Workloads
+
+## Abstract
+
+Model-first AI systems often call models too early: every request becomes a prompt even when the work is structured, deterministic, policy-driven, or validation-oriented. KORA introduces deterministic-first execution control, an execution-control layer placed before inference. Requests are represented as structured task paths, deterministic and structured routes are attempted first, validation checks confirm expected outcomes, and model escalation is used only when a request cannot be handled safely without inference. This manuscript v0.4 submission-candidate draft synchronizes manuscript references with the current preliminary BibTeX state while preserving claim boundaries. It evaluates KORA through the current public evidence: a reproducible deterministic-heavy benchmark and a synthetic customer-support local/no-network validation workload. In the deterministic-heavy benchmark, KORA-controlled execution avoided 80 of 100 simulated model invocations versus a naive direct baseline, with zero mismatches. The customer-support workload shows that KORA can measure avoided model-call events in synthetic local/no-network validation. These results support model invocation reduction and validation/reporting visibility in documented workloads. They are not production cost proof, real API-cost proof, energy evidence, production validation, or broad workload superiority evidence.
+
+## 1. Introduction
+
+Many AI systems treat every request as a model invocation. A request enters the application, the application builds a prompt, the model produces a response, and downstream logic validates or formats the result. This model-first pattern is easy to adopt, but it makes inference the default execution path even when the requested work does not require open-ended model reasoning.
+
+This default is unnecessary for many deterministic, structured, validation, policy, and routing tasks. Password reset instructions, policy lookups, report formatting, schema validation, routing decisions, and budget checks often have known rules or expected output properties. A model may still be needed for ambiguous, context-heavy, generative, or policy-sensitive cases, but those cases should be explicit escalations rather than the default for the entire workload.
+
+KORA inserts an execution-control layer before inference. Instead of treating the model as the first stop, KORA represents requests as task paths, attempts deterministic or structured handling when appropriate, validates the route outcome, records counters, and escalates only when deterministic handling is insufficient.
+
+Structure first. Inference second.
+
+This paper draft makes four contributions:
+
+- It defines KORA's deterministic-first execution-control model for routing AI work before inference.
+- It distinguishes KORA from related systems that optimize model serving, orchestrate workflows, structure agent execution, retrieve context, or provide local inference runtimes.
+- It reports the current reproducible deterministic-heavy benchmark result: an 80% model invocation reduction with zero mismatches in the documented workload.
+- It summarizes a synthetic customer-support local/no-network validation workload that measures avoided model-call events, deterministic routes, and model escalations without external providers, API keys, private data, or network calls.
+
+## 2. Background and Related Work
+
+KORA is related to model-serving systems, workflow orchestration systems, agent and programmatic AI frameworks, retrieval-augmented generation, local runtime systems, and artifact-evaluation practices. The relationship is complementary: KORA focuses on deciding whether inference is needed for a request before model invocation, while many related systems optimize or organize execution once a model, workflow, or retrieval path is already selected.
+
+### 2.1 LLM Serving and Inference Systems
+
+LLM serving systems optimize the execution of model inference. vLLM and PagedAttention address efficient memory management for large language model serving [R01]. ONNX Runtime provides an official inference runtime and optimization stack [R03].
+
+KORA does not claim to improve serving internals, scheduler design, batching, memory management, kernel performance, or model runtime efficiency. Those systems matter after a model invocation is needed. KORA focuses on the preceding control question: whether a request should reach inference at all.
+
+### 2.2 Workflow and DAG Orchestration
+
+Workflow systems such as Apache Airflow describe computation in DAG-oriented workflows [R07]. Snakemake provides a workflow-engine model for reproducible pipelines [R08]. These systems show the value of explicit execution structure, dependency ordering, and reproducible task paths.
+
+KORA borrows the discipline of explicit execution paths, but its scope is narrower and AI-specific. It applies task-path structure to model-call boundaries, deterministic route validation, model escalation, and aggregate counters. KORA is not a general-purpose workflow scheduler and does not claim to replace workflow or DAG systems.
+
+### 2.3 Agent/Tool Routing and Programmatic AI Workflows
+
+Graph-based and agent-oriented frameworks can coordinate state, tools, and execution graphs. LangGraph documents graph-based agent execution primitives [R04]. DSPy describes declarative language-model pipelines and programmatic composition around model calls [R05].
+
+Agentic and tool-using language model systems provide further context. ReAct combines reasoning traces with actions to let language models interact with external environments and tools [R11]. Toolformer studies how language models can learn to use external tools through a model-centered training procedure [R12]. These systems help frame the broader space of model-mediated reasoning, actions, and tool use.
+
+Program-aided language model workflows provide another adjacent pattern. PAL uses language models to generate programs that are executed by an interpreter, separating some reasoning work into executable program structure [R13]. This is relevant background for programmatic AI workflows, but it is not evidence for KORA's model-call avoidance result.
+
+KORA is adjacent to this space but emphasizes a different default. Agent and programmatic AI systems often organize model-centered workflows, generated programs, or tool-use behavior. KORA's central concern is deterministic-first execution control: using task structure, deterministic handlers, policy checks, and validation boundaries before deciding whether model inference is needed. KORA is complementary to these approaches: rather than teaching a model to reason through actions, use tools, or generate programs, KORA controls the execution path around the model and routes deterministic work before inference when possible. This paper does not claim that KORA replaces or outperforms agent frameworks, tool-use systems, or program-aided language model workflows.
+
+### 2.4 Retrieval-Augmented Generation
+
+Retrieval-augmented generation grounds model outputs by retrieving external knowledge before generation [R06]. RAG is useful when a model still needs to generate or reason with retrieved context.
+
+KORA is not a RAG replacement. RAG improves context selection for model use. KORA decides whether a task needs inference at all. A future system could use both: KORA could route deterministic work without inference and escalate retrieval-grounded questions to a RAG path when model reasoning is required.
+
+### 2.5 Local Model and Runtime Systems
+
+Local runtime systems make it possible to run inference locally. The llama.cpp project provides local LLM inference in C/C++ [R09]. ONNX Runtime is also relevant as an inference runtime [R03].
+
+This paper uses local/no-network validation for current public evidence, but it does not present local model runtime validation as complete. Local runtime references are included as future-work context only. KORA does not currently claim measured local model performance, local runtime superiority, or integration evidence from llama.cpp, ONNX Runtime, Ollama, or other local runtimes.
+
+### 2.6 Benchmarking and Artifact Evaluation
+
+Benchmark and artifact practices matter because KORA's current evidence depends on reproducible commands, synthetic workloads, aggregate counters, and explicit claim boundaries. ACM Artifact Review and Badging provides a public framework for artifact and reproducibility expectations [R10].
+
+KORA has not undergone formal artifact evaluation or external validation. This paper uses those references only to motivate transparent reporting: reproducible commands, clear workload boundaries, local/no-network labels, and explicit non-claims.
+
+## 3. KORA Execution Model
+
+KORA is an execution-control layer between request intake and model invocation. Its current public design uses a small set of concepts:
+
+- task graph: the structured representation of possible work paths
+- deterministic route: a path resolved through known logic, rules, templates, or validation checks
+- structured lookup: a path that maps to a known lookup or backend placeholder
+- policy/validation: checks that confirm the route and output properties are acceptable
+- model escalation: the boundary used when deterministic handling is not sufficient
+- telemetry/reporting: counters and reports that summarize route decisions and validation outcomes
+
+The high-level flow is:
+
+```text
+Request -> Task Graph -> Deterministic/Structured Route -> Validation -> Output
+                         -> Model Escalation -> Validation -> Output
+```
+
+KORA is not a claim that every task can be handled deterministically. It is a control layer for deciding which tasks should be handled deterministically and which tasks should escalate to inference.
+
+The direct baseline path sends every request to the model:
+
+```text
+request -> model -> output
+```
+
+The KORA-controlled path routes through execution control before inference:
+
+```text
+request -> task graph -> deterministic route or model escalation -> validation -> telemetry
+```
+
+An avoided model-call event occurs when the baseline would count a model call for a request, but the KORA-controlled path handles the request through a deterministic or structured route without model escalation.
+
+Current route classes include:
+
+- deterministic route: known logic, templates, rules, or validations handle the request
+- structured lookup: the request maps to a known structured handler or lookup placeholder
+- policy route: explicit policy logic or policy tables handle the request
+- `model_required` route: deterministic handling is not sufficient, so the request escalates
+
+The main metrics are:
+
+- `baseline_model_calls`: model-call events counted by the direct baseline path
+- `kora_model_calls`: model-call events counted by the KORA-controlled path
+- `avoided_model_calls`: `baseline_model_calls - kora_model_calls`
+- `avoided_model_call_rate`: `avoided_model_calls / baseline_model_calls`
+- `deterministic_routes`: requests handled through deterministic routing
+- `model_escalations`: requests escalated to the model-call path
+- `mismatch_count`: benchmark outputs that did not match expected results
+
+These metrics separate two questions: whether KORA reduced model-call events, and whether validation outcomes remained expected for the workload under test.
+
+## 4. Evaluation Methodology
+
+This manuscript v0.4 submission-candidate draft uses two current public workloads.
+
+The deterministic-heavy benchmark contains 100 tasks. The direct baseline counts one model call for each task. The KORA-controlled path routes deterministic work before inference and records model calls only for the remaining model-candidate routes. This benchmark is appropriate first evidence because it isolates the central hypothesis: deterministic-heavy workloads should not require a model call for every request.
+
+The synthetic customer-support triage workload contains 12 synthetic requests across deterministic FAQ, deterministic policy, structured lookup, and model-required route classes. It is evaluated through local/no-network validation. This means it uses synthetic data, deterministic local validation paths, aggregate counters, and no external providers, API keys, private data, network calls, raw provider responses, or production traffic.
+
+The workloads show different levels of evidence. The deterministic-heavy benchmark supports the current approved benchmark claim. The customer-support workload shows an application-shaped local/no-network validation path and demonstrates how KORA records avoided model-call events, deterministic routes, and model escalations. Neither workload proves production behavior, real provider behavior, real API-cost reduction, energy reduction, or broad workload superiority.
+
+## 5. Results
+
+### 5.1 Deterministic-heavy benchmark
+
+| Metric | Value |
+|---|---:|
+| Total tasks | 100 |
+| Baseline model calls | 100 |
+| KORA-controlled model calls | 20 |
+| Avoided model calls | 80 |
+| Avoided model-call rate | 80% |
+| Mismatches | 0 |
+
+This result supports the current approved public claim:
+
+> KORA reduced model invocations by 80% in a reproducible deterministic-heavy benchmark workload.
+
+The interpretation is intentionally narrow. In this benchmark, KORA-controlled execution avoided 80 of 100 simulated model invocations versus a naive direct baseline while preserving expected benchmark outputs with zero mismatches. This is benchmark evidence for the documented deterministic-heavy workload. It is not production evidence, not real provider validation, and not a cost or energy claim.
+
+### 5.2 Customer-support triage synthetic workload
+
+| Metric | Value |
+|---|---:|
+| Total requests | 12 |
+| Baseline model calls | 12 |
+| KORA-controlled model calls | 4 |
+| Avoided model calls | 8 |
+| Avoided model-call rate | 66.67% |
+| Deterministic routes | 8 |
+| Model escalations | 4 |
+
+This is local/no-network validation only and not real provider validation. The workload uses synthetic customer-support requests to exercise deterministic FAQ, policy, structured lookup, and model-required route classes. The current example shows that KORA can measure avoided model-call events in a synthetic application-shaped workload without API keys, external providers, private data, or network calls.
+
+### 5.3 Latency direction
+
+This manuscript does not include measured latency evidence yet. The expected direction is route-dependent:
+
+- deterministic fast paths can reduce latency by avoiding inference
+- structured lookup and policy routes can avoid model wait time when validation succeeds
+- model escalation paths may add orchestration overhead before inference
+
+Measured p50/p95 latency remains future work. Until those measurements exist, KORA should not be described as universally faster across all workloads.
+
+## 6. Limitations
+
+Current limitations include:
+
+- synthetic workloads
+- limited workload diversity
+- no production traffic
+- no real provider validation
+- no real API-cost proof
+- no production benchmark proof
+- no full runtime-integrated real-provider benchmark evidence
+- no energy measurement
+- no user study
+- no broad workload superiority claim
+- preliminary reference integration only
+- full BibTeX remains incomplete
+- final citation style still pending
+
+The deterministic-heavy benchmark and customer-support triage workload are useful early evidence, but they are not sufficient for production, cost, energy, or broad generalization claims. They show that KORA can reduce model-call events in documented deterministic-heavy and synthetic local/no-network validation contexts.
+
+The related-work references integrated in this draft provide background and positioning. They do not prove KORA's claims, do not establish superiority over cited systems, and do not replace final bibliography review.
+
+## 7. Reproducibility and Artifact Notes
+
+KORA's current public evidence is organized around reproducible commands, local/no-network examples, aggregate counters, and claim-safe reports. This aligns with systems-paper artifact discipline but does not constitute formal artifact evaluation. ACM artifact review and badging guidance is cited only as a reference point for transparent artifact practices [R10].
+
+Current reproduction expectations for this draft are:
+
+- run the deterministic-heavy benchmark in offline mode
+- run the customer-support triage local/no-network validation example
+- inspect aggregate counters and claim-boundary text
+- avoid committing generated raw reports unless explicitly selected for review
+- keep raw provider responses, credentials, private data, and production traffic out of public artifacts
+
+The paper still needs a final clean command transcript, final bibliography normalization, final figure/table review, and a final claim audit before submission.
+
+## 8. Conclusion
+
+Model-first execution is not always necessary. Many AI workloads include structured, deterministic, policy-driven, or validation-oriented tasks that can be routed before inference.
+
+KORA introduces deterministic-first execution control: it represents requests as structured task paths, attempts deterministic handling before inference, validates route outcomes, records counters, and escalates to a model only when needed. Current evidence shows model invocation reduction in a reproducible deterministic-heavy benchmark and measurable avoided model-call events in a synthetic customer-support local/no-network validation workload.
+
+KORA is complementary to model serving systems, workflow orchestrators, agent frameworks, RAG systems, and local runtimes. Future work should expand runtime validation, latency measurement, local model evaluation, real provider experiments, and visualization without weakening claim boundaries.
+
+## References
+
+This preliminary references section uses manuscript-cited records that are currently present in preliminary BibTeX. Citation style and BibTeX are not final. See [KORA First Paper Manuscript Bibliography Sync v0.1](kora-first-paper-manuscript-bibliography-sync-v0-1.md) and [KORA First Paper Citation Audit v0.1](kora-first-paper-citation-audit-v0-1.md) for citation consistency, traceability, and claim-boundary notes.
+
+- [R01] Woosuk Kwon, Zhuohan Li, Siyuan Zhuang, Ying Sheng, Lianmin Zheng, Cody Hao Yu, Joseph E. Gonzalez, Hao Zhang, and Ion Stoica. "Efficient Memory Management for Large Language Model Serving with PagedAttention." SOSP 2023; arXiv:2309.06180. Source: https://arxiv.org/abs/2309.06180; https://doi.org/10.48550/arXiv.2309.06180
+- [R03] ONNX Runtime project. "ONNX Runtime" official documentation. Source owner: ONNX Runtime project / Microsoft. Date unavailable; accessed 2026-05-11. Source: https://onnxruntime.ai/docs/
+- [R04] LangChain. "LangGraph Graph API overview." Official LangGraph documentation. Date unavailable; accessed 2026-05-11. Source: https://docs.langchain.com/oss/python/langgraph/graph-api
+- [R05] Omar Khattab, Arnav Singhvi, Paridhi Maheshwari, Zhiyuan Zhang, Keshav Santhanam, Sri Vardhamanan, Saiful Haq, Ashutosh Sharma, Thomas T. Joshi, Hanna Moazam, Heather Miller, Matei Zaharia, and Christopher Potts. "DSPy: Compiling Declarative Language Model Calls into Self-Improving Pipelines." arXiv:2310.03714, 2023. Source: https://arxiv.org/abs/2310.03714
+- [R06] Patrick Lewis, Ethan Perez, Aleksandra Piktus, Fabio Petroni, Vladimir Karpukhin, Naman Goyal, Heinrich Kuttler, Mike Lewis, Wen-tau Yih, Tim Rocktaschel, Sebastian Riedel, and Douwe Kiela. "Retrieval-Augmented Generation for Knowledge-Intensive NLP Tasks." NeurIPS 2020; arXiv:2005.11401. Source: https://arxiv.org/abs/2005.11401; https://doi.org/10.48550/arXiv.2005.11401
+- [R07] Apache Airflow project. "Dags." Apache Airflow 3.2.1 documentation. Source owner: Apache Software Foundation. Date unavailable; accessed 2026-05-11. Source: https://airflow.apache.org/docs/apache-airflow/stable/core-concepts/dags.html
+- [R08] Johannes Koster and Sven Rahmann. "Snakemake-a scalable bioinformatics workflow engine." Bioinformatics 28(19), 2520-2522, 2012. Source: https://doi.org/10.1093/bioinformatics/bts480
+- [R09] ggml-org. "llama.cpp: LLM inference in C/C++." Official GitHub repository. Date unavailable; accessed 2026-05-11. Source: https://github.com/ggml-org/llama.cpp
+- [R10] Association for Computing Machinery. "Artifact Review and Badging - Current." Version 1.1, 2020. Source: https://www.acm.org/publications/policies/artifact-review-and-badging-current
+- [R11] Shunyu Yao, Jeffrey Zhao, Dian Yu, Nan Du, Izhak Shafran, Karthik Narasimhan, and Yuan Cao. "ReAct: Synergizing Reasoning and Acting in Language Models." ICLR 2023; arXiv:2210.03629. Source: https://arxiv.org/abs/2210.03629; https://doi.org/10.48550/arXiv.2210.03629
+- [R12] Timo Schick, Jane Dwivedi-Yu, Roberto Dessi, Roberta Raileanu, Maria Lomeli, Luke Zettlemoyer, Nicola Cancedda, and Thomas Scialom. "Toolformer: Language Models Can Teach Themselves to Use Tools." arXiv:2302.04761, 2023. Source: https://arxiv.org/abs/2302.04761; https://doi.org/10.48550/arXiv.2302.04761
+- [R13] Luyu Gao, Aman Madaan, Shuyan Zhou, Uri Alon, Pengfei Liu, Yiming Yang, Jamie Callan, and Graham Neubig. "PAL: Program-aided Language Models." arXiv:2211.10435, 2022; revised 2023. Source: https://arxiv.org/abs/2211.10435; https://doi.org/10.48550/arXiv.2211.10435
+
+## Claim Boundary Note
+
+This manuscript draft is based on reproducible benchmark and local/no-network validation evidence. It does not claim production cost reduction, real API-cost reduction, energy reduction, production validation, broad workload superiority, formal artifact evaluation, or superiority over cited systems.

--- a/docs/paper/kora-first-paper-missing-evidence-checklist.md
+++ b/docs/paper/kora-first-paper-missing-evidence-checklist.md
@@ -111,6 +111,8 @@ Citation style decision:
 - Final bibliography and claim audit v0.1 has been created.
 - Expanded BibTeX remains preliminary, and full BibTeX is still incomplete until deferred and still-not-eligible records are resolved.
 - Submission readiness gate v0.1 has been created to separate required blockers from optional improvements.
+- Manuscript v0.4 submission-candidate draft has been created with current preliminary BibTeX citation synchronization.
+- Manuscript bibliography sync v0.1, manuscript claim-to-evidence audit v0.1, and submission-candidate status v0.1 have been created.
 - Paper is still not submission-ready.
 
 ## Follow-Up Papers / Technical Reports

--- a/docs/paper/kora-first-paper-reference-plan.md
+++ b/docs/paper/kora-first-paper-reference-plan.md
@@ -404,6 +404,17 @@ Status:
 - Bibliography blockers remain the first recommended sequence item.
 - The paper remains not submission-ready.
 
+## Manuscript Submission-Candidate Batch Status
+
+[KORA First Paper Manuscript Bibliography Sync v0.1](kora-first-paper-manuscript-bibliography-sync-v0-1.md), [KORA First Paper Manuscript Claim-to-Evidence Audit v0.1](kora-first-paper-manuscript-claim-to-evidence-audit-v0-1.md), and [KORA First Paper Submission-Candidate Status v0.1](kora-first-paper-submission-candidate-status-v0-1.md) have been created.
+
+Status:
+
+- Manuscript v0.4 has been created as a submission-candidate draft.
+- Manuscript v0.4 cites only records currently present in preliminary BibTeX.
+- The bounded 80% deterministic-heavy benchmark claim remains unchanged.
+- Full BibTeX remains incomplete, and the paper remains not submission-ready.
+
 ## Next Verification Procedure
 
 1. Search official sources first.

--- a/docs/paper/kora-first-paper-submission-candidate-status-v0-1.md
+++ b/docs/paper/kora-first-paper-submission-candidate-status-v0-1.md
@@ -1,0 +1,60 @@
+# KORA First Paper Submission-Candidate Status v0.1
+
+Status date: 2026-05-13
+
+## Purpose
+
+This status note records the bundled manuscript synchronization and claim-to-evidence pass that produced manuscript v0.4 as a submission-candidate draft. It does not mark the paper as submission-ready.
+
+## Manuscript v0.4
+
+Manuscript v0.4 was created:
+
+- `docs/paper/kora-first-paper-manuscript-v0-4.md`
+
+v0.4 is a submission-candidate draft, not a final submission package.
+
+## What Was Synchronized
+
+- Manuscript citations were compared against preliminary BibTeX v0.1.
+- Manuscript v0.3 cited `[R02]`, which remains still-not-eligible and absent from preliminary BibTeX.
+- Manuscript v0.4 removes `[R02]` from background-only text and the preliminary references section.
+- Manuscript v0.4 now cites only records currently present in preliminary BibTeX.
+- Preliminary BibTeX still has 16 entries.
+- Unused preliminary BibTeX entries remain `[R14]`, `[R16]`, `[R21]`, and `[R24]`.
+
+## Claim Wording
+
+The bounded claim is preserved:
+
+> KORA reduced model invocations by 80% in a reproducible deterministic-heavy benchmark workload.
+
+No production, API-cost, energy, broad superiority, formal approval, or submission-readiness claim was added.
+
+## Remaining Required Blockers
+
+- Full BibTeX remains incomplete.
+- `[R02]`, `[R15]`, `[R19]`, `[R20]`, `[R22]`, and `[R23]` remain still-not-eligible.
+- `[R17]` and `[R18]` remain deferred.
+- Final citation style conversion and final bibliography formatting remain pending.
+- Final manuscript-to-final-BibTeX synchronization remains pending.
+- Final claim-to-evidence audit must be repeated after any future manuscript or bibliography changes.
+- Final figures and tables are not locked.
+- Final export package is not prepared.
+- Clean reproduction transcript and artifact package review remain pending.
+- Final human review remains pending.
+
+## User Approval Still Needed
+
+- Target venue or target package format.
+- Whether `[R17]` and `[R18]` should be included or excluded once venue direction is known.
+- Whether benchmark-methodology records `[R19]` through `[R24]` should be integrated into the manuscript methodology section.
+- Whether optional workload, latency, API-cost, production-traffic, or energy work stays out of the first submission scope.
+
+## Target Venue, Export, and Package Decisions
+
+No target venue was selected in this pass. The draft remains venue-neutral. Export/package preparation should wait until bibliography scope and target format are stable.
+
+## Status
+
+The manuscript has advanced to v0.4 submission-candidate draft status. Full BibTeX remains incomplete, and the paper remains not submission-ready.

--- a/docs/paper/kora-first-paper-submission-readiness.md
+++ b/docs/paper/kora-first-paper-submission-readiness.md
@@ -2,9 +2,9 @@
 
 ## Current Status
 
-Manuscript v0.3 exists but is not submission-ready.
+Manuscript v0.4 submission-candidate draft exists but is not submission-ready.
 
-The current paper track has a thesis, manuscript v0.3, claim-boundary docs, reviewer questions, evidence summaries, and local/no-network validation context. It still needs final bibliography normalization, final figures, finalized tables, and a clean reproduction transcript before arXiv or workshop-style release.
+The current paper track has a thesis, manuscript v0.4 submission-candidate draft, claim-boundary docs, reviewer questions, evidence summaries, and local/no-network validation context. It still needs final bibliography normalization, final figures, finalized tables, and a clean reproduction transcript before arXiv or workshop-style release.
 
 The reference scaffold now exists, and the first verified reference pass has collected 10 citation candidates across the major related-work categories. Manuscript v0.2 integrates those verified references as preliminary citation labels. No fake citations or unverified BibTeX entries have been added.
 
@@ -44,12 +44,15 @@ Final bibliography and claim audit v0.1 exists. It confirms that preliminary Bib
 
 Submission readiness gate v0.1 exists. It records required and optional blockers before any submission package and confirms the paper remains not submission-ready.
 
+Manuscript v0.4 submission-candidate draft exists. It synchronizes manuscript citations with current preliminary BibTeX by removing still-not-eligible `[R02]` from background-only manuscript text. Full BibTeX remains incomplete, and the paper remains not submission-ready.
+
 ## Ready
 
 - Thesis.
 - Initial manuscript skeleton.
 - Manuscript v0.2 with first verified reference integration.
 - Manuscript v0.3 with selected [R11] through [R13] integration.
+- Manuscript v0.4 submission-candidate draft with current preliminary BibTeX citation synchronization.
 - Deterministic-heavy benchmark evidence.
 - Customer-support local/no-network validation evidence.
 - Claim boundary docs.
@@ -74,6 +77,9 @@ Submission readiness gate v0.1 exists. It records required and optional blockers
 - Expanded preliminary BibTeX candidate audit v0.1.
 - Final bibliography and claim audit v0.1.
 - Submission readiness gate v0.1.
+- Manuscript bibliography sync v0.1.
+- Manuscript claim-to-evidence audit v0.1.
+- Submission-candidate status v0.1.
 - Citation audit v0.1.
 - Manuscript v0.3 reference integration plan.
 
@@ -112,6 +118,6 @@ These are suggested formats only. This document does not claim acceptance, endor
 
 ## Reference Status
 
-The first verified reference pass is complete, manuscript v0.2 integrates the first-pass verified references as preliminary citation labels and a preliminary references section, citation audit v0.1 exists, additional reference verification pass 2 has added 8 verified tracker entries, manuscript v0.3 integrates [R11], [R12], and [R13] as preliminary related-work references, the benchmark-construction reference pass has added [R19] through [R24] as tracker/audit entries, the working citation style decision selects stable [Rxx] labels, metadata audit v0.1 exists, normalized bibliography v0.1 exists, metadata gap resolution v0.1 exists, preliminary BibTeX v0.1 exists for ready records, ready-subset BibTeX keys are normalized, expanded preliminary BibTeX exists for the candidate subset that passed final field check, final bibliography and claim audit v0.1 exists, and submission readiness gate v0.1 exists. The paper is still not submission-ready because [R17] and [R18] remain deferred, [R02], [R15], [R19], [R20], [R22], and [R23] remain excluded from BibTeX, [R19] through [R24] are not yet integrated into manuscript methodology, more direct deterministic-heavy synthetic workload references may still be needed, production benchmark evidence is still not available, final bibliography entries are not complete, and submission-package blockers remain unresolved.
+The first verified reference pass is complete, manuscript v0.2 integrates the first-pass verified references as preliminary citation labels and a preliminary references section, citation audit v0.1 exists, additional reference verification pass 2 has added 8 verified tracker entries, manuscript v0.3 integrates [R11], [R12], and [R13] as preliminary related-work references, manuscript v0.4 exists as a submission-candidate draft synchronized to current preliminary BibTeX citations, the benchmark-construction reference pass has added [R19] through [R24] as tracker/audit entries, the working citation style decision selects stable [Rxx] labels, metadata audit v0.1 exists, normalized bibliography v0.1 exists, metadata gap resolution v0.1 exists, preliminary BibTeX v0.1 exists for ready records, ready-subset BibTeX keys are normalized, expanded preliminary BibTeX exists for the candidate subset that passed final field check, final bibliography and claim audit v0.1 exists, and submission readiness gate v0.1 exists. The paper is still not submission-ready because [R17] and [R18] remain deferred, [R02], [R15], [R19], [R20], [R22], and [R23] remain excluded from BibTeX, [R19] through [R24] are not yet integrated into manuscript methodology, more direct deterministic-heavy synthetic workload references may still be needed, production benchmark evidence is still not available, final bibliography entries are not complete, and submission-package blockers remain unresolved.
 
 No fake citations were added. Future citation work should use only verified tracker entries and should not support production, API-cost, energy, production-validation, broad superiority, or cited-system superiority claims.


### PR DESCRIPTION
## Summary
- Creates manuscript v0.4 as a submission-candidate draft, not a submission-ready paper.
- Adds manuscript/BibTeX sync, claim-to-evidence audit, and submission-candidate status artifacts.
- Updates Paper Track status docs to reference the batch.

## Files changed
- docs/paper/kora-first-paper-manuscript-v0-4.md
- docs/paper/kora-first-paper-manuscript-bibliography-sync-v0-1.md
- docs/paper/kora-first-paper-manuscript-claim-to-evidence-audit-v0-1.md
- docs/paper/kora-first-paper-submission-candidate-status-v0-1.md
- docs/paper/kora-first-paper-submission-readiness.md
- docs/paper/kora-first-paper-bibliography-notes.md
- docs/paper/kora-first-paper-reference-plan.md
- docs/paper/kora-first-paper-missing-evidence-checklist.md

## Citation / BibTeX sync
- Manuscript v0.3 cited [R02], which remains still-not-eligible and absent from preliminary BibTeX.
- Manuscript v0.4 removes [R02] from background-only text and now cites only records present in preliminary BibTeX.
- Preliminary BibTeX remains at 16 entries and excludes deferred/still-not-eligible records.
- Full BibTeX remains incomplete.

## Claim-to-evidence result
- Preserves the bounded claim: KORA reduced model invocations by 80% in a reproducible deterministic-heavy benchmark workload.
- Adds no production, API-cost, energy, broad superiority, formal approval, or submission-readiness claims.

## Remaining blockers
- Resolve deferred/still-not-eligible bibliography records or final exclusion policy.
- Final citation style, final bibliography formatting, and manuscript-to-final-BibTeX sync.
- Target venue/export package decisions.
- Clean reproduction transcript, artifact package review, final figures/tables, and final human review.

## Validation
- git diff --check: passed
- python3 -m pytest: 159 passed
- Unicode scan over changed files: clean
- Manuscript v0.4 citation/BibTeX check: no missing cited records
- Preliminary BibTeX exclusion check: 16 entries, no deferred/still-not-eligible entries
- Targeted internal/claim text scan: only expected non-claim/status language found

Paper remains not submission-ready.