### PR TITLE
docs: add paper figure table algorithm asset pass

### DIFF
--- a/docs/paper/kora-first-paper-arxiv-style-package-readiness-v0-1.md
+++ b/docs/paper/kora-first-paper-arxiv-style-package-readiness-v0-1.md
@@ -36,6 +36,7 @@ This artifact records readiness for a venue-neutral arXiv-style preprint package
 | License | Pending arXiv distribution-license decision | User decision required |
 | Export format | Markdown draft exists | PDF/LaTeX/Markdown export package pending |
 | Source package | Not prepared | Prepare only after export route is selected |
+| Figures/tables/algorithm assets | Text-based drafts exist | Human insertion, numbering, and export treatment pending |
 | Review/survey/position framing | Avoided | Preserve original systems/evaluation framing |
 | Final human review | Pending | Required before any submission action |
 
@@ -69,6 +70,10 @@ The reproduction transcript checklist exists, but a final clean transcript has n
 
 The artifact package inventory exists. Final artifact availability wording, selected artifact bundle, and export package remain pending.
 
+## Figure, Table, and Algorithm Status
+
+The figure/table/algorithm plan and draft docs exist. They provide text-based Mermaid diagrams, benchmark and evidence-boundary tables, deterministic-first routing pseudocode, and an appendix artifact inventory table. Manuscript v0.4 was not edited in that pass. Human review is still needed before insertion into the arXiv-style export package.
+
 ## Missing User Approvals
 
 - Final title and abstract approval.
@@ -76,7 +81,7 @@ The artifact package inventory exists. Final artifact availability wording, sele
 - arXiv category and category compatibility approval.
 - arXiv license selection.
 - Final bibliography/citation formatting approval.
-- Final figures, tables, reproduction transcript, and artifact package approval.
+- Final figures, tables, algorithm placement, reproduction transcript, and artifact package approval.
 - Final submission-ready decision.
 
 ## Conclusion

