### PR TITLE
docs: review v0.5 paper render and export readiness

### DIFF
--- a/docs/paper/kora-first-paper-arxiv-export-package-manifest-v0-1.md
+++ b/docs/paper/kora-first-paper-arxiv-export-package-manifest-v0-1.md
@@ -1,0 +1,59 @@
+# KORA First Paper arXiv Export Package Manifest v0.1
+
+Status date: 2026-05-13
+
+## Purpose
+
+This text-only manifest lists candidate source files and pending package items for a future arXiv-style export. It does not create an export package, does not generate binary outputs, does not upload artifacts, and does not mark the paper as submission-ready.
+
+## Candidate Source Files
+
+| Role | Path | Status |
+|---|---|---|
+| Source manuscript | `docs/paper/kora-first-paper-manuscript-v0-5.md` | Current draft source |
+| Preliminary BibTeX | `docs/paper/kora-first-paper-preliminary-bibtex-v0-1.md` | Preliminary; final formatting pending |
+| Bibliography scope | `docs/paper/kora-first-paper-arxiv-bibliography-scope-v0-1.md` | Scope note exists |
+| Metadata checklist | `docs/paper/kora-first-paper-arxiv-metadata-checklist-v0-1.md` | Metadata draft exists |
+| Render/export readiness report | `docs/paper/kora-first-paper-v0-5-render-export-readiness-v0-1.md` | Created in this pass |
+| Figure/table/algorithm drafts | `docs/paper/kora-first-paper-figure-table-algorithm-drafts-v0-1.md` | Source for inserted text assets |
+| Figure/table/algorithm plan | `docs/paper/kora-first-paper-figure-table-algorithm-plan-v0-1.md` | Planning/status source |
+| Reproduction checklist | `docs/paper/kora-first-paper-reproduction-transcript-checklist-v0-1.md` | Checklist exists; final transcript pending |
+| Artifact inventory | `docs/paper/kora-first-paper-artifact-package-inventory-v0-1.md` | Inventory exists; final package selection pending |
+| Benchmark artifact policy | `docs/reports/benchmark_artifact_policy.md` | Policy source |
+| Runtime evidence reviewer guide | `docs/reports/v0.3.0-alpha-runtime-evidence-reviewer-guide.md` | Reviewer guide |
+
+## Figures, Tables, and Algorithm Source
+
+- Figure 1 source: Mermaid block in `docs/paper/kora-first-paper-manuscript-v0-5.md`.
+- Figure 2 source: Mermaid block in `docs/paper/kora-first-paper-manuscript-v0-5.md`.
+- Table 1 source: Markdown table in `docs/paper/kora-first-paper-manuscript-v0-5.md`.
+- Table 2 source: Markdown table in `docs/paper/kora-first-paper-manuscript-v0-5.md`.
+- Algorithm 1 source: fenced text block in `docs/paper/kora-first-paper-manuscript-v0-5.md`.
+- Appendix Table A1 source: Markdown table in `docs/paper/kora-first-paper-manuscript-v0-5.md`.
+
+## Not Included
+
+- Binary PDF.
+- Rendered figure image files.
+- Raw benchmark JSON artifacts.
+- Temporary Markdown evidence packets.
+- Provider responses.
+- API keys or credentials.
+- Private user data or production traffic.
+- arXiv submission package upload.
+- Release assets.
+
+## Pending Package Items
+
+- Select final arXiv category and confirm category compatibility.
+- Confirm arXiv license.
+- Choose export route and source-package format.
+- Convert or render Mermaid diagrams to arXiv-compatible figure assets if needed.
+- Finalize bibliography and citation formatting.
+- Review table widths and caption placement for PDF layout.
+- Capture final clean reproduction transcript.
+- Complete final human review.
+
+## Status
+
+This manifest is a planning artifact only. No binary outputs or raw benchmark artifacts were created or committed. The paper remains not submission-ready.

--- a/docs/paper/kora-first-paper-arxiv-style-package-readiness-v0-1.md
+++ b/docs/paper/kora-first-paper-arxiv-style-package-readiness-v0-1.md
@@ -9,6 +9,7 @@ This artifact records readiness for a venue-neutral arXiv-style preprint package
 ## Source Files Reviewed
 
 - `docs/paper/kora-first-paper-manuscript-v0-4.md`
+- `docs/paper/kora-first-paper-manuscript-v0-5.md`
 - `docs/paper/kora-first-paper-arxiv-metadata-checklist-v0-1.md`
 - `docs/paper/kora-first-paper-arxiv-bibliography-scope-v0-1.md`
 - `docs/paper/kora-first-paper-submission-package-readiness-v0-1.md`
