### PR TITLE
docs: add paper submission package readiness packet

### DIFF
--- a/docs/paper/kora-first-paper-artifact-package-inventory-v0-1.md
+++ b/docs/paper/kora-first-paper-artifact-package-inventory-v0-1.md
@@ -1,0 +1,80 @@
+# KORA First Paper Artifact Package Inventory v0.1
+
+Status date: 2026-05-13
+
+## Purpose
+
+This inventory lists repository-tracked materials that may support a future paper submission package. It does not create a package, upload artifacts, or claim formal artifact approval.
+
+## Tracked Paper Files
+
+- `docs/paper/kora-first-paper-manuscript-v0-4.md`
+- `docs/paper/kora-first-paper-manuscript-bibliography-sync-v0-1.md`
+- `docs/paper/kora-first-paper-manuscript-claim-to-evidence-audit-v0-1.md`
+- `docs/paper/kora-first-paper-submission-candidate-status-v0-1.md`
+- `docs/paper/kora-first-paper-submission-readiness-gate-v0-1.md`
+- `docs/paper/kora-first-paper-final-bibliography-claim-audit-v0-1.md`
+- `docs/paper/kora-first-paper-preliminary-bibtex-v0-1.md`
+- `docs/paper/kora-first-paper-figures-and-tables.md`
+- `docs/paper/kora-first-paper-figure-specs.md`
+- `docs/paper/kora-first-paper-table-specs.md`
+- `docs/paper/kora-first-paper-evidence-summary.md`
+
+## Tracked Runtime and Evidence Docs
+
+- `docs/reports/v0.3.0-alpha-runtime-evidence-reviewer-guide.md`
+- `docs/reports/benchmark_artifact_policy.md`
+- `docs/reports/v0.3.0-alpha-docs-claim-audit.md`
+- `docs/reports/v0.3.0-alpha-release-validation-packet.md`
+
+## Tracked Code, Workloads, and Examples
+
+- `kora/`
+- `tests/`
+- `examples/runtime_integrated_benchmark/run.py`
+- `examples/runtime_integrated_benchmark/report.py`
+- `examples/customer_support_triage_fake_validation/run.py`
+- `examples/direct_vs_kora/run.py`
+- `experiments/generate_workload.py`
+- `experiments/run_benchmark.py`
+- `experiments/summarize_benchmark_results.py`
+- `experiments/workloads/deterministic_heavy_v1_100.json`
+- `experiments/workloads/customer_support_triage_synthetic_v1.json`
+
+## Tracked Benchmark or Report Artifacts
+
+- The repository includes reviewer-safe documentation and sample inputs.
+- The repository does not need raw temporary benchmark JSON outputs for this packet.
+- Any generated benchmark or telemetry output should be reviewed before public inclusion.
+
+## Included In Repository
+
+- Source code needed to run local KORA examples.
+- Offline examples and tests.
+- Deterministic-heavy workload files.
+- Paper draft and audit docs.
+- Claim-boundary, bibliography, and submission-readiness docs.
+- Repository license file.
+
+## Deliberately Not Included
+
+- Raw provider responses.
+- API keys or provider credentials.
+- Production traffic.
+- Private user data.
+- Proprietary datasets.
+- Raw benchmark artifacts generated in temporary directories.
+- Release assets or packaged submission uploads.
+
+## Remaining Package Work
+
+- Select exact artifact bundle after venue/export direction is known.
+- Capture a clean reproduction transcript on the final package commit.
+- Finalize figures, tables, captions, and manuscript export.
+- Finalize bibliography and citation format.
+- Prepare artifact availability statement.
+- Review license, author, affiliation, acknowledgement, funding, conflict, and ethics metadata.
+
+## Claim Boundary
+
+This inventory supports reproducibility planning only. It does not support production cost reduction proof, real API-cost reduction proof, production benchmark proof, broad workload superiority, energy reduction evidence, formal government validation, signed partner validation, guaranteed adoption or funding, or formal artifact approval.