--- a/docs/paper/kora-first-paper-figure-table-algorithm-drafts-v0-1.md
+++ b/docs/paper/kora-first-paper-figure-table-algorithm-drafts-v0-1.md
@@ -1,0 +1,155 @@
+# KORA First Paper Figure, Table, and Algorithm Drafts v0.1
+
+Status date: 2026-05-13
+
+## Purpose
+
+This document drafts text-based paper assets for manuscript v0.4 review: figures, tables, pseudocode, captions, and appendix inventory material. It does not create binary assets, does not add new benchmark numbers, and does not mark the paper as submission-ready.
+
+## Figure 1: KORA Execution-Control Architecture
+
+Suggested insertion: Section 3, KORA Execution Model.
+
+```mermaid
+flowchart LR
+  A["User or application input"] --> B["KORA execution-control layer"]
+  B --> C["Task path / route selection"]
+  C --> D["Deterministic route"]
+  C --> E["Tool / schema / validation route"]
+  C --> F["Model escalation path"]
+  D --> G["Validation"]
+  E --> G
+  F --> G
+  G --> H["Output"]
+  G --> I["Telemetry and counters"]
+```
+
+Caption: KORA inserts an execution-control layer before inference. Deterministic, structured, and validation routes are attempted when sufficient; model escalation remains available when deterministic handling is not sufficient. The figure describes architecture only and does not claim production readiness.
+
+Insertion note: Use as a rendered figure or keep as a text/flowchart appendix item depending on final export route.
+
+## Figure 2: Direct Baseline vs KORA-Controlled Benchmark Flow
+
+Suggested insertion: Section 4, Evaluation Methodology, or Section 5.1, Deterministic-heavy benchmark.
+
+```mermaid
+flowchart LR
+  A["100 deterministic-heavy tasks"] --> B["Naive direct baseline"]
+  B --> C["100 simulated model invocations"]
+  A --> D["KORA-controlled path"]
+  D --> E["80 deterministic / no-model completions"]
+  D --> F["20 model-candidate paths"]
+  E --> G["80 avoided simulated model invocations"]
+  F --> H["20 simulated model invocations counted"]
+```
+
+Caption: The deterministic-heavy benchmark compares a naive direct baseline with KORA-controlled execution. The direct baseline counts 100 simulated model invocations. KORA-controlled execution records 20 simulated model invocations and 80 avoided simulated model invocations, for an 80% avoided invocation rate in this workload. This does not imply real API calls, production traffic, cost savings, or energy reduction.
+
+Insertion note: Keep "simulated model invocations" in labels and caption.
+
+## Table 1: Deterministic-Heavy Benchmark Result Summary
+
+Suggested insertion: Section 5.1, Deterministic-heavy benchmark.
+
+| Metric | Value | Scope note |
+|---|---:|---|
+| Total tasks | 100 | Deterministic-heavy benchmark workload |
+| Deterministic/no-model tasks | 80 | Established workload metadata |
+| Fallback/model-candidate tasks | 20 | Established workload metadata |
+| Direct-baseline simulated model invocations | 100 | Baseline counts one simulated invocation per task |
+| KORA-controlled simulated model invocations | 20 | KORA-controlled path counts model-candidate paths |
+| Avoided simulated model invocations | 80 | Baseline count minus KORA-controlled count |
+| Avoided invocation rate | 80% | `80 / 100` |
+| Deterministic outputs checked | 80 | Established benchmark metadata |
+| Mismatches | 0 | Established benchmark metadata |
+| Fallback/model-candidate skipped | 20 | Established benchmark metadata |
+
+Caption: Deterministic-heavy benchmark counters for the current reproducible 100-task workload. Values are simulated model-invocation counters and deterministic output checks; they are not production, real API-cost, latency, or energy measurements.
+
+## Table 2: Evidence Boundary / Non-Claim Table
+
+Suggested insertion: Section 6, Limitations, or near the Results interpretation.
+
+| Statement | Status in current paper | Evidence basis |
+|---|---|---|
+| Reproducible deterministic-heavy benchmark | Supported | Tracked workload, benchmark commands, and reviewer-safe docs |
+| Simulated model invocation reduction | Supported for current workload | 100 direct-baseline simulated invocations vs 20 KORA-controlled simulated invocations |
+| Deterministic output checks | Supported for deterministic subset | 80 deterministic outputs checked with 0 mismatches |
+| Synthetic local/no-network validation | Supported as local validation only | Customer-support triage fake validation example |
+| Production API cost reduction | Not claimed | No production traffic, provider billing, or cost methodology in current evidence |
+| Real provider benchmark | Not claimed | Offline/local evidence only in current paper scope |
+| Energy reduction | Not claimed | No energy measurement methodology or result |
+| Broad workload superiority | Not claimed | Evidence is limited to documented workloads |
+| Formal artifact approval | Not claimed | No formal artifact evaluation has occurred |
+
+Caption: Evidence boundary table for the first KORA paper. The supported claims are limited to documented benchmark and local/no-network validation evidence; stronger production, cost, energy, broad-superiority, and formal-approval claims are out of scope.
+
+## Algorithm 1: Deterministic-First Routing Pseudocode
+
+Suggested insertion: Section 3, KORA Execution Model.
+
+```text
+Algorithm 1: Deterministic-first routing
+
+Input:
+  tasks: structured task requests
+  routes: deterministic, structured, policy, and model-candidate routes
+
+Output:
+  outputs, validation results, telemetry counters
+
+for each task in tasks:
+    path = select_task_path(task, routes)
+
+    if deterministic_or_structured_route_is_sufficient(path, task):
+        candidate_output = run_deterministic_or_structured_route(path, task)
+        validation_result = validate_output(candidate_output, task)
+
+        if validation_result.accepted:
+            record_telemetry(task, route="deterministic_or_structured")
+            emit(candidate_output)
+            continue
+
+    model_candidate = prepare_model_candidate_path(task, path)
+    candidate_output = run_or_count_model_candidate(model_candidate)
+    validation_result = validate_output(candidate_output, task)
+    record_telemetry(task, route="model_candidate")
+    emit(candidate_output)
+```
+
+Caption: Conceptual pseudocode for deterministic-first routing. KORA attempts deterministic or structured handling before model-candidate escalation, validates route outputs, and records telemetry. This is a paper-level abstraction and not an implementation guarantee for every route class.
+
+## Appendix Table: Artifact and Reproducibility Inventory
+
+Suggested insertion: appendix or reproducibility section.
+
+| Artifact role | Repository path | Package status |
+|---|---|---|
+| Manuscript draft | `docs/paper/kora-first-paper-manuscript-v0-4.md` | Current submission-candidate draft, not final |
+| Figure/table/algorithm plan | `docs/paper/kora-first-paper-figure-table-algorithm-plan-v0-1.md` | Created for human review |
+| Figure/table/algorithm drafts | `docs/paper/kora-first-paper-figure-table-algorithm-drafts-v0-1.md` | Created for human review |
+| Workload generator | `experiments/generate_workload.py` | Tracked source |
+| Canonical deterministic-heavy workload | `experiments/workloads/deterministic_heavy_v1_100.json` | Tracked workload |
+| Benchmark runner | `experiments/run_benchmark.py` | Tracked source |
+| Benchmark summary generator | `experiments/summarize_benchmark_results.py` | Tracked source |
+| Runtime benchmark example | `examples/runtime_integrated_benchmark/run.py` | Tracked source |
+| Runtime benchmark report script | `examples/runtime_integrated_benchmark/report.py` | Tracked source |
+| Reproduction transcript checklist | `docs/paper/kora-first-paper-reproduction-transcript-checklist-v0-1.md` | Checklist exists; final transcript pending |
+| Artifact package inventory | `docs/paper/kora-first-paper-artifact-package-inventory-v0-1.md` | Inventory exists; final package pending |
+| Benchmark artifact policy | `docs/reports/benchmark_artifact_policy.md` | Tracked policy |
+| Runtime evidence reviewer guide | `docs/reports/v0.3.0-alpha-runtime-evidence-reviewer-guide.md` | Tracked reviewer guide |
+
+Caption: Repository artifact and reproducibility inventory for the first KORA paper package. The table identifies tracked source and documentation paths; it does not include raw generated benchmark artifacts and does not claim formal artifact approval.
+
+## Human Review Items
+
+- Decide whether Mermaid diagrams should be rendered into final PDF figures or converted to venue/export-specific graphics later.
+- Decide whether Table 1 replaces or augments the current Section 5.1 table.
+- Decide whether Table 2 belongs in the main text or limitations section.
+- Decide whether Algorithm 1 belongs in the main text or appendix.
+- Decide whether the appendix artifact table should be shortened for arXiv export.
+- Confirm figure/table/algorithm numbering after final export format is selected.
+
+## Status
+
+The draft assets are ready for human review. Manuscript v0.4 was not edited in this pass. The paper remains not submission-ready.

