### PR TITLE
docs: prepare arxiv-style paper package draft

### DIFF
--- a/docs/paper/kora-first-paper-arxiv-bibliography-scope-v0-1.md
+++ b/docs/paper/kora-first-paper-arxiv-bibliography-scope-v0-1.md
@@ -1,0 +1,59 @@
+# KORA First Paper arXiv Bibliography Scope v0.1
+
+Status date: 2026-05-13
+
+## Purpose
+
+This note records the conservative bibliography scope for the first arXiv-style preprint package draft. It does not add references, does not generate new BibTeX, and does not mark the paper as submission-ready.
+
+## Source Files Reviewed
+
+- `docs/paper/kora-first-paper-manuscript-v0-4.md`
+- `docs/paper/kora-first-paper-preliminary-bibtex-v0-1.md`
+- `docs/paper/kora-first-paper-manuscript-bibliography-sync-v0-1.md`
+- `docs/paper/kora-first-paper-final-bibliography-claim-audit-v0-1.md`
+- `docs/paper/kora-first-paper-reference-tracker.md`
+- `docs/paper/kora-first-paper-reference-plan.md`
+
+## Manuscript v0.4 Cited Records
+
+Manuscript v0.4 currently cites:
+
+- `[R01]`
+- `[R03]`
+- `[R04]`
+- `[R05]`
+- `[R06]`
+- `[R07]`
+- `[R08]`
+- `[R09]`
+- `[R10]`
+- `[R11]`
+- `[R12]`
+- `[R13]`
+
+All manuscript v0.4 cited records are present in preliminary BibTeX.
+
+## Preliminary BibTeX Scope
+
+- Preliminary BibTeX entries count: 16.
+- Included ready records: `[R01]`, `[R06]`, `[R08]`, `[R11]`, `[R14]`, `[R21]`, `[R24]`.
+- Included expanded candidate records: `[R03]`, `[R04]`, `[R05]`, `[R07]`, `[R09]`, `[R10]`, `[R12]`, `[R13]`, `[R16]`.
+- Unused preliminary BibTeX records in manuscript v0.4: `[R14]`, `[R16]`, `[R21]`, `[R24]`.
+
+Unused preliminary BibTeX records are available for final bibliography decisions. They should not be treated as new manuscript claims.
+
+## First arXiv-Style Package Exclusions
+
+- `[R17]` and `[R18]` remain excluded from the first arXiv-style package.
+- `[R19]` through `[R24]` remain tracker/audit-only for now and should not be forced into methodology/background.
+- Optional workload, latency, API-cost, production, energy, KORA Studio, and real customer-data evidence remain outside the first package scope.
+- Deferred or still-not-eligible records should not be cited in the manuscript body.
+
+## Full BibTeX Status
+
+Full BibTeX remains incomplete. The first arXiv-style package draft may proceed using the current included bibliography subset, but final submission readiness still requires human approval, final citation formatting, and a final manuscript-to-bibliography sync.
+
+## Claim Safety
+
+The bibliography scope supports background, positioning, artifact practice, and reproducible evidence context only. It does not support production cost reduction proof, real API-cost reduction proof, production benchmark proof, broad workload superiority proof, energy reduction evidence, formal artifact approval, or paper submission readiness.

