### PR TITLE
docs: add local arxiv export tooling plan

### DIFF
--- a/docs/paper/kora-first-paper-arxiv-dry-build-command-plan-v0-1.md
+++ b/docs/paper/kora-first-paper-arxiv-dry-build-command-plan-v0-1.md
@@ -1,0 +1,118 @@
+# KORA First Paper arXiv Dry Build Command Plan v0.1
+
+Status date: 2026-05-13
+
+## Purpose
+
+This command plan defines a repeatable local dry build path for manuscript v0.5 once the required local export tools are installed. It does not run an arXiv submission, does not create committed binaries, and does not mark the paper as submission-ready.
+
+## Working Directory
+
+Use a temporary working directory:
+
+```bash
+rm -rf /tmp/kora-paper-arxiv-dry-build
+mkdir -p /tmp/kora-paper-arxiv-dry-build
+```
+
+Generated outputs must stay under `/tmp/kora-paper-arxiv-dry-build` unless a later task explicitly approves a tracked source package.
+
+## Source Inputs
+
+Copy the current manuscript and bibliography draft:
+
+```bash
+cp docs/paper/kora-first-paper-manuscript-v0-5.md /tmp/kora-paper-arxiv-dry-build/
+cp docs/paper/kora-first-paper-preliminary-bibtex-v0-1.md /tmp/kora-paper-arxiv-dry-build/
+cd /tmp/kora-paper-arxiv-dry-build
+```
+
+## Pandoc-to-LaTeX Command
+
+```bash
+pandoc kora-first-paper-manuscript-v0-5.md \
+  -s \
+  -t latex \
+  -o kora-first-paper-manuscript-v0-5.tex
+```
+
+Expected result: LaTeX source is generated as a starting point. Manual cleanup is still required for diagrams, wide tables, bibliography formatting, and final package structure.
+
+## Mermaid Rendering Command Template
+
+If Mermaid CLI is installed and the final figure decision approves rendered figures:
+
+```bash
+mmdc -i figure-1-kora-execution-control.mmd -o figure-1-kora-execution-control.svg
+mmdc -i figure-2-benchmark-flow.mmd -o figure-2-benchmark-flow.svg
+```
+
+These commands require extracting the Figure 1 and Figure 2 Mermaid blocks from manuscript v0.5 into `.mmd` files under `/tmp/kora-paper-arxiv-dry-build`.
+
+Do not commit rendered figure files until final package policy is approved.
+
+## LaTeX / PDF Command Templates
+
+If `tectonic` is installed:
+
+```bash
+tectonic kora-first-paper-manuscript-v0-5.tex
+```
+
+If a TeX Live/MacTeX/BasicTeX route is selected:
+
+```bash
+pdflatex kora-first-paper-manuscript-v0-5.tex
+pdflatex kora-first-paper-manuscript-v0-5.tex
+```
+
+If BibTeX is converted to a `.bib` file and cited from LaTeX:
+
+```bash
+pdflatex kora-first-paper-manuscript-v0-5.tex
+bibtex kora-first-paper-manuscript-v0-5
+pdflatex kora-first-paper-manuscript-v0-5.tex
+pdflatex kora-first-paper-manuscript-v0-5.tex
+```
+
+The exact bibliography command sequence depends on the final bibliography format.
+
+## Source Package Assembly Checklist
+
+- Include the final `.tex` source.
+- Include only approved figure files or approved text/ASCII figure replacements.
+- Include only the finalized bibliography subset.
+- Include any required style files that are not standard in the selected route.
+- Include artifact appendix content only in approved source form.
+- Exclude raw benchmark artifacts.
+- Exclude generated temporary logs unless needed for debugging and explicitly approved.
+
+## Package Hygiene Checks
+
+Run these checks from the dry-build directory before any package is considered for upload:
+
+```bash
+find . -maxdepth 2 -type f -print | sort
+grep -RInE 'sk-|ghp_|password=|secret=|api_key=|OPENAI_API_KEY=|ANTHROPIC_API_KEY=' .
+grep -RInE 'production cost reduction|real API-cost reduction|production benchmark proof|formally approved|guaranteed' .
+```
+
+Also inspect manually for absolute local home paths, private local context paths, and internal workflow markers. Matches must be reviewed before any upload. Non-claim boundary text may be acceptable in repository docs, but the final arXiv source package should avoid unrelated audit/status material unless intentionally included.
+
+## Commands Not to Run Without User Approval
+
+Do not run any actual arXiv upload command or use the arXiv submission UI as part of this dry build.
+
+Do not commit:
+
+- generated PDFs,
+- rendered figure binaries,
+- source packages,
+- raw benchmark artifacts,
+- provider responses,
+- private data,
+- temporary build outputs.
+
+## Current Dry-Build Status
+
+A full `/tmp` dry build was not attempted in this task because no LaTeX engine and no Mermaid CLI are currently installed locally. The next dry build should start after the user approves and installs the selected tooling.