--- a/docs/paper/kora-first-paper-final-human-review-packet-v0-1.md
+++ b/docs/paper/kora-first-paper-final-human-review-packet-v0-1.md
@@ -1,0 +1,65 @@
+# KORA First Paper Final Human Review Packet v0.1
+
+Status date: 2026-05-13
+
+## Purpose
+
+This packet lists the human decisions still required before any submission-ready decision. It does not answer those decisions and does not mark the paper as submission-ready.
+
+## Source Files Reviewed
+
+- `docs/paper/kora-first-paper-manuscript-v0-4.md`
+- `docs/paper/kora-first-paper-submission-package-readiness-v0-1.md`
+- `docs/paper/kora-first-paper-submission-candidate-status-v0-1.md`
+- `docs/paper/kora-first-paper-final-bibliography-claim-audit-v0-1.md`
+- `docs/paper/kora-first-paper-submission-readiness-gate-v0-1.md`
+- `docs/paper/kora-first-paper-manuscript-claim-to-evidence-audit-v0-1.md`
+- `docs/paper/kora-first-paper-manuscript-bibliography-sync-v0-1.md`
+- `docs/paper/kora-first-paper-preliminary-bibtex-v0-1.md`
+
+## Review Checklist
+
+| Review item | Human decision needed | Current status |
+|---|---|---|
+| Title and abstract | Approve final wording or request edits | Pending |
+| Claim boundary | Approve the bounded deterministic-heavy benchmark claim | Pending |
+| Bibliography scope | Approve which records remain in or out of the first submission scope | Pending |
+| Limitations | Approve limitations and non-claim language | Pending |
+| Artifact and reproducibility | Approve artifact package scope and reproduction transcript expectations | Pending |
+| Figures and tables | Approve final rendered figures, tables, captions, and numbering | Pending |
+| Author and affiliation metadata | Approve final author block and affiliations | Pending |
+| Acknowledgement, funding, conflict, and ethics metadata | Approve any required disclosure text | Pending |
+| Target venue and export format | Choose venue, template, or venue-neutral preprint route | Pending |
+| Final submission-ready decision | Decide whether the exact final package is ready to submit | Pending |
+
+## Bibliography Scope Decisions
+
+- Decide whether `[R17]` and `[R18]` remain excluded from the first submission or are resolved for inclusion later.
+- Decide whether `[R19]` through `[R24]` remain tracker/audit-only methodology references for the first submission.
+- Decide whether deferred and still-not-eligible records should remain excluded from preliminary BibTeX until a later bibliography pass.
+- Confirm that no missing metadata should be filled without source-backed verification.
+
+## Evidence Scope Decisions
+
+- Decide whether optional expanded workload evidence stays outside the first submission scope.
+- Decide whether latency p50/p95 evidence stays outside the first submission scope.
+- Decide whether API-cost, production-traffic, energy, and real customer-data studies stay outside the first submission scope.
+- Decide whether KORA Studio discussion remains outside the first submission scope.
+
+## Venue and Export Decisions
+
+- Decide whether to proceed with a venue-neutral preprint style or select a specific venue.
+- If a venue is selected, approve template, page limit, citation style, artifact appendix expectations, and disclosure requirements.
+- Approve whether export preparation should wait until full BibTeX and final figures/tables are complete.
+
+## Claim Boundary Reminder
+
+The current safe claim is:
+
+> KORA reduced model invocations by 80% in a reproducible deterministic-heavy benchmark workload.
+
+This packet does not approve stronger claims about production cost reduction, real API-cost reduction, production benchmark proof, broad workload superiority, energy reduction evidence, formal government validation, signed partner validation, guaranteed adoption or funding, or formal artifact approval.
+
+## Signoff Status
+
+No final human signoff is recorded in this document. The paper remains not submission-ready until the pending decisions above are explicitly resolved and the exact final package is reviewed.

--- a/docs/paper/kora-first-paper-missing-evidence-checklist.md
+++ b/docs/paper/kora-first-paper-missing-evidence-checklist.md
@@ -113,6 +113,8 @@ Citation style decision:
 - Submission readiness gate v0.1 has been created to separate required blockers from optional improvements.
 - Manuscript v0.4 submission-candidate draft has been created with current preliminary BibTeX citation synchronization.
 - Manuscript bibliography sync v0.1, manuscript claim-to-evidence audit v0.1, and submission-candidate status v0.1 have been created.
+- Submission package readiness v0.1, final human review packet v0.1, reproduction transcript checklist v0.1, and artifact package inventory v0.1 have been created.
+- Clean reproduction transcript capture, final artifact package review, final venue/export decision, and final human review remain pending.
 - Paper is still not submission-ready.
 
 ## Follow-Up Papers / Technical Reports