@@ -34,9 +35,9 @@ This artifact records readiness for a venue-neutral arXiv-style preprint package
 | Candidate categories | `cs.AI`, `cs.LG`, `cs.DC`, `cs.SE` | Candidates only; no category selected here |
 | Title / abstract | v0.5 title and abstract exist | Final human approval pending |
 | License | Pending arXiv distribution-license decision | User decision required |
-| Export format | Markdown draft exists | PDF/LaTeX/Markdown export package pending |
-| Source package | Not prepared | Prepare only after export route is selected |
-| Figures/tables/algorithm assets | Text-based drafts exist | Human insertion, numbering, and export treatment pending |
+| Export format | Markdown draft exists; render/export readiness reviewed | PDF/LaTeX/Markdown export package pending |
+| Source package | Text-only export manifest exists | Prepare final package only after export route is selected |
+| Figures/tables/algorithm assets | Inserted in manuscript v0.5 as Markdown/Mermaid/text assets | Render/conversion, numbering, and export treatment pending |
 | Review/survey/position framing | Avoided | Preserve original systems/evaluation framing |
 | Final human review | Pending | Required before any submission action |
 
@@ -73,6 +74,15 @@ The artifact package inventory exists. Final artifact availability wording, sele
 ## Figure, Table, and Algorithm Status
 
 The figure/table/algorithm plan and draft docs exist. They provide text-based Mermaid diagrams, benchmark and evidence-boundary tables, deterministic-first routing pseudocode, and an appendix artifact inventory table. Manuscript v0.5 now inserts those assets. Human review is still needed before final rendering and inclusion in the arXiv-style export package.
+
+## Render and Export Readiness Status
+
+The v0.5 render/export readiness report and text-only export package manifest now exist:
+
+- `docs/paper/kora-first-paper-v0-5-render-export-readiness-v0-1.md`
+- `docs/paper/kora-first-paper-arxiv-export-package-manifest-v0-1.md`
+
+No repository paper export pipeline was found, no PDF was generated, and no binary output was committed. Mermaid diagrams remain suitable for repository review but need rendering or conversion before an arXiv-compatible package.
 
 ## Missing User Approvals
 

--- a/docs/paper/kora-first-paper-final-human-review-packet-v0-1.md
+++ b/docs/paper/kora-first-paper-final-human-review-packet-v0-1.md
@@ -55,6 +55,8 @@ This packet lists the human decisions still required before any submission-ready
 - Review whether Algorithm 1 should stay in Section 3 or move to an appendix.
 - Review whether Appendix Table A1 should be included in the arXiv-style package or kept as reviewer-support material.
 - Confirm final numbering and captions after export format is selected.
+- Review the v0.5 render/export readiness report before approving final PDF/source-package treatment.
+- Decide whether Mermaid diagrams should be rendered to image files, converted to another source format, or replaced with text/ASCII diagrams for final export.
 
 ## Venue and Export Decisions
 

--- a/docs/paper/kora-first-paper-missing-evidence-checklist.md
+++ b/docs/paper/kora-first-paper-missing-evidence-checklist.md
@@ -120,6 +120,8 @@ Citation style decision:
 - Figure/table/algorithm plan v0.1 and draft assets v0.1 have been created.
 - Manuscript v0.5 has been created with figure/table/algorithm assets inserted.
 - Final figure/table/algorithm numbering, layout, rendering, and export treatment remain pending human review.
+- v0.5 render/export readiness report and text-only export manifest have been created.
+- No dedicated paper export pipeline has been found; final PDF/source-package generation remains pending.
 - Clean reproduction transcript capture, final artifact package review, final venue/export decision, and final human review remain pending.
 - Paper is still not submission-ready.
 

--- a/docs/paper/kora-first-paper-submission-candidate-status-v0-1.md
+++ b/docs/paper/kora-first-paper-submission-candidate-status-v0-1.md
@@ -96,6 +96,15 @@ Manuscript v0.5 now inserts:
 
 The inserted assets remain draft Markdown/Mermaid/text assets. Final rendering, numbering, layout, and export treatment remain pending.
 
+## v0.5 Render and Export Readiness Pass
+
+The v0.5 render/export readiness report and text-only export manifest now exist:
+
+- `docs/paper/kora-first-paper-v0-5-render-export-readiness-v0-1.md`
+- `docs/paper/kora-first-paper-arxiv-export-package-manifest-v0-1.md`
+
+No dedicated paper export pipeline was found. No PDF, rendered figure, binary export, or raw benchmark artifact was generated or committed. The manuscript remains suitable for repository Markdown review, but final arXiv-compatible export requires a chosen export route and figure rendering/conversion.
+
 ## Submission Package Packet
 
 The venue-neutral submission package readiness packet now exists:
@@ -109,4 +118,4 @@ These files organize package blockers, human review decisions, reproduction tran
 
 ## Status
 
-The manuscript has advanced to v0.5 submission-candidate draft status. Full BibTeX remains incomplete, final asset rendering/export review remains pending, and the paper remains not submission-ready.
+The manuscript has advanced to v0.5 submission-candidate draft status. Full BibTeX remains incomplete, final export route and asset rendering/conversion remain pending, and the paper remains not submission-ready.

--- a/docs/paper/kora-first-paper-submission-package-readiness-v0-1.md
+++ b/docs/paper/kora-first-paper-submission-package-readiness-v0-1.md
@@ -89,3 +89,9 @@ Figure/table/algorithm plan and draft docs now exist:
 - `docs/paper/kora-first-paper-figure-table-algorithm-drafts-v0-1.md`
 
 They draft text-based architecture and benchmark-flow diagrams, benchmark and evidence-boundary tables, deterministic-first routing pseudocode, and an appendix artifact inventory table. Manuscript v0.5 now inserts these draft assets. Final rendered/export assets, numbering, layout, and captions remain pending human review.
+
+## v0.5 Render and Export Readiness Status
+
+Render/export readiness has been reviewed in `docs/paper/kora-first-paper-v0-5-render-export-readiness-v0-1.md`, and a text-only export package manifest exists at `docs/paper/kora-first-paper-arxiv-export-package-manifest-v0-1.md`.
+
+No dedicated paper export pipeline was found in the repository. No PDF, rendered figure, binary export, or raw benchmark artifact was generated or committed. Final export route, Mermaid rendering/conversion, table layout, bibliography formatting, and human approval remain pending.