--- a/docs/paper/kora-first-paper-arxiv-export-package-manifest-v0-1.md
+++ b/docs/paper/kora-first-paper-arxiv-export-package-manifest-v0-1.md
@@ -17,6 +17,9 @@ This text-only manifest lists candidate source files and pending package items f
 | Render/export readiness report | `docs/paper/kora-first-paper-v0-5-render-export-readiness-v0-1.md` | Created in this pass |
 | Export route dry-run report | `docs/paper/kora-first-paper-arxiv-export-route-dry-run-v0-1.md` | Dry run completed with `/tmp` outputs only |
 | Export route recommendation | `docs/paper/kora-first-paper-arxiv-export-route-recommendation-v0-1.md` | Recommends Pandoc-to-LaTeX starting route with manual cleanup |
+| Local export tooling setup | `docs/paper/kora-first-paper-local-export-tooling-setup-v0-1.md` | User-run setup commands documented |
+| Dry-build command plan | `docs/paper/kora-first-paper-arxiv-dry-build-command-plan-v0-1.md` | Commands documented; full dry build pending tools |
+| Source package hygiene checklist | `docs/paper/kora-first-paper-arxiv-source-package-hygiene-v0-1.md` | Package hygiene checklist created |
 | Figure/table/algorithm drafts | `docs/paper/kora-first-paper-figure-table-algorithm-drafts-v0-1.md` | Source for inserted text assets |
 | Figure/table/algorithm plan | `docs/paper/kora-first-paper-figure-table-algorithm-plan-v0-1.md` | Planning/status source |
 | Reproduction checklist | `docs/paper/kora-first-paper-reproduction-transcript-checklist-v0-1.md` | Checklist exists; final transcript pending |

--- a/docs/paper/kora-first-paper-arxiv-export-route-recommendation-v0-1.md
+++ b/docs/paper/kora-first-paper-arxiv-export-route-recommendation-v0-1.md
@@ -28,14 +28,28 @@ This route can support human review of content and structure, but it should not 
 
 1. Confirm final arXiv category and category compatibility.
 2. Confirm arXiv license.
-3. Choose Mermaid handling:
+3. Approve local export tooling setup:
+   - recommended minimal path: `brew install tectonic`,
+   - Mermaid rendering path if needed: `npm install -g @mermaid-js/mermaid-cli`,
+   - fallback TeX options: MacTeX or BasicTeX.
+4. Choose Mermaid handling:
    - render Figure 1 and Figure 2 to approved figure assets,
    - convert diagrams to LaTeX/TikZ manually, or
    - replace diagrams with ASCII/text diagrams if source simplicity is preferred.
-4. Convert wide tables to layout-safe LaTeX tables or simplified text tables.
-5. Convert the preliminary BibTeX subset into the final package bibliography format.
-6. Generate a clean PDF/source package in a temporary or package-specific area.
-7. Run final human review before any upload.
+5. Convert wide tables to layout-safe LaTeX tables or simplified text tables.
+6. Convert the preliminary BibTeX subset into the final package bibliography format.
+7. Generate a clean PDF/source package in a temporary or package-specific area.
+8. Run final human review before any upload.
+
+## Local Tooling Plan
+
+The local tooling plan and command plan now exist:
+
+- `docs/paper/kora-first-paper-local-export-tooling-setup-v0-1.md`
+- `docs/paper/kora-first-paper-arxiv-dry-build-command-plan-v0-1.md`
+- `docs/paper/kora-first-paper-arxiv-source-package-hygiene-v0-1.md`
+
+No tools were installed automatically. A full dry build was not attempted because a LaTeX engine and Mermaid CLI are still missing locally.
 
 ## BibTeX Handling
 

