### PR TITLE
docs: clarify local setup troubleshooting

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,15 +38,46 @@ Good contributors are interested in:
 
 ## Local setup
 
+### Prerequisites
+
+KORA uses `pyproject.toml`-based Python packaging.
+
+- Packaged support: Python 3.11 or newer, as declared in `pyproject.toml`.
+- Observed local result: Python 3.9.6 has been confirmed to run the offline `direct_vs_kora` example in one user environment.
+- Treat Python 3.9.6 as an observed troubleshooting datapoint, not as the advertised package support floor until clean Python 3.9 compatibility testing is completed.
+- Check the active terminal interpreter with `python3 --version`.
+- VS Code's selected interpreter may differ from terminal `python3`; use the intended `.venv` in both places when debugging.
+- Upgrade `pip`, `setuptools`, and `wheel` before editable install.
+
+Check your local tools before installing:
+
+```bash
+python3 --version
+python3 -m pip --version
+which python3
+```
+
 Start from a clean checkout of the repository.
 
 ```bash
+python3 --version
+
+rm -rf .venv
 python3 -m venv .venv
 source .venv/bin/activate
+
+python3 -m pip install --upgrade pip setuptools wheel
 python3 -m pip install -e ".[dev]"
 ```
 
-If editable install reports that `setup.py`, `setup.cfg`, or install metadata is missing, verify that your checkout is current:
+Run the first local examples:
+
+```bash
+python3 -m kora run hello_kora -- --offline
+python3 -m kora run direct_vs_kora -- --offline
+```
+
+If editable install reports that `setup.py`, `setup.cfg`, or install metadata is missing, first verify that your checkout is current:
 
 ```bash
 git remote -v
@@ -59,6 +90,34 @@ ls pyproject.toml
 If `pyproject.toml` is still missing after pulling, re-clone from `https://github.com/Krako-Labs/KORA.git`.
 
 The editable install should install KORA and its development dependencies into the virtual environment.
+
+### Local setup troubleshooting
+
+For first-run failures after a system restart, Python upgrade, VS Code interpreter change, or virtual environment change, capture the local environment first:
+
+```bash
+python3 --version
+python3 -m pip --version
+python3 -m pip show pydantic
+which python3
+```
+
+If `python3 -m kora run direct_vs_kora -- --offline` fails with:
+
+```text
+TypeError: unsupported operand type(s) for |: 'ModelMetaclass' and 'ModelMetaclass'
+```
+
+that usually indicates a local Python, virtual environment, `pip`, `setuptools`, or dependency compatibility problem. Python 3.9.6 has been observed to work with the offline `direct_vs_kora` example in one user environment, but packaged support is currently Python 3.11 or newer. Rebuild the virtual environment using the clean setup block above before drawing a Python-version conclusion.
+
+If editable install says `setup.py` or `setup.cfg` is missing even though `pyproject.toml` exists, upgrade local build tooling inside the activated virtual environment:
+
+```bash
+python3 -m pip install --upgrade pip setuptools wheel
+python3 -m pip install -e ".[dev]"
+```
+
+If VS Code fails while Terminal works, select the repository `.venv` interpreter in VS Code and confirm the VS Code terminal reports the same `which python3` and `python3 --version` values as your working shell.
 
 ## First verification commands
 

--- a/README.md
+++ b/README.md
@@ -26,17 +26,41 @@ request -> task graph -> deterministic path -> validation -> model escalation ->
 
 Structure first. Inference second.
 
+## Prerequisites
+
+KORA uses `pyproject.toml`-based Python packaging.
+
+- Packaged support: Python 3.11 or newer, as declared in `pyproject.toml`.
+- Observed local result: Python 3.9.6 has been confirmed to run the offline `direct_vs_kora` example in one user environment.
+- Treat Python 3.9.6 as an observed troubleshooting datapoint, not as the advertised package support floor until clean Python 3.9 compatibility testing is completed.
+- Before making Python-version compatibility assumptions, check the active interpreter with `python3 --version`.
+- VS Code's selected interpreter may differ from terminal `python3`; make sure both point to the intended environment when debugging setup issues.
+- Upgrade `pip`, `setuptools`, and `wheel` before editable install so local tooling understands modern `pyproject.toml` builds.
+
+Check your local tools first:
+
+```bash
+python3 --version
+python3 -m pip --version
+which python3
+```
+
 ## 3-Minute Local Run
 
 For local development in this repository:
 
 ```bash
+python3 --version
+
+rm -rf .venv
 python3 -m venv .venv
 source .venv/bin/activate
+
+python3 -m pip install --upgrade pip setuptools wheel
 python3 -m pip install -e ".[dev]"
 ```
 
-If editable install reports that `setup.py`, `setup.cfg`, or install metadata is missing, verify that your checkout is current:
+If editable install reports that `setup.py`, `setup.cfg`, or install metadata is missing, first verify that your checkout is current:
 
 ```bash
 git remote -v
@@ -53,10 +77,61 @@ Run the CLI and first offline demo:
 ```bash
 python3 -m kora --help
 python3 -m kora examples list
