### PR TITLE
docs: add arxiv export route dry run

### DIFF
--- a/docs/paper/kora-first-paper-arxiv-export-package-manifest-v0-1.md
+++ b/docs/paper/kora-first-paper-arxiv-export-package-manifest-v0-1.md
@@ -15,6 +15,8 @@ This text-only manifest lists candidate source files and pending package items f
 | Bibliography scope | `docs/paper/kora-first-paper-arxiv-bibliography-scope-v0-1.md` | Scope note exists |
 | Metadata checklist | `docs/paper/kora-first-paper-arxiv-metadata-checklist-v0-1.md` | Metadata draft exists |
 | Render/export readiness report | `docs/paper/kora-first-paper-v0-5-render-export-readiness-v0-1.md` | Created in this pass |
+| Export route dry-run report | `docs/paper/kora-first-paper-arxiv-export-route-dry-run-v0-1.md` | Dry run completed with `/tmp` outputs only |
+| Export route recommendation | `docs/paper/kora-first-paper-arxiv-export-route-recommendation-v0-1.md` | Recommends Pandoc-to-LaTeX starting route with manual cleanup |
 | Figure/table/algorithm drafts | `docs/paper/kora-first-paper-figure-table-algorithm-drafts-v0-1.md` | Source for inserted text assets |
 | Figure/table/algorithm plan | `docs/paper/kora-first-paper-figure-table-algorithm-plan-v0-1.md` | Planning/status source |
 | Reproduction checklist | `docs/paper/kora-first-paper-reproduction-transcript-checklist-v0-1.md` | Checklist exists; final transcript pending |
@@ -48,7 +50,8 @@ This text-only manifest lists candidate source files and pending package items f
 - Select final arXiv category and confirm category compatibility.
 - Confirm arXiv license.
 - Choose export route and source-package format.
-- Convert or render Mermaid diagrams to arXiv-compatible figure assets if needed.
+- Convert or render Mermaid diagrams to arXiv-compatible figure assets after user approval.
+- Install or select a LaTeX/PDF generation route outside this manifest.
 - Finalize bibliography and citation formatting.
 - Review table widths and caption placement for PDF layout.
 - Capture final clean reproduction transcript.

