### PR TITLE
docs: record arxiv dry build with installed tools

### DIFF
--- a/docs/paper/kora-first-paper-arxiv-dry-build-result-v0-1.md
+++ b/docs/paper/kora-first-paper-arxiv-dry-build-result-v0-1.md
@@ -1,0 +1,138 @@
+# KORA First Paper arXiv Dry Build Result v0.1
+
+Status date: 2026-05-14
+
+## Purpose
+
+This report records a local arXiv-style dry build for manuscript v0.5 after installing Tectonic and Mermaid CLI. Generated outputs were kept under `/tmp` only. No generated PDF, rendered figure, source package, binary output, or raw benchmark artifact was committed. No arXiv submission was made, and the paper remains not submission-ready.
+
+## Source Files
+
+- `docs/paper/kora-first-paper-manuscript-v0-5.md`
+- `docs/paper/kora-first-paper-preliminary-bibtex-v0-1.md`
+- `docs/paper/kora-first-paper-arxiv-dry-build-command-plan-v0-1.md`
+- `docs/paper/kora-first-paper-arxiv-source-package-hygiene-v0-1.md`
+- `docs/paper/kora-first-paper-arxiv-export-route-recommendation-v0-1.md`
+
+## Tool Versions
+
+| Tool | Version / status |
+|---|---|
+| `pandoc` | 3.9.0.2 |
+| `tectonic` | 0.16.9 |
+| `mmdc` | 11.14.0 |
+| `node` | v26.0.0 |
+| `npm` | 11.12.1 |
+| `python3` | 3.13.5 |
+
+## Temporary Workspace
+
+Dry-build workspace:
+
+```text
+/tmp/kora-paper-arxiv-dry-build
+```
+
+Generated outputs stayed in:
+
+- `/tmp/kora-paper-arxiv-dry-build/build`
+- `/tmp/kora-paper-arxiv-dry-build/source-package`
+
+## Commands Run
+
+The manuscript and preliminary BibTeX were copied to `/tmp`:
+
+```bash
+rm -rf /tmp/kora-paper-arxiv-dry-build
+mkdir -p /tmp/kora-paper-arxiv-dry-build/source /tmp/kora-paper-arxiv-dry-build/build
+cp docs/paper/kora-first-paper-manuscript-v0-5.md /tmp/kora-paper-arxiv-dry-build/source/
+cp docs/paper/kora-first-paper-preliminary-bibtex-v0-1.md /tmp/kora-paper-arxiv-dry-build/source/
+```
+
+The two Mermaid blocks were extracted into:
+
+- `/tmp/kora-paper-arxiv-dry-build/build/figure-1.mmd`
+- `/tmp/kora-paper-arxiv-dry-build/build/figure-2.mmd`
+
+Initial Mermaid rendering commands:
+
+```bash
+mmdc -i figure-1.mmd -o figure-1.pdf
+mmdc -i figure-2.mmd -o figure-2.pdf
+```
+
+Initial result: failed because Mermaid CLI could not find its Puppeteer-managed Chrome/headless-shell.
+
+Successful Mermaid rendering commands using the locally installed browser:
+
+```bash
+PUPPETEER_EXECUTABLE_PATH="/Applications/Google Chrome.app/Contents/MacOS/Google Chrome" mmdc -i figure-1.mmd -o figure-1.pdf
+PUPPETEER_EXECUTABLE_PATH="/Applications/Google Chrome.app/Contents/MacOS/Google Chrome" mmdc -i figure-2.mmd -o figure-2.pdf
+```
+
+Markdown-to-LaTeX command:
+
+```bash
+pandoc kora-first-paper-manuscript-v0-5-figures.md -s -t latex -o kora-first-paper-manuscript-v0-5.tex
+```
+
+PDF dry-build command:
+
+```bash
+tectonic kora-first-paper-manuscript-v0-5.tex
+```
+
+## Results
+
+| Step | Result | Notes |
+|---|---|---|
+| Mermaid extraction | Passed | Two `.mmd` files created under `/tmp`. |
+| Mermaid rendering, default `mmdc` | Failed | Puppeteer-managed Chrome/headless-shell was missing. |
+| Mermaid rendering with local browser path | Passed | Figure 1 and Figure 2 PDFs were generated under `/tmp`. |
+| Pandoc Markdown-to-LaTeX | Passed | Generated LaTeX source under `/tmp`. |
+| Tectonic PDF build | Passed | Generated dry-run PDF under `/tmp`. |
+| Source-package folder assembly | Passed as dry-run only | Created a source-only folder under `/tmp` with LaTeX, figure PDFs, and preliminary bibliography draft. |
+
+## Generated `/tmp` Outputs
+
+Key generated outputs:
+
+- `/tmp/kora-paper-arxiv-dry-build/build/figure-1.pdf` - 20,448 bytes
+- `/tmp/kora-paper-arxiv-dry-build/build/figure-2.pdf` - 19,644 bytes
+- `/tmp/kora-paper-arxiv-dry-build/build/kora-first-paper-manuscript-v0-5.tex` - 38,224 bytes
+- `/tmp/kora-paper-arxiv-dry-build/build/kora-first-paper-manuscript-v0-5.pdf` - 92,996 bytes
+
+Dry-run source-package folder:
+
+- `/tmp/kora-paper-arxiv-dry-build/source-package/kora-first-paper-manuscript-v0-5.tex`
+- `/tmp/kora-paper-arxiv-dry-build/source-package/figure-1.pdf`
+- `/tmp/kora-paper-arxiv-dry-build/source-package/figure-2.pdf`
+- `/tmp/kora-paper-arxiv-dry-build/source-package/kora-first-paper-preliminary-bibtex-v0-1.md`
+
+No `/tmp` output was committed.
+
+## Build Warnings
+
+Tectonic completed the PDF build, but emitted layout warnings:
+
+- overfull boxes in long table and reference-heavy sections,
+- underfull boxes in some paragraphs,
+- repeated warnings around the appendix artifact table area,
+- warnings about tagged PDF inputs from rendered figure PDFs.
+
+These warnings do not block a dry build, but they do block treating the package as final without layout review.
+
+## Remaining Blockers
+
+- Final arXiv category and license confirmation.
+- Final Mermaid rendering policy and browser configuration.
+- Final wide-table and appendix-table layout cleanup.
+- Final bibliography formatting; current dry-run package uses the preliminary bibliography draft as a source input, not a final `.bib` integration.
+- Final source-package hygiene review.
+- Final human review of the exact PDF and source package.
+
+## Claim and Submission Status
+
+This dry build does not add evidence for production cost reduction, real API-cost reduction, production benchmark proof, broad workload superiority, energy reduction evidence, formal artifact approval, or paper submission readiness.
+
+The dry build demonstrates that a local PDF can be generated from manuscript v0.5 using rendered Mermaid figures and Tectonic, but the paper remains not submission-ready.

