### PR TITLE
docs: review v0.9 paper draft figures

### DIFF
--- a/docs/paper/kora-first-paper-submission-candidate-status-v0-1.md
+++ b/docs/paper/kora-first-paper-submission-candidate-status-v0-1.md
@@ -125,6 +125,14 @@ The draft figure note now exists:
 
 The draft assets follow the v0.9 figure rebuild specification and are not final publication figures. Current manuscript placeholders should not yet be treated as final publication layout. No Word, PDF, arXiv, archive, or manuscript export artifact was generated. Final manuscript integration and export review remain pending.
 
+## Manuscript v0.9 Figure Asset Review Note
+
+The manuscript v0.9 figure asset review note now exists:
+
+- `docs/paper/kora-first-paper-v0-9-figure-asset-review-note.md`
+
+The review records that draft Figure 1 and Figure 2 match the manuscript purpose and merged rebuild specification, use readable simple-box and straight-connector structure, preserve visual non-claims, and are suitable for later human visual review and insertion testing. It also records that manuscript placeholders remain, final publication layout is not approved, and Word/PDF/arXiv/export work remains paused.
+
 ## What Was Synchronized
 
 - Manuscript citations were compared against preliminary BibTeX v0.1.
@@ -281,4 +289,4 @@ These files organize package blockers, human review decisions, reproduction tran
 
 ## Status
 
-The manuscript has advanced to v0.9 Word-first working draft status. Full BibTeX remains incomplete, Word-first human review is still the active route with Figure 1 and Figure 2 placeholders, and final visual review, figure rebuilding, layout cleanup, bibliography formatting, source-package hygiene, and human review remain pending. v0.9 applies only the v0.9 working-inclusion items from the v0.8 source-verification decision note while keeping manual/external verification, final-packaging/export deferrals, keep-excluded/do-not-add records, final citation style conversion, bibliography finalization, and export work out of scope. The v0.7 citation and bibliography readiness review, v0.7 citation cleanup action plan, v0.8 citation cleanup delta, v0.8 source-verification packet, v0.8 source-verification decision note, v0.9 working delta, v0.9 figure rebuild specification, and v0.9 draft figure assets are complete, but final bibliography scope, final citation style conversion, source verification execution, final manuscript-to-final-BibTeX synchronization, final figure approval, figure insertion review, and export checks remain pending. PDF/arXiv export remains paused until manuscript text, final figures, and bibliography/export package blockers are resolved. The paper remains not submission-ready.
+The manuscript has advanced to v0.9 Word-first working draft status. Full BibTeX remains incomplete, Word-first human review is still the active route with Figure 1 and Figure 2 placeholders, and final visual review, figure rebuilding, layout cleanup, bibliography formatting, source-package hygiene, and human review remain pending. v0.9 applies only the v0.9 working-inclusion items from the v0.8 source-verification decision note while keeping manual/external verification, final-packaging/export deferrals, keep-excluded/do-not-add records, final citation style conversion, bibliography finalization, and export work out of scope. The v0.7 citation and bibliography readiness review, v0.7 citation cleanup action plan, v0.8 citation cleanup delta, v0.8 source-verification packet, v0.8 source-verification decision note, v0.9 working delta, v0.9 figure rebuild specification, v0.9 draft figure assets, and v0.9 figure asset review note are complete, but final bibliography scope, final citation style conversion, source verification execution, final manuscript-to-final-BibTeX synchronization, final figure approval, figure insertion review, and export checks remain pending. PDF/arXiv export remains paused until manuscript text, final figures, and bibliography/export package blockers are resolved. The paper remains not submission-ready.