--- a/docs/paper/kora-first-paper-arxiv-metadata-checklist-v0-1.md
+++ b/docs/paper/kora-first-paper-arxiv-metadata-checklist-v0-1.md
@@ -1,0 +1,55 @@
+# KORA First Paper arXiv Metadata Checklist v0.1
+
+Status date: 2026-05-13
+
+## Purpose
+
+This checklist records arXiv-style preprint metadata for the current KORA first paper package draft. It does not submit the paper to arXiv and does not mark the paper as submission-ready.
+
+## Source Files Reviewed
+
+- `docs/paper/kora-first-paper-manuscript-v0-4.md`
+- `docs/paper/kora-first-paper-submission-package-readiness-v0-1.md`
+- `docs/paper/kora-first-paper-final-human-review-packet-v0-1.md`
+- `docs/paper/kora-first-paper-submission-candidate-status-v0-1.md`
+- `docs/paper/2026-05-06-kora-authorship-and-contribution-policy.md`
+- `LICENSE`
+
+## Metadata Checklist
+
+| Field | Current value or status | Remaining action |
+|---|---|---|
+| Title | `KORA: Deterministic-First Execution Control for AI Workloads` | Final human title approval pending |
+| Author | Albert Heekwan Kim | Confirm exact author display before export |
+| Affiliation | Krako Labs, Inc. | Confirm exact affiliation display before export |
+| Email | a.kim@krako.xyz | Confirm whether email should appear in exported manuscript |
+| Paper type | Original reproducible systems/evaluation technical report | Preserve this framing |
+| arXiv endorsement | Already obtained / not blocking | No endorsement blocker in current package planning |
+| arXiv category | Pending | Confirm endorsed category and category compatibility before submission |
+| Candidate arXiv categories | `cs.AI`, `cs.LG`, `cs.DC`, `cs.SE` | Candidates only; no category selected here |
+| Abstract | Current manuscript v0.4 abstract exists | Final human approval pending |
+| Comments field | Pending | Decide after export format, page count, and artifact links are known |
+| License | Pending user decision for arXiv distribution | Select arXiv license before submission |
+| Funding | Not specified | Do not add funding text unless supplied or required |
+| Acknowledgements | Not specified | Do not add acknowledgement text unless supplied |
+| Conflict / disclosure | Affiliation with Krako Labs, Inc. is explicit | Add only minimal required disclosure wording if needed |
+| Ethics / human subjects | Current evidence uses synthetic local/no-network workloads and no private user data | Final wording pending human review |
+
+## Positioning
+
+The paper should be positioned as original reproducible systems/evaluation work:
+
+- deterministic-first execution-control design
+- reproducible deterministic-heavy benchmark evidence
+- synthetic local/no-network validation evidence
+- bounded evidence and explicit non-claims
+
+It should not be framed as a review paper, survey paper, or position paper.
+
+## Non-Claims
+
+This metadata checklist does not support production cost reduction proof, real API-cost reduction proof, production benchmark proof, full runtime-integrated real-provider benchmark evidence, broad workload superiority proof, energy reduction evidence, formal government validation, signed partner validation, guaranteed adoption or funding, formal artifact approval, or paper submission readiness.
+
+## Status
+
+The metadata package is partially drafted for an arXiv-style preprint. Endorsement is already obtained and not blocking. Category compatibility, title/abstract approval, license selection, export format, and final human review remain pending. The paper remains not submission-ready.