--- a/docs/paper/kora-first-paper-arxiv-export-package-manifest-v0-1.md
+++ b/docs/paper/kora-first-paper-arxiv-export-package-manifest-v0-1.md
@@ -19,6 +19,7 @@ This text-only manifest lists candidate source files and pending package items f
 | Export route recommendation | `docs/paper/kora-first-paper-arxiv-export-route-recommendation-v0-1.md` | Recommends Pandoc-to-LaTeX starting route with manual cleanup |
 | Local export tooling setup | `docs/paper/kora-first-paper-local-export-tooling-setup-v0-1.md` | User-run setup commands documented |
 | Dry-build command plan | `docs/paper/kora-first-paper-arxiv-dry-build-command-plan-v0-1.md` | Commands documented; full dry build pending tools |
+| Installed-tools dry-build result | `docs/paper/kora-first-paper-arxiv-dry-build-result-v0-1.md` | `/tmp` dry build completed; generated outputs not committed |
 | Source package hygiene checklist | `docs/paper/kora-first-paper-arxiv-source-package-hygiene-v0-1.md` | Package hygiene checklist created |
 | Figure/table/algorithm drafts | `docs/paper/kora-first-paper-figure-table-algorithm-drafts-v0-1.md` | Source for inserted text assets |
 | Figure/table/algorithm plan | `docs/paper/kora-first-paper-figure-table-algorithm-plan-v0-1.md` | Planning/status source |
