### PR TITLE
docs: add word draft and figure redesign review notes

### DIFF
--- a/docs/paper/kora-first-paper-arxiv-export-route-recommendation-v0-1.md
+++ b/docs/paper/kora-first-paper-arxiv-export-route-recommendation-v0-1.md
@@ -61,6 +61,15 @@ Using Tectonic 0.16.9 and Mermaid CLI 11.14.0, a `/tmp` dry build successfully g
 
 Remaining route work is layout cleanup, final bibliography integration, source-package hygiene review, category/license approval, and final human review.
 
+## Word-First Pause
+
+PDF and arXiv source-package work are paused while the Word draft review route is active:
+
+- `docs/paper/kora-first-paper-word-draft-review-v0-1.md`
+- `docs/paper/kora-first-paper-figure-redesign-note-v0-1.md`
+
+The export route recommendation should be revisited after human review of the Word draft and redesigned figures.
+
 ## BibTeX Handling
 
 The export route should use the conservative bibliography subset already aligned with manuscript v0.5. Full BibTeX remains incomplete, and deferred or still-not-eligible records should not be introduced during export cleanup.

--- a/docs/paper/kora-first-paper-arxiv-style-package-readiness-v0-1.md
+++ b/docs/paper/kora-first-paper-arxiv-style-package-readiness-v0-1.md
@@ -119,6 +119,15 @@ The dry-build output review now exists:
 
 The review confirms the `/tmp` output inventory and cleaned source-package folder. It records remaining layout, bibliography, link, and final human-review blockers. No generated PDFs, rendered figures, source packages, or binary outputs were committed.
 
+## Word-First Pause
+
+PDF and arXiv source-package work are paused while the Word review path is active. The Word draft review and figure redesign notes now exist:
+
+- `docs/paper/kora-first-paper-word-draft-review-v0-1.md`
+- `docs/paper/kora-first-paper-figure-redesign-note-v0-1.md`
+
+Final arXiv export remains pending until the Word draft, redesigned figures, bibliography formatting, and final human review are resolved.
+
 ## Missing User Approvals
 
 - Final title and abstract approval.

--- a/docs/paper/kora-first-paper-figure-redesign-note-v0-1.md
+++ b/docs/paper/kora-first-paper-figure-redesign-note-v0-1.md
@@ -1,0 +1,71 @@
+# KORA First Paper Figure Redesign Note v0.1
+
+Status date: 2026-05-14
+
+## Purpose
+
+This note records the figure redesign pass for the Word review draft. The redesigned figures are local-only review assets and were not committed as binary outputs.
+
+## Design Direction
+
+The Word review figures use a clean technical box-and-arrow style with:
+
+- dark navy header and outlines,
+- readable large labels,
+- simple directional arrows,
+- conservative captions and notes,
+- no production, real API-cost, energy, broad-superiority, or formal-approval claims.
+
+## Figure 1
+
+Figure: KORA execution-control architecture.
+
+Local review outputs:
+
+- `figure-1-kora-execution-control-word.png`
+- `figure-1-kora-execution-control-word.svg`
+
+Status:
+
+- Recreated for Word review.
+- Inserted into the image-inserted Word draft.
+- Ready for human visual review.
+- Not yet publication-final.
+
+Claim boundary:
+
+- Shows architecture only.
+- Does not claim production readiness.
+- Does not claim every task can be handled deterministically.
+
+## Figure 2
+
+Figure: direct baseline vs KORA-controlled benchmark flow.
+
+Local review outputs:
+
+- `figure-2-benchmark-flow-word.png`
+- `figure-2-benchmark-flow-word.svg`
+
+Status:
+
+- Recreated for Word review.
+- Inserted into the image-inserted Word draft.
+- Ready for human visual review.
+- Not yet publication-final.
+
+Claim boundary:
+
+- Uses only the established deterministic-heavy benchmark counts: 100 tasks, 100 baseline simulated model invocations, 80 deterministic/no-model completions, 20 model-candidate paths, 80 avoided simulated model invocations, and 80% avoided invocation rate.
+- Does not imply real API calls, production traffic, cost savings, latency improvement, or energy reduction.
+
+## Remaining Work
+
+- Review readability in Word.
+- Decide whether to keep the dark navy technical style.
+- Decide whether SVG or PNG should be the final editable/design source.
+- Polish final publication figures only after human review.
+
+## Status
+
+The redesigned figures are ready for Word human review. No generated image binaries were committed. The paper remains not submission-ready.