--- a/docs/paper/kora-first-paper-reference-plan.md
+++ b/docs/paper/kora-first-paper-reference-plan.md
@@ -415,6 +415,18 @@ Status:
 - The bounded 80% deterministic-heavy benchmark claim remains unchanged.
 - Full BibTeX remains incomplete, and the paper remains not submission-ready.
 
+## Submission Package Readiness Packet Status
+
+[KORA First Paper Submission Package Readiness v0.1](kora-first-paper-submission-package-readiness-v0-1.md), [KORA First Paper Final Human Review Packet v0.1](kora-first-paper-final-human-review-packet-v0-1.md), [KORA First Paper Reproduction Transcript Checklist v0.1](kora-first-paper-reproduction-transcript-checklist-v0-1.md), and [KORA First Paper Artifact Package Inventory v0.1](kora-first-paper-artifact-package-inventory-v0-1.md) have been created.
+
+Status:
+
+- Venue-neutral package blockers are now organized by component, severity, and decision owner.
+- Final human review decisions are listed but not answered.
+- Reproduction transcript commands are drafted from existing repository-documented commands only.
+- Artifact package inventory identifies tracked materials and deliberately excluded raw/private artifacts.
+- Full BibTeX remains incomplete, venue/export decisions remain user-owned, and the paper remains not submission-ready.
+
 ## Next Verification Procedure
 
 1. Search official sources first.

--- a/docs/paper/kora-first-paper-reproduction-transcript-checklist-v0-1.md
+++ b/docs/paper/kora-first-paper-reproduction-transcript-checklist-v0-1.md
@@ -1,0 +1,78 @@
+# KORA First Paper Reproduction Transcript Checklist v0.1
+
+Status date: 2026-05-13
+
+## Purpose
+
+This checklist drafts the commands and evidence expectations for a future clean reproduction transcript. It uses existing repository commands and docs only. It does not create a final transcript and does not mark the paper as submission-ready.
+
+## Source Files Reviewed
+
+- `README.md`
+- `docs/reports/v0.3.0-alpha-runtime-evidence-reviewer-guide.md`
+- `docs/reports/benchmark_artifact_policy.md`
+- `docs/paper/kora-first-paper-evidence-summary.md`
+- `docs/paper/kora-first-paper-submission-candidate-status-v0-1.md`
+
+## Baseline Validation Commands
+
+Run these from a clean checkout after installing the project in a local environment:
+
+```bash
+git diff --check
+python3 -m pytest
+python3 -m kora --help
+python3 -m kora examples list
+```
+
+Expected output type:
+
+- `git diff --check` should complete without whitespace errors.
+- `python3 -m pytest` should complete with the test suite passing.
+- CLI help and examples listing should print normal command/help output.
+
+## Offline Example Commands
+
+```bash
+python3 -m kora run direct_vs_kora -- --offline
+python3 -m kora run customer_support_triage_fake_validation -- --offline
+python3 -m kora run runtime_integrated_benchmark -- --offline
+```
+
+Expected output type:
+
+- Each command should run locally without provider credentials.
+- The runtime-integrated benchmark should report deterministic-heavy workload evidence consistent with the current paper claim boundary.
+- The customer-support validation remains local/no-network validation evidence, not production evidence.
+
+## Optional Runtime Evidence Commands
+
+The runtime evidence reviewer guide documents optional local report generation commands using temporary output paths:
+
+```bash
+python3 -m kora run runtime_integrated_benchmark -- --offline --json-out /tmp/kora_runtime_integrated_benchmark.json
+python3 examples/runtime_integrated_benchmark/report.py --input /tmp/kora_runtime_integrated_benchmark.json --md-out /tmp/kora_runtime_integrated_benchmark.md
+python3 -m kora telemetry --input /tmp/kora_runtime_integrated_benchmark.json --json-out /tmp/kora_runtime_integrated_telemetry.json --md-out /tmp/kora_runtime_integrated_telemetry.md
+```
+
+Expected output type:
+
+- JSON and Markdown outputs should be generated at the requested temporary paths.
+- Any final transcript should summarize command success and reviewer-safe metrics.
+- Raw generated outputs should be reviewed before inclusion in any submission package.
+
+## Raw Artifact Policy Reminder
+
+- Do not upload raw benchmark artifacts by default.
+- Do not commit temporary JSON, Markdown, telemetry, provider-response, or local transcript files unless they are explicitly reviewed and selected for public inclusion.
+- Do not include secrets, API keys, private user data, production traffic, raw provider responses, or proprietary datasets.
+- Use reviewer-safe summaries and tracked docs where possible.
+
+## Transcript Limitations
+
+- This checklist is not a completed reproduction transcript.
+- These commands do not provide production benchmark proof.
+- These commands do not provide real API-cost reduction proof.
+- These commands do not provide energy reduction evidence.
+- These commands do not constitute formal artifact approval.
+- Final transcript capture should be repeated on the exact commit intended for a submission package.

