### PR TITLE
docs: clarify local setup prerequisites

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,15 +38,35 @@ Good contributors are interested in:
 
 ## Local setup
 
+### Prerequisites
+
+KORA uses `pyproject.toml`-based Python packaging.
+
+- Required Python: Python 3.11 or newer.
+- Recommended Python for local development: Python 3.13, matching the current CI test environment.
+- Upgrade `pip`, `setuptools`, and `wheel` before editable install.
+
+Check your local tools before installing:
+
+```bash
+python3 --version
+python3 -m pip --version
+```
+
 Start from a clean checkout of the repository.
 
 ```bash
+python3 --version
+
+rm -rf .venv
 python3 -m venv .venv
 source .venv/bin/activate
+
+python3 -m pip install --upgrade pip setuptools wheel
 python3 -m pip install -e ".[dev]"
 ```
 
-If editable install reports that `setup.py`, `setup.cfg`, or install metadata is missing, verify that your checkout is current:
+If editable install reports that `setup.py`, `setup.cfg`, or install metadata is missing, first verify that your checkout is current:
 
 ```bash
 git remote -v
@@ -59,6 +79,31 @@ ls pyproject.toml
 If `pyproject.toml` is still missing after pulling, re-clone from `https://github.com/Krako-Labs/KORA.git`.
 
 The editable install should install KORA and its development dependencies into the virtual environment.
+
+### Local setup troubleshooting
+
+For first-run failures after a system restart, Python upgrade, or virtual environment change, capture the local environment first:
+
+```bash
+python3 --version
+python3 -m pip --version
+python3 -m pip show pydantic
+```
+
+If `python3 -m kora run direct_vs_kora -- --offline` fails with:
+
+```text
+TypeError: unsupported operand type(s) for |: 'ModelMetaclass' and 'ModelMetaclass'
+```
+
+that usually indicates a local Python, virtual environment, or dependency compatibility problem. Confirm Python is 3.11 or newer, then rebuild the virtual environment using the clean setup block above.
+
+If editable install says `setup.py` or `setup.cfg` is missing even though `pyproject.toml` exists, upgrade local build tooling inside the activated virtual environment:
+
+```bash
+python3 -m pip install --upgrade pip setuptools wheel
+python3 -m pip install -e ".[dev]"
+```
 
 ## First verification commands
 

--- a/README.md
+++ b/README.md
@@ -26,17 +26,38 @@ request -> task graph -> deterministic path -> validation -> model escalation ->
 
 Structure first. Inference second.
 
+## Prerequisites
+
+KORA uses `pyproject.toml`-based Python packaging.
+
+- Required Python: Python 3.11 or newer.
+- Recommended Python for local development: Python 3.13, matching the current CI test environment.
+- Use a fresh virtual environment after a system restart, Python upgrade, or dependency mismatch.
+- Upgrade `pip`, `setuptools`, and `wheel` before editable install so local tooling understands modern `pyproject.toml` builds.
+
+Check your local tools first:
+
+```bash
+python3 --version
+python3 -m pip --version
+```
+
 ## 3-Minute Local Run
 
 For local development in this repository:
 
 ```bash
+python3 --version
+
+rm -rf .venv
 python3 -m venv .venv
 source .venv/bin/activate
+
+python3 -m pip install --upgrade pip setuptools wheel
 python3 -m pip install -e ".[dev]"
 ```
 
-If editable install reports that `setup.py`, `setup.cfg`, or install metadata is missing, verify that your checkout is current:
+If editable install reports that `setup.py`, `setup.cfg`, or install metadata is missing, first verify that your checkout is current:
 
 ```bash
 git remote -v
@@ -57,6 +78,40 @@ python3 -m kora run direct_vs_kora -- --offline
 ```
 
 Inspect the output to see how KORA changes a direct model-first path into a controlled execution path.
