### PR TITLE
docs: switch word review figures to placeholders

### DIFF
--- a/docs/paper/kora-first-paper-arxiv-export-route-recommendation-v0-1.md
+++ b/docs/paper/kora-first-paper-arxiv-export-route-recommendation-v0-1.md
@@ -70,6 +70,8 @@ PDF and arXiv source-package work are paused while the Word draft review route i
 
 The export route recommendation should be revisited after human review of the Word draft and redesigned figures.
 
+The image-inserted Word draft is superseded by a placeholder Word review draft because the inserted figure arrows did not render correctly. Final publication-quality figures should be recreated after manuscript-body review, before resuming arXiv source-package work.
+
 ## BibTeX Handling
 
 The export route should use the conservative bibliography subset already aligned with manuscript v0.5. Full BibTeX remains incomplete, and deferred or still-not-eligible records should not be introduced during export cleanup.

--- a/docs/paper/kora-first-paper-arxiv-style-package-readiness-v0-1.md
+++ b/docs/paper/kora-first-paper-arxiv-style-package-readiness-v0-1.md
@@ -128,6 +128,14 @@ PDF and arXiv source-package work are paused while the Word review path is activ
 
 Final arXiv export remains pending until the Word draft, redesigned figures, bibliography formatting, and final human review are resolved.
 
+## Word Placeholder Review Update
+
+The image-inserted Word draft is superseded by a placeholder Word review draft because the inserted figure arrows did not render correctly:
+
+- `docs/paper/kora-first-paper-word-placeholder-review-v0-1.md`
+
+PDF/arXiv source-package work remains paused. Final publication-quality figures are deferred until after manuscript-body review.
+
 ## Missing User Approvals
 
 - Final title and abstract approval.

--- a/docs/paper/kora-first-paper-figure-redesign-note-v0-1.md
+++ b/docs/paper/kora-first-paper-figure-redesign-note-v0-1.md
@@ -68,4 +68,8 @@ Claim boundary:
 
 ## Status
 
-The redesigned figures are ready for Word human review. No generated image binaries were committed. The paper remains not submission-ready.
+The redesigned figures were reviewed in the Word draft and are not accepted for publication use because the inserted figure arrows did not render correctly. They are superseded by placeholders for Word review:
+
+- `docs/paper/kora-first-paper-word-placeholder-review-v0-1.md`
+
+Final publication-quality figures must be recreated after manuscript-body finalization. No generated image binaries were committed. The paper remains not submission-ready.

--- a/docs/paper/kora-first-paper-final-human-review-packet-v0-1.md
+++ b/docs/paper/kora-first-paper-final-human-review-packet-v0-1.md
@@ -67,6 +67,8 @@ This packet lists the human decisions still required before any submission-ready
 - Review the image-inserted Word draft before resuming PDF/arXiv source-package work.
 - Review redesigned Figure 1 and Figure 2 for readability, style, and claim boundaries.
 - Decide whether the redesigned figures should become the basis for publication figures.
+- Use the placeholder Word draft for manuscript-body review because the image-inserted figures had broken arrows.
+- Defer final Figure 1 and Figure 2 creation until after manuscript-body review.
 
 ## Venue and Export Decisions
 

--- a/docs/paper/kora-first-paper-missing-evidence-checklist.md
+++ b/docs/paper/kora-first-paper-missing-evidence-checklist.md
@@ -132,6 +132,8 @@ Citation style decision:
 - Generated PDF visual review, layout cleanup, final bibliography integration, and final source-package hygiene review remain pending.
 - Word draft review and figure redesign notes have been created.
 - Word-first human review is now active, and PDF/arXiv source-package work is paused until the Word draft and redesigned figures are reviewed.
+- Word placeholder review note has been created after human review found broken arrows in the inserted figure images.
+- Figure finalization is deferred until after manuscript-body review.
 - Clean reproduction transcript capture, final artifact package review, final venue/export decision, and final human review remain pending.
 - Paper is still not submission-ready.
 