--- a/docs/paper/kora-first-paper-arxiv-export-route-dry-run-v0-1.md
+++ b/docs/paper/kora-first-paper-arxiv-export-route-dry-run-v0-1.md
@@ -1,0 +1,151 @@
+# KORA First Paper arXiv Export Route Dry Run v0.1
+
+Status date: 2026-05-13
+
+## Purpose
+
+This report records a local export-route dry run for manuscript v0.5. It does not create a committed PDF, does not create committed figure binaries, does not upload an arXiv package, and does not mark the paper as submission-ready.
+
+## Source Files Reviewed
+
+- `docs/paper/kora-first-paper-manuscript-v0-5.md`
+- `docs/paper/kora-first-paper-preliminary-bibtex-v0-1.md`
+- `docs/paper/kora-first-paper-v0-5-render-export-readiness-v0-1.md`
+- `docs/paper/kora-first-paper-arxiv-export-package-manifest-v0-1.md`
+- `docs/paper/kora-first-paper-arxiv-style-package-readiness-v0-1.md`
+- `docs/paper/kora-first-paper-final-human-review-packet-v0-1.md`
+- `docs/paper/kora-first-paper-reproduction-transcript-checklist-v0-1.md`
+- `docs/paper/kora-first-paper-artifact-package-inventory-v0-1.md`
+- `docs/paper/kora-first-paper-submission-candidate-status-v0-1.md`
+
+## Tool Availability
+
+| Tool | Availability | Notes |
+|---|---|---|
+| `pandoc` | Available: 3.9.0.2 | Markdown-to-LaTeX and Markdown-to-HTML dry runs were feasible. |
+| `pdflatex` | Not found | Direct Pandoc PDF generation is blocked locally. |
+| `xelatex` | Not found | XeLaTeX export is blocked locally. |
+| `tectonic` | Not found | Tectonic export is blocked locally. |
+| `mmdc` | Not found | Mermaid-to-image conversion is blocked locally. |
+| `mermaid-cli` | Not found | Mermaid-to-image conversion is blocked locally. |
+| `node` | Available: v22.21.1 | Runtime exists, but no Mermaid CLI is installed. |
+| `npm` | Available: 10.9.4 | No network dependency install was performed. |
+| `python3` | Available: 3.13.5 | Useful for validation scripts only. |
+| `pdftoppm` | Not found | PDF page rendering review is blocked until a PDF renderer is installed. |
+
+## Temporary Dry-Run Area
+
+Generated outputs were placed only under:
+
+```text
+/tmp/kora-paper-export-dry-run
+```
+
+The dry run copied only:
+
+- `kora-first-paper-manuscript-v0-5.md`
+- `kora-first-paper-preliminary-bibtex-v0-1.md`
+
+No generated outputs from `/tmp` were committed.
+
+## Routes Tested
+
+### Route A: Pandoc Markdown to LaTeX / PDF
+
+Commands attempted in `/tmp/kora-paper-export-dry-run`:
+
+```bash
+pandoc kora-first-paper-manuscript-v0-5.md -s -t latex -o kora-first-paper-manuscript-v0-5.tex
+pandoc kora-first-paper-manuscript-v0-5.md -s -o kora-first-paper-manuscript-v0-5.pdf
+```
+
+Result:
+
+- Markdown-to-LaTeX succeeded.
+- Markdown-to-PDF failed because `pdflatex` is not installed locally.
+- The generated LaTeX source is useful as an intermediate export artifact, not as a final source package.
+
+Observed blockers:
+
+- Mermaid diagrams are carried through as code blocks, not rendered figures.
+- Markdown tables become LaTeX `longtable` structures and require final layout review.
+- PDF generation requires a local LaTeX engine or another approved PDF route.
+
+### Route B: Markdown to LaTeX with Mermaid Converted Separately
+
+Mermaid conversion was not executed because neither `mmdc` nor `mermaid-cli` is installed locally.
+
+Recommended blocker handling:
+
+- Convert Figure 1 and Figure 2 to arXiv-compatible figure assets only after user approval of the figure format.
+- Keep generated figure outputs outside the repository until the final package policy is approved.
+
+### Route C: Manual LaTeX Source Package Route
+
+This route was assessed but not created as a full package in this task.
+
+Required steps:
+
+- Use Pandoc-generated LaTeX as a starting point, then manually review and simplify the source.
+- Replace Mermaid code blocks with approved figure assets or text/ASCII diagrams.
+- Convert Table 1, Table 2, and Appendix Table A1 into layout-safe LaTeX tables or simplified text tables.
+- Convert the preliminary BibTeX subset into the final citation style selected for the package.
+- Include only approved source files and exclude raw benchmark artifacts.
+
+This route is likely safer than direct Markdown-to-PDF because it exposes the figure, table, and bibliography decisions before final packaging.
+
+### Route D: HTML / GitHub-Rendered Review Route
+
+Command attempted in `/tmp/kora-paper-export-dry-run`:
+
+```bash
+pandoc kora-first-paper-manuscript-v0-5.md -s -t html -o kora-first-paper-manuscript-v0-5.html
+```
+
+Result:
+
+- Markdown-to-HTML succeeded.
+- This route is useful for human review only.
+- It is not sufficient as an arXiv source package route.
+
+## Recommendation
+
+Use a Pandoc-to-LaTeX starting route followed by manual source-package cleanup:
+
+1. Generate LaTeX from manuscript v0.5 with Pandoc.
+2. Convert or replace Mermaid diagrams after user approval of figure format.
+3. Review and simplify wide tables for PDF/LaTeX layout.
+4. Finalize the bibliography subset and citation style.
+5. Generate the final PDF/source package only after category, license, figure format, and human review decisions are complete.
+
+Fallback route:
+
+- Use the HTML/GitHub-rendered path for human review only while the arXiv-compatible LaTeX/PDF route is prepared.
+
+## Outputs Generated
+
+Temporary outputs generated under `/tmp/kora-paper-export-dry-run`:
+
+- `kora-first-paper-manuscript-v0-5.tex`
+- `kora-first-paper-manuscript-v0-5.html`
+- `pandoc-latex.stdout`
+- `pandoc-latex.stderr`
+- `pandoc-pdf.stdout`
+- `pandoc-pdf.stderr`
+- `pandoc-html.stdout`
+- `pandoc-html.stderr`
+
+No PDF was generated. No binary figure files were generated. No `/tmp` outputs were committed.
+
+## Remaining User Approvals
+
+- Final arXiv category and compatibility confirmation.
+- Final arXiv license confirmation.
+- Mermaid figure format decision.
+- Wide-table layout decision.
+- Final bibliography formatting decision.
+- Final human review of the exact export package.
+
+## Status
+
+The dry run identifies a practical export route, but the paper remains not submission-ready.