--- a/docs/paper/kora-first-paper-final-human-review-packet-v0-1.md
+++ b/docs/paper/kora-first-paper-final-human-review-packet-v0-1.md
@@ -64,6 +64,9 @@ This packet lists the human decisions still required before any submission-ready
 - Review the installed-tools dry-build PDF and source-package folder under `/tmp` before approving any final export route.
 - Decide whether the Tectonic layout warnings require manuscript/table cleanup before final package assembly.
 - Review the dry-build output review report and decide whether the generated figure PDFs, repository-document links, and preliminary bibliography handling are acceptable for the final package path.
+- Review the image-inserted Word draft before resuming PDF/arXiv source-package work.
+- Review redesigned Figure 1 and Figure 2 for readability, style, and claim boundaries.
+- Decide whether the redesigned figures should become the basis for publication figures.
 
 ## Venue and Export Decisions
 

--- a/docs/paper/kora-first-paper-missing-evidence-checklist.md
+++ b/docs/paper/kora-first-paper-missing-evidence-checklist.md
@@ -130,6 +130,8 @@ Citation style decision:
 - A `/tmp` PDF dry build now passes with Mermaid CLI and Tectonic, but layout warnings, bibliography integration, source-package hygiene review, and final human approval remain pending.
 - Dry-build output review and source-package hygiene review have been created for the current `/tmp` outputs.
 - Generated PDF visual review, layout cleanup, final bibliography integration, and final source-package hygiene review remain pending.
+- Word draft review and figure redesign notes have been created.
+- Word-first human review is now active, and PDF/arXiv source-package work is paused until the Word draft and redesigned figures are reviewed.
 - Clean reproduction transcript capture, final artifact package review, final venue/export decision, and final human review remain pending.
 - Paper is still not submission-ready.
 

--- a/docs/paper/kora-first-paper-submission-candidate-status-v0-1.md
+++ b/docs/paper/kora-first-paper-submission-candidate-status-v0-1.md
@@ -140,6 +140,15 @@ The dry-build output review now exists:
 
 The review confirms the `/tmp` output inventory, cleaned source-package folder, and remaining blockers. No generated binaries or source-package files were committed.
 
+## Word Draft and Figure Redesign Pass
+
+The Word-first review route is now active, and PDF/arXiv source-package generation is paused. The Word draft review and figure redesign notes now exist:
+
+- `docs/paper/kora-first-paper-word-draft-review-v0-1.md`
+- `docs/paper/kora-first-paper-figure-redesign-note-v0-1.md`
+
+Local-only Word drafts and redesigned Figure 1/Figure 2 PNG/SVG assets were generated outside the public repository. No generated DOCX, PDF, PNG, SVG, source package, or local working Markdown was committed.
+
 ## Submission Package Packet
 
 The venue-neutral submission package readiness packet now exists:
@@ -153,4 +162,4 @@ These files organize package blockers, human review decisions, reproduction tran
 
 ## Status
 
-The manuscript has advanced to v0.5 submission-candidate draft status. Full BibTeX remains incomplete, installed-tools dry build and output review have passed as local `/tmp` work, and final visual review, layout cleanup, bibliography formatting, source-package hygiene, and human review remain pending. The paper remains not submission-ready.
+The manuscript has advanced to v0.5 submission-candidate draft status. Full BibTeX remains incomplete, Word-first human review is now the active route, and final visual review, layout cleanup, bibliography formatting, source-package hygiene, and human review remain pending. The paper remains not submission-ready.

--- a/docs/paper/kora-first-paper-submission-package-readiness-v0-1.md
+++ b/docs/paper/kora-first-paper-submission-package-readiness-v0-1.md
@@ -117,3 +117,12 @@ No tools were installed, no full dry build was attempted, and no generated PDF/s
 The installed-tools dry build is recorded in `docs/paper/kora-first-paper-arxiv-dry-build-result-v0-1.md`.
 
 The `/tmp` dry build generated rendered figure PDFs, LaTeX source, and a PDF using Mermaid CLI with a local browser path and Tectonic. No generated PDF, rendered figure, source package, binary output, or raw benchmark artifact was committed. Layout warnings, bibliography integration, source-package hygiene, and final human review remain pending.
+
+## Word-First Review Status
+
+PDF and arXiv source-package work are paused while the Word review path is active. The Word draft review and figure redesign notes now exist:
+
+- `docs/paper/kora-first-paper-word-draft-review-v0-1.md`
+- `docs/paper/kora-first-paper-figure-redesign-note-v0-1.md`
+
+Local-only Word drafts and redesigned figure assets were generated outside the repository for human review. No generated DOCX, PDF, image, source-package, or local working file was committed.

