### PR TITLE
docs: review arxiv dry build outputs

### DIFF
--- a/docs/paper/kora-first-paper-arxiv-dry-build-output-review-v0-1.md
+++ b/docs/paper/kora-first-paper-arxiv-dry-build-output-review-v0-1.md
@@ -1,0 +1,100 @@
+# KORA First Paper arXiv Dry Build Output Review v0.1
+
+Status date: 2026-05-14
+
+## Purpose
+
+This report reviews the `/tmp` dry-build outputs from the installed-tools arXiv dry build. It records output inventory, build warnings, and source-package hygiene findings. It does not commit generated PDFs, rendered figures, source packages, binary outputs, or raw benchmark artifacts. It does not submit to arXiv and does not mark the paper as submission-ready.
+
+## Source Reviewed
+
+- `docs/paper/kora-first-paper-manuscript-v0-5.md`
+- `docs/paper/kora-first-paper-preliminary-bibtex-v0-1.md`
+- `docs/paper/kora-first-paper-arxiv-dry-build-result-v0-1.md`
+- `/tmp/kora-paper-arxiv-dry-build/build`
+- `/tmp/kora-paper-arxiv-dry-build/source-package`
+
+## Output Inventory
+
+| Output | Exists | Approximate size | Purpose | Final package candidate | Committed |
+|---|---:|---:|---|---:|---:|
+| `/tmp/kora-paper-arxiv-dry-build/build/figure-1.pdf` | yes | 20,448 bytes | Rendered Figure 1 dry-run output | yes, after review | no |
+| `/tmp/kora-paper-arxiv-dry-build/build/figure-2.pdf` | yes | 19,644 bytes | Rendered Figure 2 dry-run output | yes, after review | no |
+| `/tmp/kora-paper-arxiv-dry-build/build/kora-first-paper-manuscript-v0-5.tex` | yes | 38,224 bytes | Generated LaTeX dry-run source | yes, after cleanup | no |
+| `/tmp/kora-paper-arxiv-dry-build/build/kora-first-paper-manuscript-v0-5.pdf` | yes | 92,996 bytes | Generated PDF dry-run output | no, final PDF must be regenerated after cleanup | no |
+| `/tmp/kora-paper-arxiv-dry-build/source-package/` | yes | 4 files, about 90,965 bytes total | Cleaned source-package dry-run folder | candidate structure only | no |
+
+The generated figure PDFs are PDF 1.4 one-page documents according to local `file` inspection. The generated paper PDF is a PDF 1.5 document. Page-count tooling was not available locally beyond this basic file inspection.
+
+## Source-Package Folder Contents
+
+Reviewed folder:
+
+```text
+/tmp/kora-paper-arxiv-dry-build/source-package
+```
+
+Contents:
+
+- `figure-1.pdf`
+- `figure-2.pdf`
+- `kora-first-paper-manuscript-v0-5.tex`
+- `kora-first-paper-preliminary-bibtex-v0-1.md`
+
+The cleaned source-package folder does not include the generated final PDF. A separate older scratch folder under `/tmp/kora-paper-arxiv-dry-build/package` contains a generated PDF and should not be used as the final source package candidate.
+
+## Build Warning Summary
+
+Fatal errors:
+
+- The first Tectonic run failed because `figure-1.pdf` did not exist after the default Mermaid rendering attempt failed.
+- The rerun passed after Mermaid CLI was pointed at the locally installed browser and figure PDFs were generated.
+
+Warnings in the successful Tectonic run:
+
+- Overfull boxes in route-metric text and long table/reference-heavy sections.
+- Underfull boxes in several paragraph/table areas.
+- Repeated overfull warnings around the appendix artifact inventory table.
+- Warnings that tagged figure PDFs were read while tags were ignored.
+
+No missing figure warnings remained in the successful build. Pandoc emitted no stderr output for the LaTeX generation step.
+
+## Source-Package Hygiene Findings
+
+Passed:
+
+- No hidden files found in the cleaned source-package folder.
+- No raw benchmark artifacts found.
+- No generated logs, `.aux`, `.out`, stdout, stderr, JSON, archive, or temporary files found.
+- No embedded `/tmp` paths found in the generated `.tex`.
+- Figure includes use relative paths: `figure-1.pdf` and `figure-2.pdf`.
+- No source-package files were committed.
+
+Needs review:
+
+- The bibliography source is still the preliminary Markdown BibTeX document, not final `.bib` integration.
+- The generated `.tex` still contains repository-document links from the Markdown draft; decide whether these should remain, be converted, or be removed for the final source package.
+- A broad secret-pattern scan produced a false positive on ordinary prose containing the substring `sk-`; no credential-like token was identified.
+- The cleaned source package includes binary figure PDFs, which are appropriate as final package candidates only after human visual review.
+
+## Blockers
+
+- Review the generated PDF visually.
+- Clean up overfull/underfull table and paragraph layout warnings.
+- Decide final treatment for tagged figure PDF warnings.
+- Convert preliminary bibliography handling into final package-ready form.
+- Complete source-package hygiene review on the exact final package folder.
+- Confirm arXiv category and license.
+- Complete final human approval.
+
+## Next Recommended Fixes
+
+1. Review the `/tmp` PDF visually.
+2. Simplify or reformat Table 1, Table 2, and Appendix Table A1 for LaTeX/PDF layout.
+3. Decide whether repository-document links should remain in the final paper source.
+4. Convert the preliminary BibTeX subset into a final package bibliography format.
+5. Rebuild under `/tmp` and repeat source-package hygiene checks.
+
+## Status
+
+Dry-build output review and source-package hygiene review are complete for the current `/tmp` outputs. No generated binary output was committed. The paper remains not submission-ready.