--- a/docs/paper/kora-first-paper-figure-table-algorithm-plan-v0-1.md
+++ b/docs/paper/kora-first-paper-figure-table-algorithm-plan-v0-1.md
@@ -1,0 +1,72 @@
+# KORA First Paper Figure, Table, and Algorithm Plan v0.1
+
+Status date: 2026-05-13
+
+## Purpose
+
+This plan inventories existing paper-support assets and identifies the minimum figure, table, flowchart, pseudocode, and appendix materials needed around manuscript v0.4. It does not create binary image assets, does not submit to arXiv, and does not mark the paper as submission-ready.
+
+## Source Files Reviewed
+
+- `docs/paper/kora-first-paper-manuscript-v0-4.md`
+- `docs/paper/kora-first-paper-figures-and-tables.md`
+- `docs/paper/kora-first-paper-figure-specs.md`
+- `docs/paper/kora-first-paper-table-specs.md`
+- `docs/paper/kora-first-paper-submission-candidate-status-v0-1.md`
+- `docs/paper/kora-first-paper-submission-package-readiness-v0-1.md`
+- `docs/paper/kora-first-paper-arxiv-style-package-readiness-v0-1.md`
+- `docs/paper/kora-first-paper-reproduction-transcript-checklist-v0-1.md`
+- `docs/paper/kora-first-paper-artifact-package-inventory-v0-1.md`
+- `docs/reports/benchmark_artifact_policy.md`
+- `docs/README.md`
+- `README.md`
+- `experiments/README.md`
+
+## Current Manuscript Version
+
+- Current manuscript: `docs/paper/kora-first-paper-manuscript-v0-4.md`
+- Current status: submission-candidate draft, not submission-ready.
+- Manuscript v0.4 already contains text tables for deterministic-heavy and customer-support results.
+- Manuscript v0.4 has not been edited in this asset pass.
+
+## Existing Assets Found
+
+| Asset or spec | Path | Status for paper |
+|---|---|---|
+| KORA benchmark evidence card | `docs/assets/kora-benchmark-evidence-card.svg`, `docs/assets/kora-benchmark-evidence-card.png` | Existing public visual; needs paper-fit review before inclusion |
+| KORA control layer architecture | `docs/assets/kora-control-layer-architecture.svg` | Existing public visual; candidate architecture reference |
+| KORA execution control overview | `docs/assets/kora-execution-control-overview.svg`, `docs/assets/kora-execution-control-overview.png` | Existing public visual; candidate architecture reference |
+| Help-test flow | `docs/assets/kora-help-test-flow.svg`, `docs/assets/kora-help-test-flow.png` | Existing public visual; not first-paper core unless appendix needs contributor flow |
+| Validation roadmap | `docs/assets/kora-validation-roadmap.svg`, `docs/assets/kora-validation-roadmap.png` | Existing public visual; future-work context only |
+| Figure specifications | `docs/paper/kora-first-paper-figure-specs.md` | Planning spec exists |
+| Table specifications | `docs/paper/kora-first-paper-table-specs.md` | Planning spec exists |
+| Figure/table planning doc | `docs/paper/kora-first-paper-figures-and-tables.md` | Planning doc exists |
+
+## Missing Recommended Assets
+
+- Paper-ready architecture figure draft with caption.
+- Paper-ready benchmark-flow figure draft with caption.
+- Consolidated deterministic-heavy benchmark result table using only established counters.
+- Evidence boundary / non-claim table.
+- Deterministic-first routing pseudocode.
+- Appendix artifact/reproducibility inventory table using real repository paths.
+- Human-reviewed insertion decision for manuscript v0.4 or a later v0.5/export draft.
+
+## Proposed Asset Set
+
+| Asset | Proposed insertion section | Claim boundary | Status |
+|---|---|---|---|
+| Figure 1: KORA execution-control architecture | Section 3, KORA Execution Model | Architecture explanation only; no production-readiness claim | Drafted in `kora-first-paper-figure-table-algorithm-drafts-v0-1.md`; needs human review |
+| Figure 2: direct baseline vs KORA-controlled benchmark flow | Section 4 or Section 5.1 | Simulated model invocation counts only; no real API or cost claim | Drafted; needs human review |
+| Table 1: deterministic-heavy benchmark result summary | Section 5.1 | Reproducible deterministic-heavy benchmark only | Drafted; values already established |
+| Table 2: evidence boundary / non-claim table | Section 6 or near Results | Separates supported claims from non-claims | Drafted; needs human review |
+| Algorithm 1: deterministic-first routing pseudocode | Section 3, after execution model | Conceptual pseudocode only; not an implementation guarantee | Drafted; needs human review |
+| Appendix table: artifact/reproducibility inventory | Appendix or Reproducibility section | Repository artifact planning only; no formal artifact approval | Drafted; needs human review |
+
+## Manuscript Insertion Decision
+
+Direct insertion into manuscript v0.4 was deferred in this pass. The manuscript already contains text flow snippets and result tables, and inserting multiple new assets would affect paper layout, numbering, and final export decisions. The safe next step is human review of the draft assets before insertion into manuscript v0.4 or a later manuscript/export draft.
+
+## Status
+
+Paper-ready text asset drafts now exist, but figure/table/algorithm insertion, layout, numbering, and final captions require human review. The paper remains not submission-ready.