--- a/docs/paper/kora-first-paper-arxiv-style-package-readiness-v0-1.md
+++ b/docs/paper/kora-first-paper-arxiv-style-package-readiness-v0-1.md
@@ -1,0 +1,84 @@
+# KORA First Paper arXiv-Style Package Readiness v0.1
+
+Status date: 2026-05-13
+
+## Purpose
+
+This artifact records readiness for a venue-neutral arXiv-style preprint package draft around manuscript v0.4. It does not submit to arXiv and does not mark the paper as submission-ready.
+
+## Source Files Reviewed
+
+- `docs/paper/kora-first-paper-manuscript-v0-4.md`
+- `docs/paper/kora-first-paper-arxiv-metadata-checklist-v0-1.md`
+- `docs/paper/kora-first-paper-arxiv-bibliography-scope-v0-1.md`
+- `docs/paper/kora-first-paper-submission-package-readiness-v0-1.md`
+- `docs/paper/kora-first-paper-reproduction-transcript-checklist-v0-1.md`
+- `docs/paper/kora-first-paper-artifact-package-inventory-v0-1.md`
+- `docs/paper/kora-first-paper-manuscript-claim-to-evidence-audit-v0-1.md`
+
+## Package Status
+
+- Package type: arXiv-style technical report / preprint draft.
+- Paper type: original reproducible systems/evaluation technical report.
+- Status: draft, not submission-ready.
+- arXiv submission action: not performed.
+- Conference, workshop, or journal selection: not performed.
+
+## arXiv-Specific Checks
+
+| Check | Current status | Remaining action |
+|---|---|---|
+| Author metadata | Albert Heekwan Kim, Krako Labs, Inc., a.kim@krako.xyz | Confirm exact display before export |
+| arXiv endorsement | Already obtained / not blocking | No action unless category compatibility requires review |
+| Category compatibility | Pending because endorsed category is not recorded here | Confirm category before submission |
+| Candidate categories | `cs.AI`, `cs.LG`, `cs.DC`, `cs.SE` | Candidates only; no category selected here |
+| Title / abstract | v0.4 title and abstract exist | Final human approval pending |
+| License | Pending arXiv distribution-license decision | User decision required |
+| Export format | Markdown draft exists | PDF/LaTeX/Markdown export package pending |
+| Source package | Not prepared | Prepare only after export route is selected |
+| Review/survey/position framing | Avoided | Preserve original systems/evaluation framing |
+| Final human review | Pending | Required before any submission action |
+
+## Manuscript Status
+
+Manuscript v0.4 exists and is the current submission-candidate draft. It remains a draft and should not be described as final or submission-ready.
+
+## Bibliography Subset Status
+
+The first arXiv-style package uses the conservative manuscript-cited bibliography subset:
+
+- Manuscript v0.4 cited records: `[R01]`, `[R03]`, `[R04]`, `[R05]`, `[R06]`, `[R07]`, `[R08]`, `[R09]`, `[R10]`, `[R11]`, `[R12]`, `[R13]`.
+- Preliminary BibTeX entries count: 16.
+- `[R17]` and `[R18]` remain excluded.
+- `[R19]` through `[R24]` remain tracker/audit-only for now.
+- Full BibTeX remains incomplete.
+
+## Claim and Evidence Status
+
+The bounded claim remains:
+
+> KORA reduced model invocations by 80% in a reproducible deterministic-heavy benchmark workload.
+
+The package remains limited to reproducible deterministic-heavy benchmark evidence and synthetic local/no-network validation evidence. It does not claim production cost reduction, real API-cost reduction, production benchmark proof, full runtime-integrated real-provider benchmark evidence, broad workload superiority, energy reduction evidence, formal artifact approval, or paper submission readiness.
+
+## Reproduction Transcript Status
+
+The reproduction transcript checklist exists, but a final clean transcript has not been captured for the exact submission package commit.
+
+## Artifact Inventory Status
+
+The artifact package inventory exists. Final artifact availability wording, selected artifact bundle, and export package remain pending.
+
+## Missing User Approvals
+
+- Final title and abstract approval.
+- Final author/email display approval.
+- arXiv category and category compatibility approval.
+- arXiv license selection.
+- Final bibliography/citation formatting approval.
+- Final figures, tables, reproduction transcript, and artifact package approval.
+- Final submission-ready decision.
+
+## Conclusion
+
+The arXiv-style preprint package draft is organized but not submission-ready. Endorsement is already obtained and not blocking. Category compatibility, license, export package, final transcript, final bibliography formatting, and final human approval remain pending.

--- a/docs/paper/kora-first-paper-final-human-review-packet-v0-1.md
+++ b/docs/paper/kora-first-paper-final-human-review-packet-v0-1.md
@@ -23,20 +23,21 @@ This packet lists the human decisions still required before any submission-ready
 |---|---|---|
 | Title and abstract | Approve final wording or request edits | Pending |
 | Claim boundary | Approve the bounded deterministic-heavy benchmark claim | Pending |
-| Bibliography scope | Approve which records remain in or out of the first submission scope | Pending |
+| Bibliography scope | Confirm the conservative first arXiv-style package scope | Draft scope supplied; final approval pending |
 | Limitations | Approve limitations and non-claim language | Pending |
 | Artifact and reproducibility | Approve artifact package scope and reproduction transcript expectations | Pending |
 | Figures and tables | Approve final rendered figures, tables, captions, and numbering | Pending |