--- a/docs/paper/kora-first-paper-arxiv-source-package-hygiene-v0-1.md
+++ b/docs/paper/kora-first-paper-arxiv-source-package-hygiene-v0-1.md
@@ -1,0 +1,92 @@
+# KORA First Paper arXiv Source Package Hygiene v0.1
+
+Status date: 2026-05-13
+
+## Purpose
+
+This checklist defines source-package hygiene expectations for a future arXiv-style package. It does not create a package, does not upload to arXiv, and does not mark the paper as submission-ready.
+
+## Include Only Build-Needed Files
+
+The package should include only files needed to build or review the final paper package:
+
+- final paper source,
+- final bibliography source,
+- approved figure files or approved source equivalents,
+- required style files,
+- required appendix or artifact-description source.
+
+## Exclude
+
+Exclude:
+
+- private or local paths,
+- raw benchmark artifacts,
+- temporary build outputs,
+- generated logs unless explicitly needed,
+- `/tmp` outputs,
+- hidden comments and unrelated planning notes,
+- provider responses,
+- API keys and credentials,
+- private user data,
+- production traffic,
+- release assets,
+- large unused files.
+
+## Secret and Path Checks
+
+Before any upload, inspect source files for:
+
+```text
+sk-
+ghp_
+password=
+secret=
+api_key=
+OPENAI_API_KEY=
+ANTHROPIC_API_KEY=
+```
+
+Also inspect manually for absolute local home paths, private local context paths, and internal workflow markers.
+
+Any match must be removed or explicitly justified before packaging.
+
+## Claim Boundary Checks
+
+Before any upload, inspect source files for unsupported claims:
+
+```text
+production cost reduction
+real API-cost reduction
+production benchmark proof
+full runtime-integrated real-provider benchmark evidence
+broad workload superiority
+energy reduction
+formal government validation
+guaranteed adoption
+formal artifact approval
+formally approved
+```
+
+Boundary or limitation wording may be appropriate in planning docs, but the final source package should only include claim language intentionally meant for the paper.
+
+## Residual File Warning
+
+arXiv source files may become downloadable after submission. Avoid unnecessary residual files, local-only notes, debug comments, temporary outputs, or unrelated planning artifacts in the source package.
+
+## Metadata Checks
+
+Before upload, confirm:
+
+- final arXiv category and category compatibility,
+- license choice,
+- title and abstract,
+- author display,
+- affiliation and email display,
+- comments field if used,
+- final bibliography formatting,
+- final figure/table rendering.
+
+## Status
+
+This is a hygiene checklist only. No source package was created, no upload was performed, and the paper remains not submission-ready.

--- a/docs/paper/kora-first-paper-arxiv-style-package-readiness-v0-1.md
+++ b/docs/paper/kora-first-paper-arxiv-style-package-readiness-v0-1.md
@@ -35,8 +35,8 @@ This artifact records readiness for a venue-neutral arXiv-style preprint package
 | Candidate categories | `cs.AI`, `cs.LG`, `cs.DC`, `cs.SE` | Candidates only; no category selected here |
 | Title / abstract | v0.5 title and abstract exist | Final human approval pending |
 | License | Pending arXiv distribution-license decision | User decision required |
-| Export format | Markdown draft exists; render/export readiness and export-route dry run completed | PDF/LaTeX/Markdown export package pending |
-| Source package | Text-only export manifest and route recommendation exist | Prepare final package only after user approvals |
+| Export format | Markdown draft exists; render/export readiness, export-route dry run, and local tooling plan completed | PDF/LaTeX/Markdown export package pending |
+| Source package | Text-only export manifest, route recommendation, command plan, and hygiene checklist exist | Prepare final package only after user approvals |
 | Figures/tables/algorithm assets | Inserted in manuscript v0.5 as Markdown/Mermaid/text assets | Render/conversion, numbering, and export treatment pending |
 | Review/survey/position framing | Avoided | Preserve original systems/evaluation framing |
 | Final human review | Pending | Required before any submission action |
@@ -92,6 +92,16 @@ The export-route dry run and recommendation now exist:
 - `docs/paper/kora-first-paper-arxiv-export-route-recommendation-v0-1.md`
 
 Pandoc is available and successfully generated LaTeX and HTML dry-run outputs under `/tmp/kora-paper-export-dry-run`. Direct PDF generation is blocked locally because no LaTeX engine is installed. Mermaid conversion is blocked locally because no Mermaid CLI is installed. The recommended route is Pandoc-to-LaTeX as a starting point, followed by manual source-package cleanup for diagrams, wide tables, and bibliography formatting.
+
+## Local Export Tooling Plan Status
+
+The local export tooling plan, dry-build command plan, and source-package hygiene checklist now exist:
+
+- `docs/paper/kora-first-paper-local-export-tooling-setup-v0-1.md`
+- `docs/paper/kora-first-paper-arxiv-dry-build-command-plan-v0-1.md`
+- `docs/paper/kora-first-paper-arxiv-source-package-hygiene-v0-1.md`
+
+No tools were installed automatically. The next practical step is user-approved installation or selection of a LaTeX/PDF engine and Mermaid handling path, followed by a `/tmp` dry build.
 
 ## Missing User Approvals
 