--- a/docs/paper/kora-first-paper-final-human-review-packet-v0-1.md
+++ b/docs/paper/kora-first-paper-final-human-review-packet-v0-1.md
@@ -26,7 +26,7 @@ This packet lists the human decisions still required before any submission-ready
 | Bibliography scope | Confirm the conservative first arXiv-style package scope | Draft scope supplied; final approval pending |
 | Limitations | Approve limitations and non-claim language | Pending |
 | Artifact and reproducibility | Approve artifact package scope and reproduction transcript expectations | Pending |
-| Figures and tables | Approve final rendered figures, tables, captions, and numbering | Pending |
+| Figures, tables, and algorithm | Approve final diagrams, tables, pseudocode, captions, numbering, and placement | Draft assets exist; final approval pending |
 | Author and affiliation metadata | Approve final author block, affiliation, and email display | Draft metadata supplied; final approval pending |
 | Acknowledgement, funding, conflict, and ethics metadata | Approve minimal required disclosure text if any | Pending |
 | Target venue and export format | Confirm arXiv category, license, and export route | arXiv-style direction supplied; details pending |
@@ -46,6 +46,15 @@ This packet lists the human decisions still required before any submission-ready
 - Decide whether latency p50/p95 evidence stays outside the first submission scope.
 - Decide whether API-cost, production-traffic, energy, and real customer-data studies stay outside the first submission scope.
 - Decide whether KORA Studio discussion remains outside the first submission scope.