--- a/docs/paper/kora-first-paper-submission-candidate-status-v0-1.md
+++ b/docs/paper/kora-first-paper-submission-candidate-status-v0-1.md
@@ -55,6 +55,17 @@ No production, API-cost, energy, broad superiority, formal approval, or submissi
 
 No target venue was selected in this pass. The draft remains venue-neutral. Export/package preparation should wait until bibliography scope and target format are stable.
 
+## Submission Package Packet
+
+The venue-neutral submission package readiness packet now exists:
+
+- `docs/paper/kora-first-paper-submission-package-readiness-v0-1.md`
+- `docs/paper/kora-first-paper-final-human-review-packet-v0-1.md`
+- `docs/paper/kora-first-paper-reproduction-transcript-checklist-v0-1.md`
+- `docs/paper/kora-first-paper-artifact-package-inventory-v0-1.md`
+
+These files organize package blockers, human review decisions, reproduction transcript expectations, and artifact inventory. They do not select a venue, finalize an export package, or mark the paper as submission-ready.
+
 ## Status
 
 The manuscript has advanced to v0.4 submission-candidate draft status. Full BibTeX remains incomplete, and the paper remains not submission-ready.

--- a/docs/paper/kora-first-paper-submission-package-readiness-v0-1.md
+++ b/docs/paper/kora-first-paper-submission-package-readiness-v0-1.md
@@ -1,0 +1,79 @@
+# KORA First Paper Submission Package Readiness v0.1
+
+Status date: 2026-05-13
+
+## Purpose
+
+This venue-neutral checklist records what is present, missing, and blocked before the KORA first paper can become a submission package. It does not select a venue and does not mark the paper as submission-ready.
+
+## Source Files Reviewed
+
+- `docs/paper/kora-first-paper-manuscript-v0-4.md`
+- `docs/paper/kora-first-paper-manuscript-bibliography-sync-v0-1.md`
+- `docs/paper/kora-first-paper-manuscript-claim-to-evidence-audit-v0-1.md`
+- `docs/paper/kora-first-paper-submission-candidate-status-v0-1.md`
+- `docs/paper/kora-first-paper-final-bibliography-claim-audit-v0-1.md`
+- `docs/paper/kora-first-paper-submission-readiness-gate-v0-1.md`
+- `docs/paper/kora-first-paper-submission-readiness.md`
+- `docs/paper/kora-first-paper-preliminary-bibtex-v0-1.md`
+- `docs/paper/kora-first-paper-figures-and-tables.md`
+- `docs/paper/kora-first-paper-figure-specs.md`
+- `docs/paper/kora-first-paper-table-specs.md`
+- `docs/reports/benchmark_artifact_policy.md`
+- `docs/reports/v0.3.0-alpha-runtime-evidence-reviewer-guide.md`
+- `LICENSE`
+
+## Current Package Status
+
+- Manuscript version: v0.4 submission-candidate draft.
+- Package status: not submission-ready.
+- Venue status: no target venue selected.
+- Bibliography status: preliminary BibTeX has 16 entries; full BibTeX remains incomplete.
+- Claim status: bounded to the reproducible deterministic-heavy benchmark workload.
+- Review status: final human review remains pending.
+
+## Required Package Components
+
+| Component | Current status | Missing or pending item | Blocker severity | Owner or decision type |
+|---|---|---|---|---|
+| Manuscript v0.4 | Candidate draft exists | Final human approval and final sync after bibliography changes | High | User approval plus mechanical sync |
+| Bibliography / BibTeX | Preliminary BibTeX has 16 entries | Full BibTeX completion and final formatting | High | Mechanical metadata work plus user scope approval |
+| Citation sync audit | v0.1 exists | Repeat after final BibTeX and any manuscript edits | Medium | Mechanical |
+| Claim-to-evidence audit | v0.1 exists | Repeat after any manuscript, figure, table, or package change | Medium | Mechanical |
+| Figures and tables | Planning and specs exist | Final rendered figures/tables are not locked | High | Mechanical preparation plus user approval |
+| Reproduction transcript | Checklist created in this packet | Clean transcript from a fresh checkout is not captured | High | Mechanical |
+| Artifact availability statement | Policy and inventory inputs exist | Final submission wording and artifact package selection are pending | Medium | User approval plus mechanical packaging |
+| Repository / artifact inventory | Inventory created in this packet | Final submission bundle selection is pending | Medium | Mechanical plus user approval |
+| License statement | Repository license exists | Submission-specific license/copyright wording is pending | Medium | User or venue decision |
+| Author and affiliation metadata | Authorship policy exists | Final author block and affiliations are not approved here | High | User approval |
+| Acknowledgement, funding, conflict, ethics metadata | Not finalized in this packet | Required disclosure wording remains pending if applicable | High | User approval |
+| Venue / export format | Venue-neutral draft exists | Target venue, template, page limits, and export format are not selected | High | User approval |
+| Final human review signoff | Packet created in this pass | No final signoff recorded | High | User approval |
+
+## Missing Components
+
+- Final full BibTeX and final bibliography formatting.
+- Final manuscript-to-final-bibliography synchronization.
+- Final rendered figures and tables.
+- Clean reproduction transcript from a fresh checkout.
+- Final artifact availability statement and package selection.
+- Final author, affiliation, acknowledgement, funding, conflict, and ethics metadata.
+- Target venue or venue-neutral preprint export decision.
+- Final human signoff.
+
+## Conservative Status Notes
+
+- Do not treat manuscript v0.4 as submission-ready.
+- Do not treat the current preliminary BibTeX as a complete bibliography.
+- Do not treat artifact docs or reproduction commands as formal artifact approval.
+- Do not use this packet to claim production cost reduction, real API-cost reduction, production benchmark proof, broad workload superiority, or energy reduction evidence.
+
+## Next Recommended Sequence
+
+1. User reviews the final human review packet and decides venue/export direction.
+2. Resolve bibliography scope and full BibTeX blockers.
+3. Repeat manuscript-to-bibliography sync after final BibTeX changes.
+4. Prepare final figures, tables, and reproduction transcript.
+5. Prepare artifact availability wording and submission package inventory.
+6. Run final claim-to-evidence audit against the exact exported manuscript.
+7. Complete final human review and only then decide whether the paper is submission-ready.