--- a/docs/paper/kora-first-paper-word-draft-review-v0-1.md
+++ b/docs/paper/kora-first-paper-word-draft-review-v0-1.md
@@ -1,0 +1,79 @@
+# KORA First Paper Word Draft Review v0.1
+
+Status date: 2026-05-14
+
+## Purpose
+
+This report records the Word-first human review package created from manuscript v0.5. PDF and arXiv source-package generation are paused. Generated Word files, figure images, and local Markdown working copies were created outside the public repository and were not committed. The paper remains not submission-ready.
+
+## Source Manuscript
+
+- `docs/paper/kora-first-paper-manuscript-v0-5.md`
+
+## Local Output Root
+
+Generated outputs were written under the local-only generated paper output root:
+
+```text
+generated_paper_outputs/word_draft_v0_5/
+```
+
+This directory is outside the public KORA repository and is not tracked.
+
+## Word Outputs
+
+| Output | Status | Approximate size | Recommended use | Committed |
+|---|---|---:|---|---:|
+| `kora-first-paper-manuscript-v0-5-word-review-image-inserted.docx` | generated | 177,462 bytes | Primary human review draft | no |
+| `kora-first-paper-manuscript-v0-5-word-review-text-only.docx` | generated | 22,085 bytes | Fallback text-only review draft | no |
+
+The image-inserted Word draft contains two embedded PNG figure media files. The text-only Word draft preserves the manuscript content without embedded figure images.
+
+## Figure Outputs
+
+| Figure | Local outputs | Status | Committed |
+|---|---|---|---:|
+| Figure 1: KORA execution-control architecture | `figure-1-kora-execution-control-word.png`, `figure-1-kora-execution-control-word.svg` | recreated for Word review | no |
+| Figure 2: direct baseline vs KORA-controlled benchmark flow | `figure-2-benchmark-flow-word.png`, `figure-2-benchmark-flow-word.svg` | recreated for Word review | no |
+
+The figures were recreated as simple technical diagrams for Word review rather than using the prior Mermaid-rendered outputs directly.
+
+## Generation Commands
+
+The local Word package was generated with Pandoc and local image assets:
+
+```bash
+pandoc docs/paper/kora-first-paper-manuscript-v0-5.md -o <local-output>/kora-first-paper-manuscript-v0-5-word-review-text-only.docx
+pandoc <local-output>/kora-first-paper-manuscript-v0-5-word-review-image-inserted.md --resource-path=<local-output> -o <local-output>/kora-first-paper-manuscript-v0-5-word-review-image-inserted.docx
+```
+
+The image-inserted Markdown working copy replaced the two Mermaid code blocks with local PNG figure references. The repository manuscript was not modified for local image paths.
+
+## Verification
+
+- Word generation passed.
+- The image-inserted DOCX contains two embedded PNG media files.
+- The text-only DOCX contains no embedded media files.
+- No PDF was generated for this task.
+- No generated DOCX, PNG, SVG, Markdown working copy, PDF, or source package was committed.
+
+## Known Word Layout Risks
+
+- Tables still need human visual review in Word, especially Table 1, Table 2, and Appendix Table A1.
+- Captions are plain manuscript text and may need Word-native caption styling later.
+- Cross-references are manual text references, not Word fields.
+- Bibliography remains a preliminary manuscript section and is not final Word bibliography automation.
+- Algorithm 1 remains a text block and may need styling for readability.
+
+## Remaining Review Items
+
+- Human review of the image-inserted Word draft.
+- Human review of both redesigned figures for clarity, scale, and visual style.
+- Decide whether the redesigned figures should become the basis for publication figures.
+- Review table layout and captions in Word.
+- Final bibliography formatting and citation review.
+- Final arXiv PDF/source-package work remains paused until Word review is complete.
+
+## Status
+
+The Word-first review route is active. The Word draft package was generated local-only. The paper remains not submission-ready.


### PR DESCRIPTION
## Summary
- add a Word draft review report for manuscript v0.5
- add a figure redesign note for Word-review versions of Figure 1 and Figure 2
- update Paper Track status/readiness docs to pause PDF/arXiv source-package work and activate Word-first review

## Local-only outputs
- Word outputs are under `/Users/albertkim/02_PROJECTS/05_KORA_Project/local/generated_paper_outputs/word_draft_v0_5/`
- generated an image-inserted DOCX and a text-only DOCX
- generated redesigned Figure 1/Figure 2 PNG and SVG files for review
- image-inserted DOCX contains two embedded PNG media files

## Boundaries
- no PDF generated for this task
- no generated DOCX, PNG, SVG, PDF, source package, or local working Markdown committed
- no arXiv category selected and no arXiv submission made
- paper remains not submission-ready

## Validation
- git diff --check: passed
- python3 -m pytest: 159 passed
- targeted scan: only expected non-claim/status text
- Unicode scan: no hidden/control/bidi/zero-width or non-ASCII characters
- staged binary check: no generated binary files staged