--- a/docs/paper/kora-first-paper-arxiv-dry-build-result-v0-1.md
+++ b/docs/paper/kora-first-paper-arxiv-dry-build-result-v0-1.md
@@ -131,6 +131,14 @@ These warnings do not block a dry build, but they do block treating the package 
 - Final source-package hygiene review.
 - Final human review of the exact PDF and source package.
 
+## Output Review Follow-Up
+
+The dry-build output review now exists:
+
+- `docs/paper/kora-first-paper-arxiv-dry-build-output-review-v0-1.md`
+
+The review confirms that the `/tmp` PDF, rendered figure PDFs, generated LaTeX, and cleaned source-package folder exist. It also records layout warnings, source-package hygiene findings, and remaining blockers before final package approval.
+
 ## Claim and Submission Status
 
 This dry build does not add evidence for production cost reduction, real API-cost reduction, production benchmark proof, broad workload superiority, energy reduction evidence, formal artifact approval, or paper submission readiness.

--- a/docs/paper/kora-first-paper-arxiv-export-package-manifest-v0-1.md
+++ b/docs/paper/kora-first-paper-arxiv-export-package-manifest-v0-1.md
@@ -20,6 +20,7 @@ This text-only manifest lists candidate source files and pending package items f
 | Local export tooling setup | `docs/paper/kora-first-paper-local-export-tooling-setup-v0-1.md` | User-run setup commands documented |
 | Dry-build command plan | `docs/paper/kora-first-paper-arxiv-dry-build-command-plan-v0-1.md` | Commands documented; full dry build pending tools |
 | Installed-tools dry-build result | `docs/paper/kora-first-paper-arxiv-dry-build-result-v0-1.md` | `/tmp` dry build completed; generated outputs not committed |
+| Dry-build output review | `docs/paper/kora-first-paper-arxiv-dry-build-output-review-v0-1.md` | `/tmp` output and source-package hygiene review completed |
 | Source package hygiene checklist | `docs/paper/kora-first-paper-arxiv-source-package-hygiene-v0-1.md` | Package hygiene checklist created |
 | Figure/table/algorithm drafts | `docs/paper/kora-first-paper-figure-table-algorithm-drafts-v0-1.md` | Source for inserted text assets |
 | Figure/table/algorithm plan | `docs/paper/kora-first-paper-figure-table-algorithm-plan-v0-1.md` | Planning/status source |
@@ -59,6 +60,7 @@ This text-only manifest lists candidate source files and pending package items f
 - Finalize bibliography and citation formatting.
 - Review table widths and caption placement for PDF layout.
 - Resolve Tectonic layout warnings before final package approval.
+- Review generated PDF and source-package folder before final package approval.
 - Capture final clean reproduction transcript.
 - Complete final human review.
 

--- a/docs/paper/kora-first-paper-arxiv-source-package-hygiene-v0-1.md
+++ b/docs/paper/kora-first-paper-arxiv-source-package-hygiene-v0-1.md
@@ -89,4 +89,4 @@ Before upload, confirm:
 
 ## Status
 
-This is a hygiene checklist only. No source package was created, no upload was performed, and the paper remains not submission-ready.
+The dry-build source-package hygiene review is recorded in `docs/paper/kora-first-paper-arxiv-dry-build-output-review-v0-1.md`. The reviewed `/tmp` folder contains only generated LaTeX, rendered figure PDFs, and the preliminary bibliography draft. Final package hygiene review remains pending for the exact final source package. No upload was performed, and the paper remains not submission-ready.

--- a/docs/paper/kora-first-paper-arxiv-style-package-readiness-v0-1.md
+++ b/docs/paper/kora-first-paper-arxiv-style-package-readiness-v0-1.md
@@ -111,6 +111,14 @@ The installed-tools dry-build result now exists:
 
 With Tectonic and Mermaid CLI installed, a `/tmp` dry build generated rendered figure PDFs, LaTeX source, and a PDF after configuring Mermaid CLI to use the locally installed browser. No generated output was committed. The dry build still reports layout warnings, preliminary bibliography handling, and remaining source-package hygiene work, so the package remains not submission-ready.
 