--- a/docs/paper/kora-first-paper-submission-readiness.md
+++ b/docs/paper/kora-first-paper-submission-readiness.md
@@ -46,6 +46,8 @@ Submission readiness gate v0.1 exists. It records required and optional blockers
 
 Manuscript v0.4 submission-candidate draft exists. It synchronizes manuscript citations with current preliminary BibTeX by removing still-not-eligible `[R02]` from background-only manuscript text. Full BibTeX remains incomplete, and the paper remains not submission-ready.
 
+Submission package readiness packet v0.1 exists. It adds a venue-neutral package checklist, final human review packet, reproduction transcript checklist, and artifact package inventory. These documents organize remaining blockers and user-owned decisions; they do not mark the paper as submission-ready.
+
 ## Ready
 
 - Thesis.
@@ -80,6 +82,10 @@ Manuscript v0.4 submission-candidate draft exists. It synchronizes manuscript ci
 - Manuscript bibliography sync v0.1.
 - Manuscript claim-to-evidence audit v0.1.
 - Submission-candidate status v0.1.
+- Submission package readiness packet v0.1.
+- Final human review packet v0.1.
+- Reproduction transcript checklist v0.1.
+- Artifact package inventory v0.1.
 - Citation audit v0.1.
 - Manuscript v0.3 reference integration plan.
 
