### PR TITLE
docs: clarify paper word figure placeholder status

### DIFF
--- a/docs/paper/kora-first-paper-figure-redesign-note-v0-1.md
+++ b/docs/paper/kora-first-paper-figure-redesign-note-v0-1.md
@@ -68,8 +68,8 @@ Claim boundary:
 
 ## Status
 
-The redesigned figures were reviewed in the Word draft and are not accepted for publication use because the inserted figure arrows did not render correctly. They are superseded by placeholders for Word review:
+The redesigned figures were reviewed in the Word draft and are not accepted for publication use because inserted arrows and diagram elements did not render reliably. They are superseded by placeholders for Word-first manuscript text review:
 
 - `docs/paper/kora-first-paper-word-placeholder-review-v0-1.md`
 
-Final publication-quality figures must be recreated after manuscript-body finalization. No generated image binaries were committed. The paper remains not submission-ready.
+The current figure outputs are placeholders only and should not be treated as publication-ready. Final publication-quality figures must be rebuilt separately after manuscript-body review is complete and the body text is stable. No generated image binaries were committed. PDF/arXiv export remains paused until the text and final figures are ready. The paper remains not submission-ready.

--- a/docs/paper/kora-first-paper-final-human-review-packet-v0-1.md
+++ b/docs/paper/kora-first-paper-final-human-review-packet-v0-1.md
@@ -67,8 +67,10 @@ This packet lists the human decisions still required before any submission-ready
 - Review the image-inserted Word draft before resuming PDF/arXiv source-package work.
 - Review redesigned Figure 1 and Figure 2 for readability, style, and claim boundaries.
 - Decide whether the redesigned figures should become the basis for publication figures.
-- Use the placeholder Word draft for manuscript-body review because the image-inserted figures had broken arrows.
-- Defer final Figure 1 and Figure 2 creation until after manuscript-body review.
+- Use the placeholder Word draft for manuscript-body review because the image-inserted figures had unreliable arrows and diagram elements.
+- Treat current Figure 1 and Figure 2 content as placeholders only, not publication-ready figures.
+- Defer final Figure 1 and Figure 2 rebuilding until after manuscript-body review is complete and the body text is stable.
+- Keep PDF/arXiv export paused until both manuscript text and final figures are ready.
 
 ## Venue and Export Decisions
 

--- a/docs/paper/kora-first-paper-submission-candidate-status-v0-1.md
+++ b/docs/paper/kora-first-paper-submission-candidate-status-v0-1.md
@@ -151,11 +151,11 @@ Local-only Word drafts and redesigned Figure 1/Figure 2 PNG/SVG assets were gene
 
 ## Word Figure Placeholder Pass
 
-The image-inserted Word draft is superseded for review because human review found broken arrows in the inserted figure images. Word-first review now continues with placeholders:
+The image-inserted Word draft is superseded for review because human review found that inserted figure arrows and diagram elements did not render reliably. Word-first manuscript text review now continues with placeholders:
 
 - `docs/paper/kora-first-paper-word-placeholder-review-v0-1.md`
 
-Figure 1 and Figure 2 finalization is deferred until after manuscript-body review. No generated DOCX, PDF, image, source package, binary output, or local working Markdown was committed.
+Figure 1 and Figure 2 are placeholders only. Current figure rendering should not be treated as publication-ready. Final publication-quality figures must be rebuilt separately after manuscript-body review is complete and the body text is stable. No generated DOCX, PDF, image, source package, binary output, or local working Markdown was committed.
 
 ## Submission Package Packet
 
@@ -170,4 +170,4 @@ These files organize package blockers, human review decisions, reproduction tran
 
 ## Status
 
-The manuscript has advanced to v0.5 submission-candidate draft status. Full BibTeX remains incomplete, Word-first human review is now the active route with figure placeholders, and final visual review, figure creation, layout cleanup, bibliography formatting, source-package hygiene, and human review remain pending. The paper remains not submission-ready.
+The manuscript has advanced to v0.5 submission-candidate draft status. Full BibTeX remains incomplete, Word-first human review is now the active route with Figure 1 and Figure 2 placeholders, and final visual review, figure rebuilding, layout cleanup, bibliography formatting, source-package hygiene, and human review remain pending. PDF/arXiv export remains paused until both manuscript text and final figures are ready. The paper remains not submission-ready.

--- a/docs/paper/kora-first-paper-submission-package-readiness-v0-1.md
+++ b/docs/paper/kora-first-paper-submission-package-readiness-v0-1.md
@@ -129,8 +129,8 @@ Local-only Word drafts and redesigned figure assets were generated outside the r
 
 ## Word Placeholder Review Status
 