-| Author and affiliation metadata | Approve final author block and affiliations | Pending |
-| Acknowledgement, funding, conflict, and ethics metadata | Approve any required disclosure text | Pending |
-| Target venue and export format | Choose venue, template, or venue-neutral preprint route | Pending |
+| Author and affiliation metadata | Approve final author block, affiliation, and email display | Draft metadata supplied; final approval pending |
+| Acknowledgement, funding, conflict, and ethics metadata | Approve minimal required disclosure text if any | Pending |
+| Target venue and export format | Confirm arXiv category, license, and export route | arXiv-style direction supplied; details pending |
 | Final submission-ready decision | Decide whether the exact final package is ready to submit | Pending |
 
 ## Bibliography Scope Decisions
 
-- Decide whether `[R17]` and `[R18]` remain excluded from the first submission or are resolved for inclusion later.
-- Decide whether `[R19]` through `[R24]` remain tracker/audit-only methodology references for the first submission.
-- Decide whether deferred and still-not-eligible records should remain excluded from preliminary BibTeX until a later bibliography pass.
+- Current arXiv-style draft decision: `[R17]` and `[R18]` remain excluded from the first arXiv-style package.
+- Current arXiv-style draft decision: `[R19]` through `[R24]` remain tracker/audit-only for now.
+- Current arXiv-style draft decision: optional workload, latency, API-cost, production, energy, KORA Studio, and real customer-data evidence stay outside first package scope.
+- Deferred and still-not-eligible records should remain excluded from manuscript body citations unless later resolved.
 - Confirm that no missing metadata should be filled without source-backed verification.
 
 ## Evidence Scope Decisions
@@ -48,9 +49,11 @@ This packet lists the human decisions still required before any submission-ready
 
 ## Venue and Export Decisions
 
-- Decide whether to proceed with a venue-neutral preprint style or select a specific venue.
-- If a venue is selected, approve template, page limit, citation style, artifact appendix expectations, and disclosure requirements.
-- Approve whether export preparation should wait until full BibTeX and final figures/tables are complete.
+- Current direction: arXiv-style technical report / preprint first.
+- Endorsement status: already obtained / not blocking.
+- arXiv category compatibility remains pending because the endorsed category is not recorded here.
+- Later conference, workshop, or journal scanning is deferred and should not select a target in the current package draft.
+- Approve whether export preparation should proceed after category, license, bibliography formatting, and figures/tables are stable.
 
 ## Claim Boundary Reminder
 

--- a/docs/paper/kora-first-paper-future-venue-scan-v0-1.md
+++ b/docs/paper/kora-first-paper-future-venue-scan-v0-1.md
@@ -1,0 +1,45 @@
+# KORA First Paper Future Venue Scan v0.1
+
+Status date: 2026-05-13
+
+## Purpose
+
+This placeholder lists future venue-scan dimensions for later conference, workshop, or journal evaluation. It does not select a venue, does not submit anywhere, and does not mark the paper as submission-ready.
+
+## Current Direction
+
+- First target: arXiv-style technical report / preprint.
+- Later investigation may consider conference, workshop, or journal options if timing and fit are appropriate.
+- No conference, workshop, or journal target is selected in this document.
+
+## Candidate Venue Classes
+
+- arXiv first.
+- Systems and AI infrastructure workshops.
+- ML systems workshops.
+- Software engineering / systems venues.
+- Applied AI infrastructure tracks.
+
+## Future Information To Collect
+
+| Information needed | Why it matters |
+|---|---|
+| Deadlines | Determines whether a later venue path is feasible |
+| Formatting requirements | Determines export format, page limits, figure/table constraints, and bibliography style |
+| Anonymity / double-blind policy | Determines whether author, repo, and artifact references must be anonymized |
+| arXiv preprint compatibility | Determines whether a preprint affects later submission eligibility |
+| Artifact / reproducibility requirements | Determines artifact package, transcript, and appendix requirements |
+| Page limits | Determines whether manuscript v0.4 must be shortened or split |
+| Claim/evidence fit | Determines whether the bounded deterministic-heavy benchmark evidence is sufficient for the venue scope |
+
+## Scope Boundaries
+
+- Do not invent current deadlines in this placeholder.
+- Do not choose a target venue here.
+- Do not submit to any venue here.
+- Do not expand claims to fit a venue.
+- Do not treat optional workload, latency, API-cost, production, energy, KORA Studio, or real customer-data work as completed.
+
+## Status
+
+Future venue scanning remains a later task. The current package direction is arXiv-style preprint first, with conference, workshop, or journal evaluation deferred.