--- a/docs/paper/kora-first-paper-final-human-review-packet-v0-1.md
+++ b/docs/paper/kora-first-paper-final-human-review-packet-v0-1.md
@@ -59,6 +59,8 @@ This packet lists the human decisions still required before any submission-ready
 - Decide whether Mermaid diagrams should be rendered to image files, converted to another source format, or replaced with text/ASCII diagrams for final export.
 - Review the arXiv export route dry-run report and approve or reject the recommended Pandoc-to-LaTeX plus manual cleanup route.
 - Confirm whether the local export environment should use `pdflatex`, `xelatex`, `tectonic`, or another approved PDF generation route.
+- Approve or reject the local tooling setup commands before any tool installation.
+- Review the arXiv source package hygiene checklist before any source package is assembled or uploaded.
 
 ## Venue and Export Decisions
 

--- a/docs/paper/kora-first-paper-local-export-tooling-setup-v0-1.md
+++ b/docs/paper/kora-first-paper-local-export-tooling-setup-v0-1.md
@@ -1,0 +1,70 @@
+# KORA First Paper Local Export Tooling Setup v0.1
+
+Status date: 2026-05-13
+
+## Purpose
+
+This guide records the local tooling needed for the next arXiv-style dry build of manuscript v0.5. It does not install tools automatically, does not generate a committed PDF, does not submit to arXiv, and does not mark the paper as submission-ready.
+
+## Current Tool Availability
+
+| Tool | Current status | Use in export path |
+|---|---|---|
+| `pandoc` | Available: 3.9.0.2 | Markdown-to-LaTeX starting conversion |
+| `pdflatex` | Not found | PDF build route if TeX Live/MacTeX/BasicTeX is selected |
+| `xelatex` | Not found | Alternate PDF build route if Unicode/font handling needs it |
+| `tectonic` | Not found | Minimal PDF build route candidate |
+| `mmdc` | Not found | Mermaid figure rendering |
+| `mermaid-cli` | Not found | Mermaid figure rendering |
+| `node` | Available: v22.21.1 | Runtime for Mermaid CLI |
+| `npm` | Available: 10.9.4 | Mermaid CLI install path |
+| `brew` | Available: 5.1.10 | macOS package install path |
+| `python3` | Available: 3.13.5 | Validation and package hygiene scripts |
+
+## Recommended Minimal Tool Path
+
+Recommended minimal local tool path:
+
+1. Install one LaTeX/PDF engine.
+2. Install Mermaid CLI only if the final diagram decision is to render Mermaid diagrams locally.
+3. Keep Pandoc as the Markdown-to-LaTeX starting converter.
+4. Keep generated PDFs, rendered figures, and source packages outside the repository until final package policy is approved.
+
+## User-Run Install Commands
+
+No installation was performed in this task. If the user approves local setup, the likely macOS commands are:
+
+```bash
+brew install tectonic
+npm install -g @mermaid-js/mermaid-cli
+```
+
+If `tectonic` is insufficient for the final source package, fallback TeX options are:
+
+```bash
+brew install --cask mactex
+```
+
+or, for a smaller TeX distribution:
+
+```bash
+brew install --cask basictex
+```
+
+After installing BasicTeX, a new shell may be needed so TeX binaries are on `PATH`.
+
+## Fallback Options
+
+- Render Mermaid diagrams manually from GitHub preview or Mermaid Live Editor after final figure approval.
+- Convert Mermaid diagrams to text/ASCII diagrams if source-package simplicity is more important than visual rendering.
+- Keep Mermaid diagrams as appendix source during review, but do not treat that as final arXiv-ready figure handling.
+- Use GitHub-rendered Markdown or Pandoc HTML for human review only, not as the final arXiv source package.
+
+## Non-Goals
+
+- No automatic tool installation.
+- No generated PDF committed.
+- No rendered figure binaries committed.
+- No source package committed.
+- No arXiv upload.
+- No submission-ready claim.

--- a/docs/paper/kora-first-paper-missing-evidence-checklist.md
+++ b/docs/paper/kora-first-paper-missing-evidence-checklist.md
@@ -124,6 +124,8 @@ Citation style decision:
 - No dedicated paper export pipeline has been found; final PDF/source-package generation remains pending.
 - arXiv export route dry-run report and recommendation have been created.
 - Pandoc-to-LaTeX is feasible as a starting route, but LaTeX/PDF tooling, Mermaid conversion, table layout, final bibliography formatting, and human approval remain pending.
+- Local export tooling setup guide, dry-build command plan, and source-package hygiene checklist have been created.
+- No tools were installed automatically and no full dry build was attempted because required export tools remain missing locally.
 - Clean reproduction transcript capture, final artifact package review, final venue/export decision, and final human review remain pending.
 - Paper is still not submission-ready.
 