+python3 -m kora run hello_kora -- --offline
 python3 -m kora run direct_vs_kora -- --offline
 ```
 
 Inspect the output to see how KORA changes a direct model-first path into a controlled execution path.
+
+## Local Setup Troubleshooting
+
+If first-run setup fails after a system restart, Python upgrade, VS Code interpreter change, or virtual environment change, start by collecting the active environment:
+
+```bash
+python3 --version
+python3 -m pip --version
+python3 -m pip show pydantic
+which python3
+```
+
+### `TypeError: unsupported operand type(s) for |: 'ModelMetaclass' and 'ModelMetaclass'`
+
+This usually indicates a local Python, virtual environment, `pip`, `setuptools`, or dependency compatibility problem. Python 3.9.6 has been observed to run the offline `direct_vs_kora` example in one user environment, but packaged support is currently Python 3.11 or newer. First rebuild the local environment with current build tooling:
+
+```bash
+rm -rf .venv
+python3 -m venv .venv
+source .venv/bin/activate
+
+python3 -m pip install --upgrade pip setuptools wheel
+python3 -m pip install -e ".[dev]"
+python3 -m kora run hello_kora -- --offline
+python3 -m kora run direct_vs_kora -- --offline
+```
+
+Do not assume this error means a newer Python version is unsupported. Test Python 3.9, 3.10, 3.11, or 3.12 in clean environments before changing the package support floor.
+
+### Editable install says `setup.py` or `setup.cfg` is missing
+
+KORA uses `pyproject.toml`-based packaging, so a missing `setup.py` or `setup.cfg` message usually means the local `pip`/build tooling is too old or the virtual environment is stale. Confirm `pyproject.toml` exists, upgrade build tooling, then reinstall:
+
+```bash
+ls pyproject.toml
+python3 -m pip install --upgrade pip setuptools wheel
+python3 -m pip install -e ".[dev]"
+```
+
+### VS Code interpreter differs from terminal `python3`
+
+If KORA works in Terminal but fails in VS Code, compare the selected VS Code interpreter against terminal `python3`:
+
+```bash
+which python3
+python3 --version
+python3 -m pip --version
+```
+
+Select the repository `.venv` interpreter in VS Code, then reopen the terminal or restart the Python language server before rerunning the examples.
 
 ## What KORA Does
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -54,6 +54,31 @@ KORA Studio is future planning only. It is not implemented yet.
 - [Customer-support triage workload spec](workloads/customer-support-triage.md)
 - [Good first issue candidates](good_first_issues.md)
 
+Local setup prerequisites:
+
+- Packaged support is Python 3.11 or newer, as declared in `pyproject.toml`.
+- Python 3.9.6 has been observed to run the offline `direct_vs_kora` example in one user environment.
+- Treat Python 3.9.6 as a troubleshooting datapoint, not as the advertised package support floor until clean Python 3.9 compatibility testing is completed.
+- KORA uses `pyproject.toml`-based packaging.
+- Upgrade `pip`, `setuptools`, and `wheel` before editable install.
+- VS Code's selected interpreter may differ from terminal `python3`; use the intended `.venv` in both places.
+
+Clean local setup:
+
+```bash
+python3 --version
+
+rm -rf .venv
+python3 -m venv .venv
+source .venv/bin/activate
+
+python3 -m pip install --upgrade pip setuptools wheel
+python3 -m pip install -e ".[dev]"
+
+python3 -m kora run hello_kora -- --offline
+python3 -m kora run direct_vs_kora -- --offline
+```
+
 Core local commands:
 
 ```bash
@@ -77,6 +102,21 @@ Runnable examples
 
 Some example command names are compatibility-preserving. The local validation examples emit public-facing `local_validation` provider labels.
 Use `--report-md /tmp/kora_validation.md` with local validation examples to generate reviewer-facing Markdown reports from aggregate counters.
+
+Local setup troubleshooting:
+
+- `TypeError: unsupported operand type(s) for |: 'ModelMetaclass' and 'ModelMetaclass'` usually indicates a local Python, virtual environment, `pip`, `setuptools`, or dependency compatibility problem. Recreate `.venv`, upgrade `pip setuptools wheel`, and reinstall with `python3 -m pip install -e ".[dev]"`.
+- Editable install errors mentioning a missing `setup.py` or `setup.cfg` despite `pyproject.toml` existing usually indicate stale local build tooling. Upgrade `pip`, `setuptools`, and `wheel` inside the activated virtual environment.
+- If VS Code fails while Terminal works, select the repository `.venv` interpreter in VS Code and confirm VS Code is using the same Python as your working terminal.
+
+Useful diagnostics:
+
+```bash
+python3 --version
+python3 -m pip --version
+python3 -m pip show pydantic
+which python3
+```
 
 ## Inspect Evidence
 


### PR DESCRIPTION
## Summary
- Adds setup prerequisites and clean first-run commands for `.venv` recreation, build-tool upgrades, editable install, and offline smoke examples.
- Documents the observed Python 3.9.6 user success as a troubleshooting datapoint without lowering package metadata below the current supported floor.
- Keeps `pyproject.toml` at `requires-python = ">=3.11"` after compatibility review found current Python 3.10+ typing constructs in runtime/example code.
- Adds troubleshooting for the `ModelMetaclass` union TypeError, stale editable-install tooling, and VS Code interpreter mismatch.

## Compatibility review
- Current code contains Python 3.10+ typing syntax/runtime constructs, including evaluated `|` unions in task IR aliases and `isinstance(value, int | float)` in an example.
- Python 3.9 and 3.10 were not available locally for smoke testing.
- A clean Python 3.11 temporary venv install and offline smoke passed under `/tmp`.

## Validation
- `git diff --check`: passed
- `python3 -m pytest`: 159 passed on Python 3.13.5
- `python3 -m kora run hello_kora -- --offline`: passed on Python 3.13.5
- `python3 -m kora run direct_vs_kora -- --offline`: passed on Python 3.13.5
- Python 3.11 temporary venv: editable install passed; `hello_kora` and `direct_vs_kora --offline` passed
- Targeted internal/private path scan: clean except existing non-claim language
- Unicode scan: no hidden/control/bidi characters and no non-ASCII punctuation

## Scope
- Docs-only final diff: `README.md`, `CONTRIBUTING.md`, and `docs/README.md`.
- No runtime behavior, benchmark behavior, or production/cost/performance claims changed.