--- a/docs/paper/kora-first-paper-arxiv-export-route-recommendation-v0-1.md
+++ b/docs/paper/kora-first-paper-arxiv-export-route-recommendation-v0-1.md
@@ -1,0 +1,62 @@
+# KORA First Paper arXiv Export Route Recommendation v0.1
+
+Status date: 2026-05-13
+
+## Purpose
+
+This recommendation summarizes the safest export route after the v0.5 dry run. It does not select a final arXiv category, does not submit to arXiv, does not create a final source package, and does not mark the paper as submission-ready.
+
+## Recommended Route
+
+Recommended route: Pandoc-to-LaTeX starting export with manual source-package cleanup.
+
+Rationale:
+
+- `pandoc` is available locally and successfully converts manuscript v0.5 from Markdown to LaTeX in `/tmp`.
+- Direct PDF generation is blocked locally because no LaTeX engine is installed.
+- Mermaid diagrams need explicit conversion or replacement before an arXiv-compatible package.
+- Wide Markdown tables need final layout review before PDF generation.
+- A manual LaTeX cleanup pass keeps figure, table, citation, and artifact-package decisions visible before submission.
+
+## Fallback Route
+
+Fallback route: HTML or GitHub-rendered Markdown review only.
+
+This route can support human review of content and structure, but it should not be treated as the arXiv source-package route.
+
+## Required Next Steps
+
+1. Confirm final arXiv category and category compatibility.
+2. Confirm arXiv license.
+3. Choose Mermaid handling:
+   - render Figure 1 and Figure 2 to approved figure assets,
+   - convert diagrams to LaTeX/TikZ manually, or
+   - replace diagrams with ASCII/text diagrams if source simplicity is preferred.
+4. Convert wide tables to layout-safe LaTeX tables or simplified text tables.
+5. Convert the preliminary BibTeX subset into the final package bibliography format.
+6. Generate a clean PDF/source package in a temporary or package-specific area.
+7. Run final human review before any upload.
+
+## BibTeX Handling
+
+The export route should use the conservative bibliography subset already aligned with manuscript v0.5. Full BibTeX remains incomplete, and deferred or still-not-eligible records should not be introduced during export cleanup.
+
+## Source Package Contents
+
+Expected source package inputs, pending final approval:
+
+- Manuscript source derived from `docs/paper/kora-first-paper-manuscript-v0-5.md`.
+- Finalized bibliography subset derived from `docs/paper/kora-first-paper-preliminary-bibtex-v0-1.md`.
+- Approved figure sources or rendered figure files for Figure 1 and Figure 2.
+- Layout-safe versions of Table 1, Table 2, and Appendix Table A1.
+- Artifact/reproducibility appendix content.
+- No raw benchmark artifacts.
+- No provider responses, API keys, private user data, production traffic, release assets, or generated temporary evidence packets.
+
+## No-Submit Status
+
+No arXiv submission was made. No final source package was created. No PDF or binary figure output was committed.
+
+## Submission Status
+
+The recommended export route is identified, but final category, license, figure conversion, table layout, bibliography formatting, source-package generation, and human review remain pending. The paper remains not submission-ready.