+
+## Figure, Table, and Algorithm Decisions
+
+- Decide whether Figure 1 and Figure 2 should use Mermaid-rendered diagrams, exported graphics, or text/ASCII form.
+- Decide whether Table 1 replaces or augments the existing deterministic-heavy benchmark table in manuscript v0.4.
+- Decide whether Table 2 belongs in the main text, limitations, or appendix.
+- Decide whether Algorithm 1 belongs in Section 3 or an appendix.
+- Decide whether the appendix artifact inventory table should be included in the arXiv-style package or kept as reviewer-support material.
+- Confirm final numbering and captions after export format is selected.
 
 ## Venue and Export Decisions
 

--- a/docs/paper/kora-first-paper-missing-evidence-checklist.md
+++ b/docs/paper/kora-first-paper-missing-evidence-checklist.md
@@ -117,6 +117,8 @@ Citation style decision:
 - arXiv metadata checklist v0.1, arXiv bibliography scope v0.1, arXiv-style package readiness v0.1, and future venue scan placeholder v0.1 have been created.
 - arXiv endorsement is already obtained and is not a current blocker.
 - arXiv category compatibility, arXiv license, export package, final transcript, final artifact package review, and final human approval remain pending.
+- Figure/table/algorithm plan v0.1 and draft assets v0.1 have been created.
+- Final figure/table/algorithm insertion, numbering, layout, and export treatment remain pending human review.
 - Clean reproduction transcript capture, final artifact package review, final venue/export decision, and final human review remain pending.
 - Paper is still not submission-ready.
 