@@ -57,6 +58,7 @@ This text-only manifest lists candidate source files and pending package items f
 - Install or select a LaTeX/PDF generation route outside this manifest.
 - Finalize bibliography and citation formatting.
 - Review table widths and caption placement for PDF layout.
+- Resolve Tectonic layout warnings before final package approval.
 - Capture final clean reproduction transcript.
 - Complete final human review.
 

--- a/docs/paper/kora-first-paper-arxiv-export-route-recommendation-v0-1.md
+++ b/docs/paper/kora-first-paper-arxiv-export-route-recommendation-v0-1.md
@@ -51,6 +51,16 @@ The local tooling plan and command plan now exist:
 
 No tools were installed automatically. A full dry build was not attempted because a LaTeX engine and Mermaid CLI are still missing locally.
 
+## Installed-Tools Dry Build Result
+
+The installed-tools dry build result now exists:
+
+- `docs/paper/kora-first-paper-arxiv-dry-build-result-v0-1.md`
+
+Using Tectonic 0.16.9 and Mermaid CLI 11.14.0, a `/tmp` dry build successfully generated rendered figure PDFs, LaTeX source, and a PDF after setting Mermaid CLI to use the locally installed browser. The result remains a dry build only: no generated PDFs, rendered figures, source packages, binary outputs, or raw benchmark artifacts were committed.
+
+Remaining route work is layout cleanup, final bibliography integration, source-package hygiene review, category/license approval, and final human review.
+
 ## BibTeX Handling
 
 The export route should use the conservative bibliography subset already aligned with manuscript v0.5. Full BibTeX remains incomplete, and deferred or still-not-eligible records should not be introduced during export cleanup.

--- a/docs/paper/kora-first-paper-arxiv-style-package-readiness-v0-1.md
+++ b/docs/paper/kora-first-paper-arxiv-style-package-readiness-v0-1.md
@@ -103,6 +103,14 @@ The local export tooling plan, dry-build command plan, and source-package hygien
 
 No tools were installed automatically. The next practical step is user-approved installation or selection of a LaTeX/PDF engine and Mermaid handling path, followed by a `/tmp` dry build.
 
+## Installed-Tools Dry Build Status
+
+The installed-tools dry-build result now exists:
+
+- `docs/paper/kora-first-paper-arxiv-dry-build-result-v0-1.md`
+
+With Tectonic and Mermaid CLI installed, a `/tmp` dry build generated rendered figure PDFs, LaTeX source, and a PDF after configuring Mermaid CLI to use the locally installed browser. No generated output was committed. The dry build still reports layout warnings, preliminary bibliography handling, and remaining source-package hygiene work, so the package remains not submission-ready.
+
 ## Missing User Approvals
 
 - Final title and abstract approval.

--- a/docs/paper/kora-first-paper-final-human-review-packet-v0-1.md
+++ b/docs/paper/kora-first-paper-final-human-review-packet-v0-1.md
@@ -61,6 +61,8 @@ This packet lists the human decisions still required before any submission-ready
 - Confirm whether the local export environment should use `pdflatex`, `xelatex`, `tectonic`, or another approved PDF generation route.
 - Approve or reject the local tooling setup commands before any tool installation.
 - Review the arXiv source package hygiene checklist before any source package is assembled or uploaded.
+- Review the installed-tools dry-build PDF and source-package folder under `/tmp` before approving any final export route.
+- Decide whether the Tectonic layout warnings require manuscript/table cleanup before final package assembly.
 
 ## Venue and Export Decisions
 

--- a/docs/paper/kora-first-paper-missing-evidence-checklist.md
+++ b/docs/paper/kora-first-paper-missing-evidence-checklist.md
@@ -126,6 +126,8 @@ Citation style decision:
 - Pandoc-to-LaTeX is feasible as a starting route, but LaTeX/PDF tooling, Mermaid conversion, table layout, final bibliography formatting, and human approval remain pending.
 - Local export tooling setup guide, dry-build command plan, and source-package hygiene checklist have been created.
 - No tools were installed automatically and no full dry build was attempted because required export tools remain missing locally.