--- a/docs/paper/kora-first-paper-arxiv-style-package-readiness-v0-1.md
+++ b/docs/paper/kora-first-paper-arxiv-style-package-readiness-v0-1.md
@@ -35,8 +35,8 @@ This artifact records readiness for a venue-neutral arXiv-style preprint package
 | Candidate categories | `cs.AI`, `cs.LG`, `cs.DC`, `cs.SE` | Candidates only; no category selected here |
 | Title / abstract | v0.5 title and abstract exist | Final human approval pending |
 | License | Pending arXiv distribution-license decision | User decision required |
-| Export format | Markdown draft exists; render/export readiness reviewed | PDF/LaTeX/Markdown export package pending |
-| Source package | Text-only export manifest exists | Prepare final package only after export route is selected |
+| Export format | Markdown draft exists; render/export readiness and export-route dry run completed | PDF/LaTeX/Markdown export package pending |
+| Source package | Text-only export manifest and route recommendation exist | Prepare final package only after user approvals |
 | Figures/tables/algorithm assets | Inserted in manuscript v0.5 as Markdown/Mermaid/text assets | Render/conversion, numbering, and export treatment pending |
 | Review/survey/position framing | Avoided | Preserve original systems/evaluation framing |
 | Final human review | Pending | Required before any submission action |
@@ -83,6 +83,15 @@ The v0.5 render/export readiness report and text-only export package manifest no
 - `docs/paper/kora-first-paper-arxiv-export-package-manifest-v0-1.md`
 
 No repository paper export pipeline was found, no PDF was generated, and no binary output was committed. Mermaid diagrams remain suitable for repository review but need rendering or conversion before an arXiv-compatible package.
+
+## Export Route Dry-Run Status
+
+The export-route dry run and recommendation now exist:
+
+- `docs/paper/kora-first-paper-arxiv-export-route-dry-run-v0-1.md`
+- `docs/paper/kora-first-paper-arxiv-export-route-recommendation-v0-1.md`
+
+Pandoc is available and successfully generated LaTeX and HTML dry-run outputs under `/tmp/kora-paper-export-dry-run`. Direct PDF generation is blocked locally because no LaTeX engine is installed. Mermaid conversion is blocked locally because no Mermaid CLI is installed. The recommended route is Pandoc-to-LaTeX as a starting point, followed by manual source-package cleanup for diagrams, wide tables, and bibliography formatting.
 
 ## Missing User Approvals
 

--- a/docs/paper/kora-first-paper-final-human-review-packet-v0-1.md
+++ b/docs/paper/kora-first-paper-final-human-review-packet-v0-1.md
@@ -57,6 +57,8 @@ This packet lists the human decisions still required before any submission-ready
 - Confirm final numbering and captions after export format is selected.
 - Review the v0.5 render/export readiness report before approving final PDF/source-package treatment.
 - Decide whether Mermaid diagrams should be rendered to image files, converted to another source format, or replaced with text/ASCII diagrams for final export.
+- Review the arXiv export route dry-run report and approve or reject the recommended Pandoc-to-LaTeX plus manual cleanup route.
+- Confirm whether the local export environment should use `pdflatex`, `xelatex`, `tectonic`, or another approved PDF generation route.
 
 ## Venue and Export Decisions
 

--- a/docs/paper/kora-first-paper-missing-evidence-checklist.md
+++ b/docs/paper/kora-first-paper-missing-evidence-checklist.md
@@ -122,6 +122,8 @@ Citation style decision:
 - Final figure/table/algorithm numbering, layout, rendering, and export treatment remain pending human review.
 - v0.5 render/export readiness report and text-only export manifest have been created.
 - No dedicated paper export pipeline has been found; final PDF/source-package generation remains pending.
+- arXiv export route dry-run report and recommendation have been created.
+- Pandoc-to-LaTeX is feasible as a starting route, but LaTeX/PDF tooling, Mermaid conversion, table layout, final bibliography formatting, and human approval remain pending.
 - Clean reproduction transcript capture, final artifact package review, final venue/export decision, and final human review remain pending.
 - Paper is still not submission-ready.
 