--- a/docs/paper/kora-first-paper-v0-9-figure-asset-review-note.md
+++ b/docs/paper/kora-first-paper-v0-9-figure-asset-review-note.md
@@ -1,0 +1,59 @@
+# KORA First Paper v0.9 Figure Asset Review Note
+
+Status date: 2026-05-20
+
+## Scope
+
+This note reviews the draft Figure 1 and Figure 2 assets created for the manuscript v0.9 working draft. It does not modify manuscript text, regenerate figure assets, or create Word, PDF, arXiv, archive, or manuscript export artifacts.
+
+Reviewed sources:
+
+- `docs/paper/kora-first-paper-manuscript-v0-9.md`
+- `docs/paper/kora-first-paper-v0-9-figure-rebuild-specification.md`
+- `docs/paper/kora-first-paper-v0-9-figure-draft-note.md`
+- `docs/assets/paper/kora-first-paper-figure-1-v0-9-draft.svg`
+- `docs/assets/paper/kora-first-paper-figure-1-v0-9-draft.png`
+- `docs/assets/paper/kora-first-paper-figure-2-v0-9-draft.svg`
+- `docs/assets/paper/kora-first-paper-figure-2-v0-9-draft.png`
+
+## Figure 1 Review
+
+Figure 1 matches the manuscript purpose: it presents KORA as an execution-control layer between an application request and model invocation. The draft visual separates request intake, task/path analysis, deterministic or structured execution, validation, model-candidate escalation, output, and telemetry. That structure supports the manuscript's category framing without claiming that KORA is a production deployment result or a replacement for all model calls.
+
+The labels are likely sufficient for draft review. They identify the execution-control layer, deterministic/task-graph path, validation/output path, model-candidate route, and telemetry path. The caption requirement is also supportable because the figure can be described as an architecture/control-flow diagram rather than a performance or deployment result.
+
+The visual structure is suitable for later Word/PDF insertion testing. It uses simple boxes and straight connectors instead of fragile generated diagram arrows. The SVG source remains editable, and the flattened PNG rendering provides a stable fallback for document insertion.
+
+Recommended next action: keep Figure 1 as the current draft asset for human visual review and later insertion testing. Before final manuscript integration, verify that the connector labels and telemetry path remain readable at the actual Word/PDF figure size. No immediate redraw is required unless human reviewers request layout or emphasis changes.
+
+## Figure 2 Review
+
+Figure 2 matches the manuscript purpose: it compares the naive direct baseline against KORA-controlled execution for the approved deterministic-heavy benchmark boundary. The draft visual keeps the benchmark scope explicit by using the 100-task workload, the 100 simulated model invocation baseline, the 80 deterministic/no-model completions, and the 20 model-candidate paths.
+
+The labels are likely sufficient for draft review. The figure communicates the approved claim boundary without broadening it beyond the reproducible deterministic-heavy benchmark. The caption can safely state that the result is limited to simulated model invocations in the benchmark workload.
+
+The visual structure is suitable for later Word/PDF insertion testing. It uses a side-by-side baseline/control comparison with simple boxes, straight connectors, and a flattened PNG fallback. This avoids relying on Mermaid-style or Word-generated connector behavior.
+
+Recommended next action: keep Figure 2 as the current draft asset for human visual review and later insertion testing. Before final manuscript integration, confirm that the benchmark boundary statement remains legible at target figure size and that the visual emphasis does not make the result look like production-cost evidence.
+
+## Visual Claim Boundary
+
+The draft figures preserve the current claim boundary. They should continue to avoid visually implying:
+
+- production deployment evidence
+- real API-cost reduction proof
+- production benchmark proof
+- broad workload superiority
+- energy reduction proof
+- formal external validation
+- signed partner validation
+- guaranteed adoption or funding
+- benchmark results beyond the approved deterministic-heavy benchmark boundary
+
+Figure 2 may continue to show the approved benchmark result only within this boundary: in a reproducible 100-task deterministic-heavy benchmark workload, KORA-controlled execution avoided 80 of 100 simulated model invocations versus a naive direct baseline.
+
+## Readiness Decision
+
+The draft Figure 1 and Figure 2 assets are ready for a later human visual review and insertion trial. They should not yet be treated as final publication figures or final manuscript layout.
+
+No figure revision pass is required before an insertion test unless a human reviewer requests design changes. Final figure approval, manuscript insertion, Word/PDF readability checks, and export packaging remain pending.


### PR DESCRIPTION
## Summary
- add a public-safe review note for the manuscript v0.9 draft Figure 1 and Figure 2 assets
- record that the draft assets match manuscript purpose, preserve visual non-claims, and are suitable for later human visual review/insertion testing
- update the submission-candidate status document to link the new review note

## Validation
- git diff --check
- git diff --cached --check
- python3 -m pytest (159 passed)
- SVG/XML parse passed for both draft SVG assets
- PNG verification passed for both draft PNG assets; both are 2200x1200 RGB
- private/local path scan in docs/assets/paper clean
- Unicode/control scan clean
- generated artifact scan clean

## Scope confirmations
- manuscript v0.9 text was not modified
- figure SVG/PNG assets were not regenerated or edited
- no Word/PDF/arXiv/archive/export artifacts were generated
- no private/internal workflow details were added
- claim boundaries and visual non-claims remain safe