-The image-inserted Word draft is superseded for review because the inserted figure arrows did not render correctly. The active Word review draft uses placeholders for Figure 1 and Figure 2:
+The image-inserted Word draft is superseded for review because the inserted figure arrows and diagram elements did not render reliably. The active Word review draft uses placeholders for Figure 1 and Figure 2:
 
 - `docs/paper/kora-first-paper-word-placeholder-review-v0-1.md`
 
-PDF generation remains paused. Final publication-quality figure creation is deferred until after manuscript-body review.
+Figure 1 and Figure 2 are placeholders only and should not be treated as publication-ready. Word-first manuscript text review remains the priority. Final publication-quality figures should be rebuilt separately after manuscript-body review is complete and the body text is stable. PDF/arXiv export remains paused until both text and final figures are ready.

--- a/docs/paper/kora-first-paper-word-placeholder-review-v0-1.md
+++ b/docs/paper/kora-first-paper-word-placeholder-review-v0-1.md
@@ -47,16 +47,16 @@ Figure 2 placeholder:
 
 ## Reason for Switching to Placeholders
 
-Human review found that arrows in the inserted figure images were broken. The current figure images are not being forced into the Word draft. The goal is to keep manuscript-body review moving while deferring final figure creation.
+Human review found that arrows and diagram elements in the inserted figure images did not render reliably in the generated Word draft. The current figure images are not being forced into the Word draft and must not be treated as publication-ready. The goal is to keep manuscript-body review moving while deferring final figure creation until the manuscript body is stable.
 
 ## Figure Status
 
 | Figure | Current status | Next action |
 |---|---|---|
-| Figure 1: KORA execution-control architecture | deferred | Recreate publication-quality figure after manuscript body finalization |
-| Figure 2: direct baseline vs KORA-controlled deterministic-heavy benchmark flow | deferred | Recreate publication-quality figure after manuscript body finalization |
+| Figure 1: KORA execution-control architecture | placeholder only | Rebuild a publication-quality figure after manuscript body review is complete |
+| Figure 2: direct baseline vs KORA-controlled deterministic-heavy benchmark flow | placeholder only | Rebuild a publication-quality figure after manuscript body review is complete |
 
-Previous redesigned figures are not accepted for publication use. They are superseded by placeholders for Word review.
+Previous redesigned figures are not accepted for publication use. They are superseded by placeholders for Word review. Final figures should be rebuilt separately after the manuscript body is stable and then inserted in a later figure-finalization pass.
 
 ## Verification
 
@@ -70,9 +70,10 @@ Previous redesigned figures are not accepted for publication use. They are super
 
 - Review manuscript body using the placeholder Word draft.
 - Review Table 1, Table 2, Algorithm 1, and Appendix Table A1 in Word.
-- Finalize publication-quality figures only after manuscript-body review.
-- Resume PDF/arXiv source-package work only after Word review and figure decisions are complete.
+- Rebuild publication-quality Figure 1 and Figure 2 only after manuscript-body review is complete.
+- Insert final publication-ready figures in a later pass after the figure redesign is stable.
+- Resume PDF/arXiv source-package work only after Word text review and final figure decisions are complete.
 
 ## Status
 
-Word-first review continues with placeholders. Figure insertion is not complete. Final figure creation is deferred. The paper remains not submission-ready.
+Word-first manuscript text review continues with placeholders. Figure insertion is not complete, and current figure rendering should not be treated as publication-ready. Final figure creation is deferred until after the manuscript body is stable. PDF/arXiv export remains paused. The paper remains not submission-ready.


### PR DESCRIPTION
## Summary
- Clarifies that current Word draft Figure 1 and Figure 2 are placeholders only.
- Records that arrows and diagram elements did not render reliably in the generated Word draft.
- Keeps Word-first manuscript text review as the active priority.
- Records that final publication-quality figures should be rebuilt separately after manuscript body review is complete.
- Keeps PDF/arXiv export paused until both text and final figures are ready.

## Scope
- Paper Track docs only.
- No runtime code changed.
- No benchmark behavior changed.
- No production, cost-reduction, performance, or benchmark claims added.
- No private/internal workflow details added.

## Validation
- `git diff --check`: passed
- `python3 -m pytest`: 159 passed
- Unicode scan: no hidden/control/bidi characters and no non-ASCII punctuation
- Public-safety scan: no private/internal workflow details found; only expected placeholder status and existing non-claim text matched