--- a/docs/paper/kora-first-paper-submission-candidate-status-v0-1.md
+++ b/docs/paper/kora-first-paper-submission-candidate-status-v0-1.md
@@ -105,6 +105,15 @@ The v0.5 render/export readiness report and text-only export manifest now exist:
 
 No dedicated paper export pipeline was found. No PDF, rendered figure, binary export, or raw benchmark artifact was generated or committed. The manuscript remains suitable for repository Markdown review, but final arXiv-compatible export requires a chosen export route and figure rendering/conversion.
 
+## arXiv Export Route Dry Run
+
+The export-route dry run and recommendation now exist:
+
+- `docs/paper/kora-first-paper-arxiv-export-route-dry-run-v0-1.md`
+- `docs/paper/kora-first-paper-arxiv-export-route-recommendation-v0-1.md`
+
+Pandoc-generated LaTeX and HTML outputs were tested under `/tmp/kora-paper-export-dry-run` only. No PDF was generated because a LaTeX engine is not installed locally. No generated outputs or binary figures were committed. The recommended route is a Pandoc-to-LaTeX starting export followed by manual cleanup for Mermaid diagrams, wide tables, and bibliography formatting.
+
 ## Submission Package Packet
 
 The venue-neutral submission package readiness packet now exists:
@@ -118,4 +127,4 @@ These files organize package blockers, human review decisions, reproduction tran
 
 ## Status
 
-The manuscript has advanced to v0.5 submission-candidate draft status. Full BibTeX remains incomplete, final export route and asset rendering/conversion remain pending, and the paper remains not submission-ready.
+The manuscript has advanced to v0.5 submission-candidate draft status. Full BibTeX remains incomplete, final export route approval, asset rendering/conversion, table layout, bibliography formatting, and human review remain pending. The paper remains not submission-ready.

--- a/docs/paper/kora-first-paper-submission-package-readiness-v0-1.md
+++ b/docs/paper/kora-first-paper-submission-package-readiness-v0-1.md
@@ -95,3 +95,9 @@ They draft text-based architecture and benchmark-flow diagrams, benchmark and ev
 Render/export readiness has been reviewed in `docs/paper/kora-first-paper-v0-5-render-export-readiness-v0-1.md`, and a text-only export package manifest exists at `docs/paper/kora-first-paper-arxiv-export-package-manifest-v0-1.md`.
 
 No dedicated paper export pipeline was found in the repository. No PDF, rendered figure, binary export, or raw benchmark artifact was generated or committed. Final export route, Mermaid rendering/conversion, table layout, bibliography formatting, and human approval remain pending.
+
+## arXiv Export Route Dry-Run Status
+
+The export route dry run is recorded in `docs/paper/kora-first-paper-arxiv-export-route-dry-run-v0-1.md`, with the recommendation recorded in `docs/paper/kora-first-paper-arxiv-export-route-recommendation-v0-1.md`.
+
+Pandoc can produce a LaTeX starting point from manuscript v0.5, but direct PDF generation is blocked locally by missing LaTeX tooling and Mermaid conversion is blocked locally by missing Mermaid CLI tooling. Generated dry-run outputs were kept under `/tmp/kora-paper-export-dry-run` and were not committed.


### PR DESCRIPTION
## Summary
- add an arXiv export-route dry-run report for manuscript v0.5
- add a route recommendation identifying Pandoc-to-LaTeX plus manual cleanup as the safest starting route
- update Paper Track package/readiness docs with the dry-run result and remaining blockers

## Tool and route results
- pandoc 3.9.0.2 is available and generated LaTeX and HTML outputs under `/tmp/kora-paper-export-dry-run`
- pdflatex, xelatex, tectonic, mmdc, mermaid-cli, and pdftoppm were not available locally
- direct PDF generation failed because no LaTeX engine is installed
- Mermaid conversion was not attempted because no Mermaid CLI is installed

## Boundaries
- generated outputs stayed under `/tmp` only
- no PDFs, rendered figures, binary assets, raw benchmark artifacts, release assets, or arXiv uploads were committed
- no arXiv category or conference/journal/workshop target was selected
- paper remains not submission-ready

## Validation
- git diff --check: passed
- python3 -m pytest: 159 passed
- targeted internal/claim scan: only expected non-claim/status language
- Unicode scan: no hidden/control/bidi/zero-width or non-ASCII characters
