### PR TITLE
docs: add contributor branch and PR workflow

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -12,11 +12,17 @@ Briefly describe the problem.
 
 ## How to reproduce
 
-Steps or command:
+Exact command or screen flow:
 
 ```bash
 
 ```
+
+Steps:
+
+1.
+2.
+3.
 
 Does this affect one or more of these areas?
 
@@ -24,6 +30,7 @@ Does this affect one or more of these areas?
 - [ ] Example
 - [ ] Benchmark / evidence
 - [ ] Documentation
+- [ ] Browser / local UI
 - [ ] Other
 
 ## Expected behavior
@@ -39,8 +46,16 @@ What happened instead?
 - KORA version or commit:
 - Python version:
 - Operating system:
+- Browser and version, if applicable:
+- Runtime, local server, or editor, if applicable:
 - Did `./scripts/release_smoke.sh` pass?
 - Did `python3 -m pytest -q` pass?
+
+## Evidence
+
+- Screenshot or screen recording, if useful and safe to share:
+- Terminal logs or traceback excerpt:
+- Last command or action before the failure:
 
 ## Notes
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -174,11 +174,57 @@ If you are unsure whether a change expands the public surface, open an issue or 
 
 ## Branch and PR workflow
 
-Use a short topic branch name:
+Do not push directly to `main`. Start each change from the latest `main`, create a topic branch, push that branch, and open a pull request into `main`.
+
+Start from latest `main`:
 
 ```bash
-git switch -c your-name/small-description
+git checkout main
+git pull origin main
 ```
+
+Create your branch:
+
+```bash
+git checkout -b <type>/<short-description>
+```
+
+Recommended branch name prefixes:
+
+- `feature/` for a new capability or example
+- `fix/` for a bug fix
+- `docs/` for documentation-only changes
+- `test/` for tests or test fixtures
+- `chore/` for maintenance that does not change behavior
+
+Good branch names:
+
+- `fix/login-screen-freeze`
+- `docs/python-setup-guide`
+- `test/offline-runner-smoke`
+- `feature/dev-error-reporting`
+
+Check your changes before committing:
+
+```bash
+git status
+git diff
+```
+
+Commit with a short imperative summary:
+
+```bash
+git add .
+git commit -m "Short imperative summary"
+```
+
+Push your branch:
+
+```bash
+git push -u origin <branch-name>
+```
+
+Then open a pull request on GitHub from your branch into `main`.
 
 Keep pull requests focused. A good PR should explain:
 
@@ -188,6 +234,24 @@ Keep pull requests focused. A good PR should explain:
 - what verification commands were run
 
 Prefer one logical change per PR. Do not bundle documentation cleanup, runtime edits, and unrelated formatting in the same pull request.
+
+## Reproducible bug reports
+
+Before attempting a code fix for a support-channel report, capture enough detail for another contributor to reproduce the problem. For example, a report like "login screen appears but code is not accepted" should become a concrete bug report before implementation starts.
+
+Include:
+
+- exact command or screen flow
+- operating system and version
+- Python version, if Python is involved
+- browser or runtime, if a browser or local UI is involved
+- screenshot or screen recording, if useful and safe to share
+- terminal logs or traceback excerpts
+- steps to reproduce
+- expected result
+- actual result
+
+Do not include secrets, tokens, private data, private paths, or sensitive security details in public issues. Use [SECURITY.md](SECURITY.md) for sensitive security reports.
 
 ## Verification expectations
 

--- a/README.md
+++ b/README.md
@@ -240,6 +240,10 @@ Useful entry points:
 - [Community manager guide](docs/community/KORA_COMMUNITY_MANAGER_GUIDE.md)
 - [Contributing guide](CONTRIBUTING.md)
 
+For branch naming, pushing your work, and opening a pull request into `main`, see the [branch and PR workflow](CONTRIBUTING.md#branch-and-pr-workflow).
+
+For support-channel problems or bugs, start with a reproducible report using the [bug report template](.github/ISSUE_TEMPLATE/bug_report.md) before attempting a code change.
+
 ## Install
 
 Target package install path:

--- a/docs/README.md
+++ b/docs/README.md
@@ -203,6 +203,8 @@ Good candidate workloads:
 
 - [Canonical governance document](../GOVERNANCE.md)
 - [Contributing guide](../CONTRIBUTING.md)
+- [Branch and PR workflow](../CONTRIBUTING.md#branch-and-pr-workflow)
+- [Bug report template](../.github/ISSUE_TEMPLATE/bug_report.md)
 - [Contact and discussion routes](community/contact-and-discussion-routes.md)
 - [Contributor pathway](community/contributor-pathway.md)
 - [Good first issue candidates](community/good-first-issue-candidates.md)


### PR DESCRIPTION
## Summary
- Expands `CONTRIBUTING.md` with a step-by-step branch, commit, push, and pull request workflow into `main`.
- Adds recommended branch prefixes and example branch names for new contributors.
- Adds a reproducible bug-report checklist for support-channel reports before code changes are attempted.
- Tightens the bug report issue template with screen flow, reproduction steps, browser/runtime context, screenshots, logs, and last action before failure.
- Adds lightweight links from `README.md` and `docs/README.md` to the contributor workflow and bug report template.

## Validation
- `git diff --check`: passed
- `python3 -m pytest`: 159 passed
- Internal/private path scan: clean except existing non-claim checklist language
- Unicode scan: no hidden/control/bidi characters and no non-ASCII punctuation

## Scope
- Docs/templates only.
- No runtime behavior, benchmark behavior, performance, production, or cost claims changed.
- No merge performed by request.