+
+## Local Setup Troubleshooting
+
+If first-run setup fails after a system restart, Python upgrade, or virtual environment change, start by checking the local environment:
+
+```bash
+python3 --version
+python3 -m pip --version
+python3 -m pip show pydantic
+```
+
+### `TypeError: unsupported operand type(s) for |: 'ModelMetaclass' and 'ModelMetaclass'`
+
+This usually indicates a local Python, virtual environment, or dependency compatibility problem. KORA requires Python 3.11 or newer. Recreate the environment and reinstall with current build tooling:
+
+```bash
+rm -rf .venv
+python3 -m venv .venv
+source .venv/bin/activate
+
+python3 -m pip install --upgrade pip setuptools wheel
+python3 -m pip install -e ".[dev]"
+python3 -m kora run direct_vs_kora -- --offline
+```
+
+### Editable install says `setup.py` or `setup.cfg` is missing
+
+KORA uses `pyproject.toml`-based packaging, so a missing `setup.py` or `setup.cfg` message usually means the local `pip`/build tooling is too old or the virtual environment is stale. Confirm `pyproject.toml` exists, upgrade build tooling, then reinstall:
+
+```bash
+ls pyproject.toml
+python3 -m pip install --upgrade pip setuptools wheel
+python3 -m pip install -e ".[dev]"
+```
 
 ## What KORA Does
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -54,6 +54,26 @@ KORA Studio is future planning only. It is not implemented yet.
 - [Customer-support triage workload spec](workloads/customer-support-triage.md)
 - [Good first issue candidates](good_first_issues.md)
 
+Local setup prerequisites:
+
+- Python 3.11 or newer is required.
+- Python 3.13 is recommended for local development because it matches the current CI test environment.
+- KORA uses `pyproject.toml`-based packaging.
+- Upgrade `pip`, `setuptools`, and `wheel` before editable install.
+
+Clean local setup:
+
+```bash
+python3 --version
+
+rm -rf .venv
+python3 -m venv .venv
+source .venv/bin/activate
+
+python3 -m pip install --upgrade pip setuptools wheel
+python3 -m pip install -e ".[dev]"
+```
+
 Core local commands:
 
 ```bash
@@ -77,6 +97,19 @@ Runnable examples
 
 Some example command names are compatibility-preserving. The local validation examples emit public-facing `local_validation` provider labels.
 Use `--report-md /tmp/kora_validation.md` with local validation examples to generate reviewer-facing Markdown reports from aggregate counters.
+
+Local setup troubleshooting:
+
+- `TypeError: unsupported operand type(s) for |: 'ModelMetaclass' and 'ModelMetaclass'` usually indicates a local Python, virtual environment, or dependency compatibility problem. Confirm Python is 3.11 or newer, recreate `.venv`, upgrade `pip setuptools wheel`, and reinstall with `python3 -m pip install -e ".[dev]"`.
+- Editable install errors mentioning a missing `setup.py` or `setup.cfg` despite `pyproject.toml` existing usually indicate stale local build tooling. Upgrade `pip`, `setuptools`, and `wheel` inside the activated virtual environment.
+
+Useful diagnostics:
+
+```bash
+python3 --version
+python3 -m pip --version
+python3 -m pip show pydantic
+```
 
 ## Inspect Evidence
 


### PR DESCRIPTION
## Summary
- Adds explicit Python prerequisites for local setup: Python 3.11+ required and Python 3.13 recommended to match CI.
- Updates first-run setup commands to recreate `.venv` and upgrade `pip`, `setuptools`, and `wheel` before editable install.
- Adds troubleshooting guidance for the Pydantic union type error and the `setup.py`/`setup.cfg` editable install error when `pyproject.toml` exists.

## Scope
- Docs-only change: `README.md`, `CONTRIBUTING.md`, and `docs/README.md`.
- No package behavior, benchmark behavior, or runtime claims changed.

## Validation
- `git diff --check`: passed
- `python3 -m pytest`: 159 passed
- Targeted internal/private path scan: clean except existing non-claim language
- Unicode scan: no hidden/control/bidi characters and no non-ASCII punctuation