--- a/docs/paper/kora-first-paper-submission-candidate-status-v0-1.md
+++ b/docs/paper/kora-first-paper-submission-candidate-status-v0-1.md
@@ -114,6 +114,16 @@ The export-route dry run and recommendation now exist:
 
 Pandoc-generated LaTeX and HTML outputs were tested under `/tmp/kora-paper-export-dry-run` only. No PDF was generated because a LaTeX engine is not installed locally. No generated outputs or binary figures were committed. The recommended route is a Pandoc-to-LaTeX starting export followed by manual cleanup for Mermaid diagrams, wide tables, and bibliography formatting.
 
+## Local Export Tooling Plan
+
+The local export tooling setup guide, dry-build command plan, and source-package hygiene checklist now exist:
+
+- `docs/paper/kora-first-paper-local-export-tooling-setup-v0-1.md`
+- `docs/paper/kora-first-paper-arxiv-dry-build-command-plan-v0-1.md`
+- `docs/paper/kora-first-paper-arxiv-source-package-hygiene-v0-1.md`
+
+No system packages were installed automatically. A full `/tmp` dry build was not attempted because the required LaTeX/PDF and Mermaid rendering tools are still missing locally.
+
 ## Submission Package Packet
 
 The venue-neutral submission package readiness packet now exists:
@@ -127,4 +137,4 @@ These files organize package blockers, human review decisions, reproduction tran
 
 ## Status
 
-The manuscript has advanced to v0.5 submission-candidate draft status. Full BibTeX remains incomplete, final export route approval, asset rendering/conversion, table layout, bibliography formatting, and human review remain pending. The paper remains not submission-ready.
+The manuscript has advanced to v0.5 submission-candidate draft status. Full BibTeX remains incomplete, final export tooling approval, asset rendering/conversion, table layout, bibliography formatting, source-package generation, and human review remain pending. The paper remains not submission-ready.

--- a/docs/paper/kora-first-paper-submission-package-readiness-v0-1.md
+++ b/docs/paper/kora-first-paper-submission-package-readiness-v0-1.md
@@ -101,3 +101,13 @@ No dedicated paper export pipeline was found in the repository. No PDF, rendered
 The export route dry run is recorded in `docs/paper/kora-first-paper-arxiv-export-route-dry-run-v0-1.md`, with the recommendation recorded in `docs/paper/kora-first-paper-arxiv-export-route-recommendation-v0-1.md`.
 
 Pandoc can produce a LaTeX starting point from manuscript v0.5, but direct PDF generation is blocked locally by missing LaTeX tooling and Mermaid conversion is blocked locally by missing Mermaid CLI tooling. Generated dry-run outputs were kept under `/tmp/kora-paper-export-dry-run` and were not committed.
+
+## Local Export Tooling and Hygiene Status
+
+Local export tooling setup guidance, a dry-build command plan, and a source-package hygiene checklist now exist:
+
+- `docs/paper/kora-first-paper-local-export-tooling-setup-v0-1.md`
+- `docs/paper/kora-first-paper-arxiv-dry-build-command-plan-v0-1.md`
+- `docs/paper/kora-first-paper-arxiv-source-package-hygiene-v0-1.md`
+
+No tools were installed, no full dry build was attempted, and no generated PDF/source package/binary output was committed.


### PR DESCRIPTION
## Summary
- add local arXiv export tooling setup guidance for manuscript v0.5
- add a /tmp-only dry-build command plan
- add an arXiv source package hygiene checklist
- update Paper Track readiness/status docs to reflect the tooling plan and remaining blockers

## Tool availability
- available: pandoc 3.9.0.2, node v22.21.1, npm 10.9.4, brew 5.1.10, python3 3.13.5
- missing: pdflatex, xelatex, tectonic, mmdc, mermaid-cli

## Dry-build status
- no tools were installed automatically
- no full /tmp dry build was attempted because LaTeX/PDF and Mermaid rendering tools are missing
- documented user-run install candidates: `brew install tectonic`, `npm install -g @mermaid-js/mermaid-cli`, with MacTeX/BasicTeX fallback options

## Boundaries
- no PDFs, rendered figures, source packages, binary outputs, raw benchmark artifacts, or /tmp outputs were committed
- no arXiv category selected and no arXiv submission made
- paper remains not submission-ready

## Validation
- git diff --check: passed
- python3 -m pytest: 159 passed
- targeted internal/private scan: cleaned; remaining matches are expected non-claim or hygiene-check text
- Unicode scan: no hidden/control/bidi/zero-width or non-ASCII characters