--- a/docs/paper/kora-first-paper-submission-candidate-status-v0-1.md
+++ b/docs/paper/kora-first-paper-submission-candidate-status-v0-1.md
@@ -149,6 +149,14 @@ The Word-first review route is now active, and PDF/arXiv source-package generati
 
 Local-only Word drafts and redesigned Figure 1/Figure 2 PNG/SVG assets were generated outside the public repository. No generated DOCX, PDF, PNG, SVG, source package, or local working Markdown was committed.
 
+## Word Figure Placeholder Pass
+
+The image-inserted Word draft is superseded for review because human review found broken arrows in the inserted figure images. Word-first review now continues with placeholders:
+
+- `docs/paper/kora-first-paper-word-placeholder-review-v0-1.md`
+
+Figure 1 and Figure 2 finalization is deferred until after manuscript-body review. No generated DOCX, PDF, image, source package, binary output, or local working Markdown was committed.
+
 ## Submission Package Packet
 
 The venue-neutral submission package readiness packet now exists:
@@ -162,4 +170,4 @@ These files organize package blockers, human review decisions, reproduction tran
 
 ## Status
 
-The manuscript has advanced to v0.5 submission-candidate draft status. Full BibTeX remains incomplete, Word-first human review is now the active route, and final visual review, layout cleanup, bibliography formatting, source-package hygiene, and human review remain pending. The paper remains not submission-ready.
+The manuscript has advanced to v0.5 submission-candidate draft status. Full BibTeX remains incomplete, Word-first human review is now the active route with figure placeholders, and final visual review, figure creation, layout cleanup, bibliography formatting, source-package hygiene, and human review remain pending. The paper remains not submission-ready.

--- a/docs/paper/kora-first-paper-submission-package-readiness-v0-1.md
+++ b/docs/paper/kora-first-paper-submission-package-readiness-v0-1.md
@@ -126,3 +126,11 @@ PDF and arXiv source-package work are paused while the Word review path is activ
 - `docs/paper/kora-first-paper-figure-redesign-note-v0-1.md`
 
 Local-only Word drafts and redesigned figure assets were generated outside the repository for human review. No generated DOCX, PDF, image, source-package, or local working file was committed.
+
+## Word Placeholder Review Status
+
+The image-inserted Word draft is superseded for review because the inserted figure arrows did not render correctly. The active Word review draft uses placeholders for Figure 1 and Figure 2:
+
+- `docs/paper/kora-first-paper-word-placeholder-review-v0-1.md`
+
+PDF generation remains paused. Final publication-quality figure creation is deferred until after manuscript-body review.

--- a/docs/paper/kora-first-paper-word-draft-review-v0-1.md
+++ b/docs/paper/kora-first-paper-word-draft-review-v0-1.md
@@ -76,4 +76,8 @@ The image-inserted Markdown working copy replaced the two Mermaid code blocks wi
 
 ## Status
 
-The Word-first review route is active. The Word draft package was generated local-only. The paper remains not submission-ready.
+The image-inserted Word draft is superseded for review because the inserted figure arrows did not render correctly. The active Word review draft uses figure placeholders and is recorded in:
+
+- `docs/paper/kora-first-paper-word-placeholder-review-v0-1.md`
+
+The Word-first review route remains active. The paper remains not submission-ready.