--- a/docs/paper/kora-first-paper-missing-evidence-checklist.md
+++ b/docs/paper/kora-first-paper-missing-evidence-checklist.md
@@ -114,6 +114,9 @@ Citation style decision:
 - Manuscript v0.4 submission-candidate draft has been created with current preliminary BibTeX citation synchronization.
 - Manuscript bibliography sync v0.1, manuscript claim-to-evidence audit v0.1, and submission-candidate status v0.1 have been created.
 - Submission package readiness v0.1, final human review packet v0.1, reproduction transcript checklist v0.1, and artifact package inventory v0.1 have been created.
+- arXiv metadata checklist v0.1, arXiv bibliography scope v0.1, arXiv-style package readiness v0.1, and future venue scan placeholder v0.1 have been created.
+- arXiv endorsement is already obtained and is not a current blocker.
+- arXiv category compatibility, arXiv license, export package, final transcript, final artifact package review, and final human approval remain pending.
 - Clean reproduction transcript capture, final artifact package review, final venue/export decision, and final human review remain pending.
 - Paper is still not submission-ready.
 

--- a/docs/paper/kora-first-paper-reference-plan.md
+++ b/docs/paper/kora-first-paper-reference-plan.md
@@ -427,6 +427,20 @@ Status:
 - Artifact package inventory identifies tracked materials and deliberately excluded raw/private artifacts.
 - Full BibTeX remains incomplete, venue/export decisions remain user-owned, and the paper remains not submission-ready.
 
+## arXiv-Style Preprint Package Draft Status
+
+[KORA First Paper arXiv Metadata Checklist v0.1](kora-first-paper-arxiv-metadata-checklist-v0-1.md), [KORA First Paper arXiv Bibliography Scope v0.1](kora-first-paper-arxiv-bibliography-scope-v0-1.md), [KORA First Paper arXiv-Style Package Readiness v0.1](kora-first-paper-arxiv-style-package-readiness-v0-1.md), and [KORA First Paper Future Venue Scan v0.1](kora-first-paper-future-venue-scan-v0-1.md) have been created.
+
+Status:
+
+- First package direction is arXiv-style technical report / preprint.
+- arXiv endorsement is already obtained and is not a current blocker.
+- arXiv category compatibility remains pending because the endorsed category is not recorded here.
+- Manuscript v0.4 remains framed as original reproducible systems/evaluation work, not a review/survey/position paper.
+- First arXiv-style bibliography scope keeps `[R17]` and `[R18]` excluded and `[R19]` through `[R24]` tracker/audit-only for now.
+- Later conference, workshop, or journal venue scanning is deferred.
+- The paper remains not submission-ready.
+
 ## Next Verification Procedure
 
 1. Search official sources first.

--- a/docs/paper/kora-first-paper-submission-candidate-status-v0-1.md
+++ b/docs/paper/kora-first-paper-submission-candidate-status-v0-1.md
@@ -53,7 +53,18 @@ No production, API-cost, energy, broad superiority, formal approval, or submissi
 
 ## Target Venue, Export, and Package Decisions
 