--- a/docs/paper/kora-first-paper-submission-candidate-status-v0-1.md
+++ b/docs/paper/kora-first-paper-submission-candidate-status-v0-1.md
@@ -66,6 +66,15 @@ The arXiv-style package draft docs now exist:
 
 These files record the supplied author metadata, endorsement status, conservative bibliography scope, original systems/evaluation framing, and future venue-scan placeholder. They do not submit to arXiv, select an arXiv category, select a conference/workshop/journal, or mark the paper as submission-ready.
 
+## Figure, Table, and Algorithm Asset Pass
+
+The figure/table/algorithm asset pass now exists:
+
+- `docs/paper/kora-first-paper-figure-table-algorithm-plan-v0-1.md`
+- `docs/paper/kora-first-paper-figure-table-algorithm-drafts-v0-1.md`
+
+These files inventory existing visual assets, draft paper-ready text diagrams, benchmark tables, an evidence-boundary table, deterministic-first routing pseudocode, and an appendix artifact inventory table. Manuscript v0.4 was not edited in this pass; final insertion, numbering, layout, and export treatment require human review.
+
 ## Submission Package Packet
 
 The venue-neutral submission package readiness packet now exists:

--- a/docs/paper/kora-first-paper-submission-package-readiness-v0-1.md
+++ b/docs/paper/kora-first-paper-submission-package-readiness-v0-1.md
@@ -56,7 +56,7 @@ This venue-neutral checklist records what is present, missing, and blocked befor
 
 - Final full BibTeX and final bibliography formatting.
 - Final manuscript-to-final-bibliography synchronization.
-- Final rendered figures and tables.
+- Final human-approved figures, tables, algorithm placement, numbering, and rendered/export form.
 - Clean reproduction transcript from a fresh checkout.
 - Final artifact availability statement and package selection.
 - Final author/email display, acknowledgement, funding, conflict, and ethics wording if needed.
@@ -80,3 +80,12 @@ This venue-neutral checklist records what is present, missing, and blocked befor
 6. Prepare artifact availability wording and selected artifact bundle.
 7. Run final claim-to-evidence audit against the exact exported manuscript.
 8. Complete final human review and only then decide whether the paper is submission-ready.
+
+## Figure, Table, and Algorithm Asset Status
+
+Figure/table/algorithm plan and draft docs now exist:
+
+- `docs/paper/kora-first-paper-figure-table-algorithm-plan-v0-1.md`
+- `docs/paper/kora-first-paper-figure-table-algorithm-drafts-v0-1.md`
+
+They draft text-based architecture and benchmark-flow diagrams, benchmark and evidence-boundary tables, deterministic-first routing pseudocode, and an appendix artifact inventory table. Manuscript insertion and final rendered/export assets remain pending human review.


### PR DESCRIPTION
## Summary
- Added a Paper Track figure/table/algorithm inventory and insertion plan.
- Added paper-ready text asset drafts: two Mermaid flow diagrams, deterministic-heavy benchmark table, evidence-boundary table, deterministic-first routing pseudocode, and appendix artifact inventory table.
- Updated package/readiness and human-review docs to track asset insertion, numbering, layout, and export review.

## Scope
- Paper Track docs only.
- Manuscript v0.4 was not edited; insertion remains pending human review.
- No binary image assets added.
- No source code, tests, CI, README, benchmark raw artifacts, release files, or KORA Studio files changed.
- No arXiv category selected and no arXiv submission made.

## Claim safety
- Uses only established benchmark values: 100 tasks, 80 deterministic/no-model tasks, 20 model-candidate paths, 100 direct-baseline simulated invocations, 20 KORA-controlled simulated invocations, 80 avoided simulated invocations, 80% avoided rate, 80 deterministic outputs checked, 0 mismatches, 20 fallback/model-candidate skipped.
- No production/API-cost/energy/broad superiority/formal approval claims added.
- Paper remains not submission-ready.

## Validation
- git diff --check: passed
- python3 -m pytest: 159 passed
- Unicode scan over changed files and manuscript v0.4: clean, ASCII only
- Targeted internal/claim scan: only expected non-claim and not-ready status language found