--- a/docs/paper/kora-first-paper-word-placeholder-review-v0-1.md
+++ b/docs/paper/kora-first-paper-word-placeholder-review-v0-1.md
@@ -1,0 +1,78 @@
+# KORA First Paper Word Placeholder Review v0.1
+
+Status date: 2026-05-15
+
+## Purpose
+
+This report records the cleanup of the Word review draft after human review found that the inserted figure images did not render correctly. The Word-first review route continues with text placeholders for Figure 1 and Figure 2. PDF and arXiv source-package work remain paused. The paper remains not submission-ready.
+
+## Source Manuscript
+
+- `docs/paper/kora-first-paper-manuscript-v0-5.md`
+
+The repository manuscript was preserved. A local-only working Markdown copy was created for Word review.
+
+## Local Output Root
+
+Generated outputs were written under the local-only generated paper output root:
+
+```text
+generated_paper_outputs/word_draft_v0_5_placeholders/
+```
+
+This directory is outside the public KORA repository and is not tracked.
+
+## Placeholder Word Output
+
+| Output | Status | Approximate size | Committed |
+|---|---|---:|---:|
+| `kora-first-paper-manuscript-v0-5-word-review-placeholders.docx` | generated | 21,877 bytes | no |
+| `kora-first-paper-manuscript-v0-5-word-review-placeholders.md` | generated local working copy | 28,466 bytes | no |
+
+The placeholder Word draft contains no embedded media files.
+
+## Placeholder Text
+
+Figure 1 placeholder:
+
+```text
+[Figure 1 placeholder: KORA execution-control architecture. Final publication-quality figure to be inserted after manuscript body review.]
+```
+
+Figure 2 placeholder:
+
+```text
+[Figure 2 placeholder: Direct baseline vs KORA-controlled deterministic-heavy benchmark flow. Final publication-quality figure to be inserted after manuscript body review.]
+```
+
+## Reason for Switching to Placeholders
+
+Human review found that arrows in the inserted figure images were broken. The current figure images are not being forced into the Word draft. The goal is to keep manuscript-body review moving while deferring final figure creation.
+
+## Figure Status
+
+| Figure | Current status | Next action |
+|---|---|---|
+| Figure 1: KORA execution-control architecture | deferred | Recreate publication-quality figure after manuscript body finalization |
+| Figure 2: direct baseline vs KORA-controlled deterministic-heavy benchmark flow | deferred | Recreate publication-quality figure after manuscript body finalization |
+
+Previous redesigned figures are not accepted for publication use. They are superseded by placeholders for Word review.
+
+## Verification
+
+- Word generation passed.
+- Placeholder DOCX contains both Figure 1 and Figure 2 placeholder text.
+- Placeholder DOCX contains no embedded media.
+- No PDF was generated.
+- No generated DOCX, local Markdown working copy, PDF, image, source package, or binary output was committed.
+
+## Remaining Review Items
+
+- Review manuscript body using the placeholder Word draft.
+- Review Table 1, Table 2, Algorithm 1, and Appendix Table A1 in Word.
+- Finalize publication-quality figures only after manuscript-body review.
+- Resume PDF/arXiv source-package work only after Word review and figure decisions are complete.
+
+## Status
+
+Word-first review continues with placeholders. Figure insertion is not complete. Final figure creation is deferred. The paper remains not submission-ready.


### PR DESCRIPTION
## Summary
- Adds a Word placeholder review report for manuscript v0.5.
- Marks the prior redesigned Figure 1 and Figure 2 outputs as superseded for Word review after broken arrow rendering was found.
- Updates Paper Track status/readiness docs to keep Word-first body review moving while deferring publication-quality figure finalization.

## Local-only Word output
- Placeholder DOCX: `/Users/albertkim/02_PROJECTS/05_KORA_Project/local/generated_paper_outputs/word_draft_v0_5_placeholders/kora-first-paper-manuscript-v0-5-word-review-placeholders.docx`
- Word generation passed.
- PDF generation was skipped.
- No generated DOCX, PDF, images, source packages, or other binaries are committed.

## Claim safety
- The bounded 80% deterministic-heavy benchmark claim is preserved.
- No production/API-cost/energy/broad superiority/formal approval claims were added.

## Remaining review items
- Human manuscript-body review using the placeholder Word draft.
- Publication-quality Figure 1 and Figure 2 redesign after body text is finalized.
- Final export/arXiv package work remains paused.
- Paper remains not submission-ready.

## Validation
- `git diff --check`: passed
- `python3 -m pytest`: 159 passed
- Targeted internal/claim scan: clean except expected non-claim/status language
- Unicode scan: no hidden/control/bidi/zero-width characters; no non-ASCII punctuation
- Staged binary check: no `.docx`, `.pdf`, `.png`, `.svg`, `.zip`, `.tar`, or `.gz` staged