@@ -94,8 +100,10 @@ Manuscript v0.4 submission-candidate draft exists. It synchronizes manuscript ci
 - Final citation audit review completed.
 - Figure drafts created.
 - Tables finalized.
-- Clean command transcript captured.
+- Clean reproduction transcript captured.
 - Reproduction instructions checked on clean checkout.
+- Final human review packet resolved.
+- Artifact package inventory reviewed for the selected submission context.
 - Expanded workload optional but recommended.
 - Latency p50/p95 optional but valuable.
 - Final claim review completed.
@@ -118,6 +126,6 @@ These are suggested formats only. This document does not claim acceptance, endor
 
 ## Reference Status
 
-The first verified reference pass is complete, manuscript v0.2 integrates the first-pass verified references as preliminary citation labels and a preliminary references section, citation audit v0.1 exists, additional reference verification pass 2 has added 8 verified tracker entries, manuscript v0.3 integrates [R11], [R12], and [R13] as preliminary related-work references, manuscript v0.4 exists as a submission-candidate draft synchronized to current preliminary BibTeX citations, the benchmark-construction reference pass has added [R19] through [R24] as tracker/audit entries, the working citation style decision selects stable [Rxx] labels, metadata audit v0.1 exists, normalized bibliography v0.1 exists, metadata gap resolution v0.1 exists, preliminary BibTeX v0.1 exists for ready records, ready-subset BibTeX keys are normalized, expanded preliminary BibTeX exists for the candidate subset that passed final field check, final bibliography and claim audit v0.1 exists, and submission readiness gate v0.1 exists. The paper is still not submission-ready because [R17] and [R18] remain deferred, [R02], [R15], [R19], [R20], [R22], and [R23] remain excluded from BibTeX, [R19] through [R24] are not yet integrated into manuscript methodology, more direct deterministic-heavy synthetic workload references may still be needed, production benchmark evidence is still not available, final bibliography entries are not complete, and submission-package blockers remain unresolved.
+The first verified reference pass is complete, manuscript v0.2 integrates the first-pass verified references as preliminary citation labels and a preliminary references section, citation audit v0.1 exists, additional reference verification pass 2 has added 8 verified tracker entries, manuscript v0.3 integrates [R11], [R12], and [R13] as preliminary related-work references, manuscript v0.4 exists as a submission-candidate draft synchronized to current preliminary BibTeX citations, the benchmark-construction reference pass has added [R19] through [R24] as tracker/audit entries, the working citation style decision selects stable [Rxx] labels, metadata audit v0.1 exists, normalized bibliography v0.1 exists, metadata gap resolution v0.1 exists, preliminary BibTeX v0.1 exists for ready records, ready-subset BibTeX keys are normalized, expanded preliminary BibTeX exists for the candidate subset that passed final field check, final bibliography and claim audit v0.1 exists, submission readiness gate v0.1 exists, and submission package readiness packet v0.1 exists. The paper is still not submission-ready because [R17] and [R18] remain deferred, [R02], [R15], [R19], [R20], [R22], and [R23] remain excluded from BibTeX, [R19] through [R24] are not yet integrated into manuscript methodology, more direct deterministic-heavy synthetic workload references may still be needed, production benchmark evidence is still not available, final bibliography entries are not complete, final reproduction transcript and artifact package review are incomplete, final venue/export decisions remain unresolved, and final human review has not been completed.
 
 No fake citations were added. Future citation work should use only verified tracker entries and should not support production, API-cost, energy, production-validation, broad superiority, or cited-system superiority claims.


### PR DESCRIPTION
## Summary
- Added a venue-neutral submission package readiness checklist around manuscript v0.4.
- Added a final human review packet with user-owned decision prompts left pending.
- Added a reproduction transcript checklist using existing documented commands only.
- Added an artifact/package inventory and updated Paper Track status docs.

## Boundaries
- Paper remains not submission-ready.
- No target venue selected.
- No source code, tests, CI, benchmark artifacts, README, or KORA Studio files changed.
- No new references or metadata added.
- No production/API-cost/energy/broad superiority/formal approval claims added.

## Validation
- git status --short: clean before commit
- git diff --check: passed
- python3 -m pytest: 159 passed
- Unicode scan over changed files: clean, ASCII only
- Targeted internal/claim scan: only expected non-claim and not-ready status language found