-No target venue was selected in this pass. The draft remains venue-neutral. Export/package preparation should wait until bibliography scope and target format are stable.
+The first target package direction is arXiv-style technical report / preprint. Endorsement has been obtained and is not a current blocker. arXiv category compatibility, license, export format, and final human approval remain pending. No conference, workshop, or journal target has been selected.
+
+## arXiv-Style Package Draft
+
+The arXiv-style package draft docs now exist:
+
+- `docs/paper/kora-first-paper-arxiv-metadata-checklist-v0-1.md`
+- `docs/paper/kora-first-paper-arxiv-bibliography-scope-v0-1.md`
+- `docs/paper/kora-first-paper-arxiv-style-package-readiness-v0-1.md`
+- `docs/paper/kora-first-paper-future-venue-scan-v0-1.md`
+
+These files record the supplied author metadata, endorsement status, conservative bibliography scope, original systems/evaluation framing, and future venue-scan placeholder. They do not submit to arXiv, select an arXiv category, select a conference/workshop/journal, or mark the paper as submission-ready.
 
 ## Submission Package Packet
 

--- a/docs/paper/kora-first-paper-submission-package-readiness-v0-1.md
+++ b/docs/paper/kora-first-paper-submission-package-readiness-v0-1.md
@@ -27,7 +27,9 @@ This venue-neutral checklist records what is present, missing, and blocked befor
 
 - Manuscript version: v0.4 submission-candidate draft.
 - Package status: not submission-ready.
-- Venue status: no target venue selected.
+- Venue status: arXiv-style technical report / preprint is the first target package direction; no conference, workshop, or journal target is selected.
+- arXiv endorsement status: already obtained / not blocking.
+- arXiv category compatibility: pending until endorsed category and selected category are confirmed.
 - Bibliography status: preliminary BibTeX has 16 entries; full BibTeX remains incomplete.
 - Claim status: bounded to the reproducible deterministic-heavy benchmark workload.
 - Review status: final human review remains pending.
@@ -42,12 +44,12 @@ This venue-neutral checklist records what is present, missing, and blocked befor
 | Claim-to-evidence audit | v0.1 exists | Repeat after any manuscript, figure, table, or package change | Medium | Mechanical |
 | Figures and tables | Planning and specs exist | Final rendered figures/tables are not locked | High | Mechanical preparation plus user approval |
 | Reproduction transcript | Checklist created in this packet | Clean transcript from a fresh checkout is not captured | High | Mechanical |
-| Artifact availability statement | Policy and inventory inputs exist | Final submission wording and artifact package selection are pending | Medium | User approval plus mechanical packaging |
+| Artifact availability statement | Policy and inventory inputs exist | Final preprint wording and artifact package selection are pending | Medium | User approval plus mechanical packaging |
 | Repository / artifact inventory | Inventory created in this packet | Final submission bundle selection is pending | Medium | Mechanical plus user approval |
-| License statement | Repository license exists | Submission-specific license/copyright wording is pending | Medium | User or venue decision |
-| Author and affiliation metadata | Authorship policy exists | Final author block and affiliations are not approved here | High | User approval |
-| Acknowledgement, funding, conflict, ethics metadata | Not finalized in this packet | Required disclosure wording remains pending if applicable | High | User approval |
-| Venue / export format | Venue-neutral draft exists | Target venue, template, page limits, and export format are not selected | High | User approval |
+| License statement | Repository license exists | arXiv distribution-license decision is pending | Medium | User decision |
+| Author and affiliation metadata | Author metadata supplied for preprint draft | Final display approval remains pending | Medium | User approval |
+| Acknowledgement, funding, conflict, ethics metadata | Minimal/no-extra-statement approach selected | Required disclosure wording remains pending if applicable | Medium | User approval |
+| Venue / export format | arXiv-style preprint direction selected | arXiv category, license, and export format are pending | High | User approval |
 | Final human review signoff | Packet created in this pass | No final signoff recorded | High | User approval |
 
 ## Missing Components
@@ -57,8 +59,8 @@ This venue-neutral checklist records what is present, missing, and blocked befor
 - Final rendered figures and tables.
 - Clean reproduction transcript from a fresh checkout.
 - Final artifact availability statement and package selection.
-- Final author, affiliation, acknowledgement, funding, conflict, and ethics metadata.
-- Target venue or venue-neutral preprint export decision.
+- Final author/email display, acknowledgement, funding, conflict, and ethics wording if needed.
+- arXiv category, license, and export format decision.
 - Final human signoff.
 
 ## Conservative Status Notes