--- a/docs/paper/kora-first-paper-v0-5-render-export-readiness-v0-1.md
+++ b/docs/paper/kora-first-paper-v0-5-render-export-readiness-v0-1.md
@@ -1,0 +1,113 @@
+# KORA First Paper v0.5 Render and Export Readiness v0.1
+
+Status date: 2026-05-13
+
+## Purpose
+
+This report reviews manuscript v0.5 for Markdown, Mermaid, table, pseudocode, and export-package readiness. It does not generate a PDF, does not submit to arXiv, and does not mark the paper as submission-ready.
+
+## Manuscript Reviewed
+
+- `docs/paper/kora-first-paper-manuscript-v0-5.md`
+
+## Source Files Reviewed
+
+- `docs/paper/kora-first-paper-manuscript-v0-5.md`
+- `docs/paper/kora-first-paper-figure-table-algorithm-plan-v0-1.md`
+- `docs/paper/kora-first-paper-figure-table-algorithm-drafts-v0-1.md`
+- `docs/paper/kora-first-paper-arxiv-style-package-readiness-v0-1.md`
+- `docs/paper/kora-first-paper-submission-package-readiness-v0-1.md`
+- `docs/paper/kora-first-paper-final-human-review-packet-v0-1.md`
+- `docs/paper/kora-first-paper-reproduction-transcript-checklist-v0-1.md`
+- `docs/paper/kora-first-paper-artifact-package-inventory-v0-1.md`
+- `docs/paper/kora-first-paper-preliminary-bibtex-v0-1.md`
+- `README.md`
+- `docs/README.md`
+- `.github/workflows/ci.yml`
+- `pyproject.toml`
+
+## Rendering Review
+
+| Area | Review result | Risk | Action |
+|---|---|---|---|
+| Heading hierarchy | Ordered from title to section/subsection/appendix | Low | No manuscript fix needed |
+| Mermaid Figure 1 | Uses a simple `flowchart LR`; node labels are quoted | Medium | GitHub Markdown should render; arXiv/PDF export needs rendered image or conversion path |
+| Mermaid Figure 2 | Uses a simple `flowchart LR`; node labels are quoted | Medium | GitHub Markdown should render; arXiv/PDF export needs rendered image or conversion path |
+| Markdown tables | Tables are syntactically valid | Medium | Wide rows may need narrowing for PDF/LaTeX export |
+| Algorithm block | Uses fenced `text` pseudocode | Low | No manuscript fix needed |
+| Figure/table numbering | Figure 1, Figure 2, Table 1, Table 2, Algorithm 1, Appendix Table A1 are internally consistent | Low | Final numbering still needs human review after export |
+| Appendix numbering | Appendix A and Table A1 are consistent | Low | No manuscript fix needed |
+| Internal references | No broken Markdown links found in the new v0.5 additions | Low | No manuscript fix needed |
+| Local paths | Artifact paths in Appendix Table A1 exist in the repository | Low | No manuscript fix needed |
+| Unicode/text hygiene | ASCII-only in changed files | Low | No manuscript fix needed |
+
+## Fixes Applied
+
+No manuscript content fixes were required in this pass. Status/readiness documents were updated to record that render/export readiness has been reviewed and that final export remains pending.
+
+## Export Pipeline Status
+
+No dedicated paper export pipeline was found in the repository.
+
+Checked for:
+
+- repository `Makefile`
+- Pandoc or LaTeX paper build scripts
+- Markdown-to-PDF export scripts
+- paper-specific export instructions
+- docs build/export GitHub Actions
+- pyproject export tooling
+
+Current repository automation is CI/test oriented. `.github/workflows/ci.yml` installs the package, runs release smoke checks, and runs pytest. It does not build a paper PDF or arXiv source package.
+
+## PDF and Source Package Status
+
+- PDF generated in this pass: no.
+- Binary PDF committed: no.
+- arXiv source package created: no.
+- Raw benchmark artifacts uploaded or committed: no.
+- Export package manifest created: yes, see `docs/paper/kora-first-paper-arxiv-export-package-manifest-v0-1.md`.
+
+## Mermaid Rendering Status
+
+Mermaid syntax is appropriate for GitHub Markdown review, but arXiv does not accept Mermaid as a rendered figure by itself. Before submission, Figure 1 and Figure 2 need one of these paths:
+
+- render Mermaid diagrams to reviewed image files and include those in the source package, or
+- convert diagrams to LaTeX/TikZ or another arXiv-compatible figure source, or
+- replace Mermaid diagrams with plain text/ASCII diagrams if the package stays text-only.
+
+No rendered diagram files were created in this pass.
+
+## Table Rendering Status
+
+The Markdown tables are valid for repository review. For PDF/LaTeX export, Table 1, Table 2, and Appendix Table A1 may need:
+
+- shortened row text,
+- smaller font or landscape/appendix treatment,
+- conversion to LaTeX tables,
+- final caption placement.
+
+No benchmark values were changed.
+
+## Remaining Blockers
+
+- Select final arXiv category and confirm category compatibility.
+- Confirm arXiv license.
+- Decide final export route: Markdown-to-PDF, LaTeX, or another arXiv-compatible source package.
+- Render or convert Mermaid diagrams for arXiv-compatible submission.
+- Review and possibly narrow wide tables for final PDF layout.
+- Finalize bibliography formatting and full citation treatment.
+- Capture final clean reproduction transcript.
+- Complete final human review.
+
+## Claim Safety
+
+The render/export review does not change the bounded claim:
+
+> KORA reduced model invocations by 80% in a reproducible deterministic-heavy benchmark workload.
+
+This report does not support production cost reduction proof, real API-cost reduction proof, production benchmark proof, full runtime-integrated real-provider benchmark evidence, broad workload superiority proof, energy reduction evidence, formal government validation, signed partner validation, guaranteed adoption or funding, formal artifact approval, or paper submission readiness.
+
+## Status
+
+Manuscript v0.5 is ready for repository Markdown review, but not ready for arXiv submission. Export tooling, figure rendering/conversion, final table layout, final bibliography formatting, and human approval remain pending. The paper remains not submission-ready.


### PR DESCRIPTION
## Summary
- add a v0.5 render/export readiness report for the KORA first paper
- add a text-only arXiv export package manifest
- update Paper Track status/readiness docs to reflect export-pipeline status, Mermaid/table export blockers, and pending human review

## Rendering / export status
- manuscript v0.5 Markdown structure, Mermaid blocks, tables, algorithm block, numbering, appendix numbering, and inserted artifact paths were reviewed
- no manuscript content changes were needed
- no dedicated paper export pipeline was found in the repo
- no PDF, binary figure export, arXiv upload, or raw benchmark artifact was generated or committed

## Claim and readiness boundaries
- bounded 80% deterministic-heavy benchmark claim is preserved
- no production/API-cost/energy/broad superiority/formal approval claims are added
- paper remains not submission-ready

## Validation
- git diff --check: passed
- python3 -m pytest: 159 passed
- targeted internal/claim scan: only expected non-claim/status language
- Unicode scan: no hidden/control/bidi/zero-width or non-ASCII characters