+- Installed-tools arXiv dry-build result has been created.
+- A `/tmp` PDF dry build now passes with Mermaid CLI and Tectonic, but layout warnings, bibliography integration, source-package hygiene review, and final human approval remain pending.
 - Clean reproduction transcript capture, final artifact package review, final venue/export decision, and final human review remain pending.
 - Paper is still not submission-ready.
 

--- a/docs/paper/kora-first-paper-submission-candidate-status-v0-1.md
+++ b/docs/paper/kora-first-paper-submission-candidate-status-v0-1.md
@@ -124,6 +124,14 @@ The local export tooling setup guide, dry-build command plan, and source-package
 
 No system packages were installed automatically. A full `/tmp` dry build was not attempted because the required LaTeX/PDF and Mermaid rendering tools are still missing locally.
 
+## Installed-Tools Dry Build
+
+The installed-tools dry-build result now exists:
+
+- `docs/paper/kora-first-paper-arxiv-dry-build-result-v0-1.md`
+
+The `/tmp` dry build generated rendered Mermaid figure PDFs, LaTeX source, and a PDF using Mermaid CLI with a local browser path and Tectonic. Generated outputs stayed under `/tmp` and were not committed. Final layout cleanup, bibliography integration, source-package hygiene, and human review remain pending.
+
 ## Submission Package Packet
 
 The venue-neutral submission package readiness packet now exists:
@@ -137,4 +145,4 @@ These files organize package blockers, human review decisions, reproduction tran
 
 ## Status
 
-The manuscript has advanced to v0.5 submission-candidate draft status. Full BibTeX remains incomplete, final export tooling approval, asset rendering/conversion, table layout, bibliography formatting, source-package generation, and human review remain pending. The paper remains not submission-ready.
+The manuscript has advanced to v0.5 submission-candidate draft status. Full BibTeX remains incomplete, installed-tools dry build has passed as a local `/tmp` dry run, and final layout cleanup, bibliography formatting, source-package hygiene, and human review remain pending. The paper remains not submission-ready.

--- a/docs/paper/kora-first-paper-submission-package-readiness-v0-1.md
+++ b/docs/paper/kora-first-paper-submission-package-readiness-v0-1.md
@@ -111,3 +111,9 @@ Local export tooling setup guidance, a dry-build command plan, and a source-pack
 - `docs/paper/kora-first-paper-arxiv-source-package-hygiene-v0-1.md`
 
 No tools were installed, no full dry build was attempted, and no generated PDF/source package/binary output was committed.
+
+## Installed-Tools Dry Build Status
+
+The installed-tools dry build is recorded in `docs/paper/kora-first-paper-arxiv-dry-build-result-v0-1.md`.
+
+The `/tmp` dry build generated rendered figure PDFs, LaTeX source, and a PDF using Mermaid CLI with a local browser path and Tectonic. No generated PDF, rendered figure, source package, binary output, or raw benchmark artifact was committed. Layout warnings, bibliography integration, source-package hygiene, and final human review remain pending.


### PR DESCRIPTION
## Summary
- add the installed-tools arXiv dry-build result report for manuscript v0.5
- update Paper Track export/package/readiness docs with the dry-build status
- record that generated outputs stayed under `/tmp` and were not committed

## Tool versions
- pandoc 3.9.0.2
- tectonic 0.16.9
- mmdc 11.14.0
- node v26.0.0
- npm 11.12.1
- python3 3.13.5

## Dry-build results
- initial Mermaid render failed because mmdc could not find its Puppeteer-managed Chrome/headless-shell
- Mermaid render passed using `PUPPETEER_EXECUTABLE_PATH` pointed at the locally installed browser
- Pandoc Markdown-to-LaTeX passed
- Tectonic PDF build passed
- `/tmp` source-package folder assembly passed as dry-run only
- Tectonic emitted layout warnings that still require review

## Boundaries
- no generated PDFs, rendered figures, source packages, binary outputs, raw benchmark artifacts, or `/tmp` outputs were committed
- no arXiv category selected and no arXiv submission made
- paper remains not submission-ready

## Validation
- git diff --check: passed
- python3 -m pytest: 159 passed
- targeted scan: only expected non-claim/status text
- Unicode scan: no hidden/control/bidi/zero-width or non-ASCII characters