@@ -70,10 +72,11 @@ This venue-neutral checklist records what is present, missing, and blocked befor
 
 ## Next Recommended Sequence
 
-1. User reviews the final human review packet and decides venue/export direction.
-2. Resolve bibliography scope and full BibTeX blockers.
-3. Repeat manuscript-to-bibliography sync after final BibTeX changes.
-4. Prepare final figures, tables, and reproduction transcript.
-5. Prepare artifact availability wording and submission package inventory.
-6. Run final claim-to-evidence audit against the exact exported manuscript.
-7. Complete final human review and only then decide whether the paper is submission-ready.
+1. Confirm arXiv category compatibility and arXiv license.
+2. Approve final title, abstract, author display, and email display.
+3. Resolve first-package bibliography formatting using the conservative included subset.
+4. Repeat manuscript-to-bibliography sync after final citation formatting.
+5. Prepare final figures, tables, export package, and reproduction transcript.
+6. Prepare artifact availability wording and selected artifact bundle.
+7. Run final claim-to-evidence audit against the exact exported manuscript.
+8. Complete final human review and only then decide whether the paper is submission-ready.

--- a/docs/paper/kora-first-paper-submission-readiness.md
+++ b/docs/paper/kora-first-paper-submission-readiness.md
@@ -48,6 +48,8 @@ Manuscript v0.4 submission-candidate draft exists. It synchronizes manuscript ci
 
 Submission package readiness packet v0.1 exists. It adds a venue-neutral package checklist, final human review packet, reproduction transcript checklist, and artifact package inventory. These documents organize remaining blockers and user-owned decisions; they do not mark the paper as submission-ready.
 
+arXiv-style package draft v0.1 exists. It records the first target direction as an arXiv-style technical report / preprint, marks endorsement as already obtained and not blocking, keeps arXiv category compatibility pending, records supplied author metadata, preserves conservative bibliography scope, and defers later conference/workshop/journal scanning. It does not submit to arXiv or mark the paper as submission-ready.
+
 ## Ready
 
 - Thesis.
@@ -86,6 +88,10 @@ Submission package readiness packet v0.1 exists. It adds a venue-neutral package
 - Final human review packet v0.1.
 - Reproduction transcript checklist v0.1.
 - Artifact package inventory v0.1.
+- arXiv metadata checklist v0.1.
+- arXiv bibliography scope v0.1.
+- arXiv-style package readiness v0.1.
+- Future venue scan placeholder v0.1.
 - Citation audit v0.1.
 - Manuscript v0.3 reference integration plan.
 
@@ -94,9 +100,10 @@ Submission package readiness packet v0.1 exists. It adds a venue-neutral package
 - More references collected and verified.
 - Decide whether selected benchmark-construction references should be integrated if the evaluation-methodology section is expanded.
 - More direct deterministic-heavy synthetic workload construction references if needed.
-- Resolve submission readiness gate required blockers, starting with deferred and still-not-eligible bibliography records.
+- Confirm arXiv category compatibility and license.
+- Resolve first-package bibliography formatting using the conservative included subset.
 - Final bibliography entries normalized.
-- Full BibTeX completion after blocked records are resolved.
+- Full BibTeX completion remains pending beyond the conservative first-package subset.
 - Final citation audit review completed.
 - Figure drafts created.
 - Tables finalized.
@@ -104,7 +111,7 @@ Submission package readiness packet v0.1 exists. It adds a venue-neutral package
 - Reproduction instructions checked on clean checkout.
 - Final human review packet resolved.
 - Artifact package inventory reviewed for the selected submission context.
-- Expanded workload optional but recommended.
+- Expanded workload optional but outside first arXiv-style package scope.
 - Latency p50/p95 optional but valuable.
 - Final claim review completed.
 
@@ -126,6 +133,6 @@ These are suggested formats only. This document does not claim acceptance, endor
 
 ## Reference Status
 