+## Dry Build Output Review Status
+
+The dry-build output review now exists:
+
+- `docs/paper/kora-first-paper-arxiv-dry-build-output-review-v0-1.md`
+
+The review confirms the `/tmp` output inventory and cleaned source-package folder. It records remaining layout, bibliography, link, and final human-review blockers. No generated PDFs, rendered figures, source packages, or binary outputs were committed.
+
 ## Missing User Approvals
 
 - Final title and abstract approval.

--- a/docs/paper/kora-first-paper-final-human-review-packet-v0-1.md
+++ b/docs/paper/kora-first-paper-final-human-review-packet-v0-1.md
@@ -63,6 +63,7 @@ This packet lists the human decisions still required before any submission-ready
 - Review the arXiv source package hygiene checklist before any source package is assembled or uploaded.
 - Review the installed-tools dry-build PDF and source-package folder under `/tmp` before approving any final export route.
 - Decide whether the Tectonic layout warnings require manuscript/table cleanup before final package assembly.
+- Review the dry-build output review report and decide whether the generated figure PDFs, repository-document links, and preliminary bibliography handling are acceptable for the final package path.
 
 ## Venue and Export Decisions
 

--- a/docs/paper/kora-first-paper-missing-evidence-checklist.md
+++ b/docs/paper/kora-first-paper-missing-evidence-checklist.md
@@ -128,6 +128,8 @@ Citation style decision:
 - No tools were installed automatically and no full dry build was attempted because required export tools remain missing locally.
 - Installed-tools arXiv dry-build result has been created.
 - A `/tmp` PDF dry build now passes with Mermaid CLI and Tectonic, but layout warnings, bibliography integration, source-package hygiene review, and final human approval remain pending.
+- Dry-build output review and source-package hygiene review have been created for the current `/tmp` outputs.
+- Generated PDF visual review, layout cleanup, final bibliography integration, and final source-package hygiene review remain pending.
 - Clean reproduction transcript capture, final artifact package review, final venue/export decision, and final human review remain pending.
 - Paper is still not submission-ready.
 

--- a/docs/paper/kora-first-paper-submission-candidate-status-v0-1.md
+++ b/docs/paper/kora-first-paper-submission-candidate-status-v0-1.md
@@ -132,6 +132,14 @@ The installed-tools dry-build result now exists:
 
 The `/tmp` dry build generated rendered Mermaid figure PDFs, LaTeX source, and a PDF using Mermaid CLI with a local browser path and Tectonic. Generated outputs stayed under `/tmp` and were not committed. Final layout cleanup, bibliography integration, source-package hygiene, and human review remain pending.
 
+## Dry Build Output Review
+
+The dry-build output review now exists:
+
+- `docs/paper/kora-first-paper-arxiv-dry-build-output-review-v0-1.md`
+
+The review confirms the `/tmp` output inventory, cleaned source-package folder, and remaining blockers. No generated binaries or source-package files were committed.
+
 ## Submission Package Packet
 
 The venue-neutral submission package readiness packet now exists:
@@ -145,4 +153,4 @@ These files organize package blockers, human review decisions, reproduction tran
 
 ## Status
 
-The manuscript has advanced to v0.5 submission-candidate draft status. Full BibTeX remains incomplete, installed-tools dry build has passed as a local `/tmp` dry run, and final layout cleanup, bibliography formatting, source-package hygiene, and human review remain pending. The paper remains not submission-ready.
+The manuscript has advanced to v0.5 submission-candidate draft status. Full BibTeX remains incomplete, installed-tools dry build and output review have passed as local `/tmp` work, and final visual review, layout cleanup, bibliography formatting, source-package hygiene, and human review remain pending. The paper remains not submission-ready.


### PR DESCRIPTION
## Summary
- add dry-build output review report for the current `/tmp` arXiv dry build
- record PDF/figure/LaTeX/source-package inventory and sizes
- record build warnings and source-package hygiene findings
- update Paper Track readiness/status docs

## Output review
- inspected generated PDF, rendered figure PDFs, generated LaTeX, logs, and cleaned source-package folder under `/tmp/kora-paper-arxiv-dry-build`
- no generated PDFs, rendered figures, source packages, binary outputs, raw benchmark artifacts, or `/tmp` outputs were committed
- source-package folder has no hidden files, logs, raw artifacts, or embedded `/tmp` paths

## Findings
- successful build still has overfull/underfull layout warnings
- final bibliography is not yet integrated as a final `.bib` path
- generated `.tex` still contains repository-document links that need final package review
- final visual review and exact source-package hygiene review remain pending

## Validation
- git diff --check: passed
- python3 -m pytest: 159 passed
- targeted scan: only expected non-claim/status text
- Unicode scan: no hidden/control/bidi/zero-width or non-ASCII characters

Paper remains not submission-ready.