-The first verified reference pass is complete, manuscript v0.2 integrates the first-pass verified references as preliminary citation labels and a preliminary references section, citation audit v0.1 exists, additional reference verification pass 2 has added 8 verified tracker entries, manuscript v0.3 integrates [R11], [R12], and [R13] as preliminary related-work references, manuscript v0.4 exists as a submission-candidate draft synchronized to current preliminary BibTeX citations, the benchmark-construction reference pass has added [R19] through [R24] as tracker/audit entries, the working citation style decision selects stable [Rxx] labels, metadata audit v0.1 exists, normalized bibliography v0.1 exists, metadata gap resolution v0.1 exists, preliminary BibTeX v0.1 exists for ready records, ready-subset BibTeX keys are normalized, expanded preliminary BibTeX exists for the candidate subset that passed final field check, final bibliography and claim audit v0.1 exists, submission readiness gate v0.1 exists, and submission package readiness packet v0.1 exists. The paper is still not submission-ready because [R17] and [R18] remain deferred, [R02], [R15], [R19], [R20], [R22], and [R23] remain excluded from BibTeX, [R19] through [R24] are not yet integrated into manuscript methodology, more direct deterministic-heavy synthetic workload references may still be needed, production benchmark evidence is still not available, final bibliography entries are not complete, final reproduction transcript and artifact package review are incomplete, final venue/export decisions remain unresolved, and final human review has not been completed.
+The first verified reference pass is complete, manuscript v0.2 integrates the first-pass verified references as preliminary citation labels and a preliminary references section, citation audit v0.1 exists, additional reference verification pass 2 has added 8 verified tracker entries, manuscript v0.3 integrates [R11], [R12], and [R13] as preliminary related-work references, manuscript v0.4 exists as a submission-candidate draft synchronized to current preliminary BibTeX citations, the benchmark-construction reference pass has added [R19] through [R24] as tracker/audit entries, the working citation style decision selects stable [Rxx] labels, metadata audit v0.1 exists, normalized bibliography v0.1 exists, metadata gap resolution v0.1 exists, preliminary BibTeX v0.1 exists for ready records, ready-subset BibTeX keys are normalized, expanded preliminary BibTeX exists for the candidate subset that passed final field check, final bibliography and claim audit v0.1 exists, submission readiness gate v0.1 exists, submission package readiness packet v0.1 exists, and arXiv-style package draft v0.1 exists. The paper is still not submission-ready because arXiv category compatibility and license remain pending, [R17] and [R18] remain deferred, [R02], [R15], [R19], [R20], [R22], and [R23] remain excluded from BibTeX, [R19] through [R24] remain tracker/audit-only for the first arXiv-style package, production benchmark evidence is still not available, final bibliography formatting is not complete, final reproduction transcript and artifact package review are incomplete, final export decisions remain unresolved, and final human review has not been completed.
 
 No fake citations were added. Future citation work should use only verified tracker entries and should not support production, API-cost, energy, production-validation, broad superiority, or cited-system superiority claims.


### PR DESCRIPTION
## Summary
- Added arXiv-style metadata checklist with supplied author, affiliation, email, endorsement, and pending category/license/export fields.
- Added conservative arXiv bibliography scope for manuscript v0.4 citations and first-package exclusions.
- Added arXiv-style package readiness doc and future venue-scan placeholder.
- Updated Paper Track status docs and final human review packet to reflect the supplied arXiv-first direction.

## Boundaries
- Paper remains not submission-ready.
- Endorsement is marked already obtained / not blocking.
- Category compatibility remains pending; no arXiv category selected.
- No conference/workshop/journal selected or submitted to.
- No new references, source code, tests, CI, README, benchmark artifacts, or KORA Studio files changed.
- No production/API-cost/energy/broad superiority/formal approval claims added.

## Validation
- git diff --check: passed
- python3 -m pytest: 159 passed
- Unicode scan over changed files and manuscript v0.4: clean, ASCII only
- Targeted internal/claim scan: only expected non-claim and not-ready status language found