### PR TITLE
docs: add local server troubleshooting section

### DIFF
--- a/docs/kora-studio/README.md
+++ b/docs/kora-studio/README.md
@@ -109,6 +109,15 @@ python3 scripts/check_kora_studio_preview.py
 ```
 
 The smoke check only accepts `http://127.0.0.1` or `http://localhost` URLs. It checks `/health`, `/status`, and `/` without starting external services, calling providers, downloading models, executing models, scanning private model directories, or running runtime model list commands.
+## Local Server Troubleshooting
+
+If you encounter issues launching the local KORA Studio server, try the following steps:
+
+- Confirm the CLI is available by running `python3 -m kora studio --help`.
+- Start the server without opening a browser automatically by running `python3 -m kora studio --no-browser`.
+- The default local URL is `http://127.0.0.1:8765/`.
+- If port `8765` is busy, you can use another local port. For example: `python3 -m kora studio --no-browser --port 8766`.
+- Note: This preview is localhost-only and does not call providers, download models, run models, enable cloud sync, or require API keys.
 
 ## Local Server Skeleton
 

--- a/docs/kora-studio/README.md
+++ b/docs/kora-studio/README.md
@@ -109,6 +109,7 @@ python3 scripts/check_kora_studio_preview.py
 ```
 
 The smoke check only accepts `http://127.0.0.1` or `http://localhost` URLs. It checks `/health`, `/status`, and `/` without starting external services, calling providers, downloading models, executing models, scanning private model directories, or running runtime model list commands.
+
 ## Local Server Troubleshooting
 
 If you encounter issues launching the local KORA Studio server, try the following steps:


### PR DESCRIPTION
## Summary

Added a "Local Server Troubleshooting" section to the KORA Studio README, as requested in #212. This keeps the guidance local-only and avoids making unsupported claims.

## Type of change

- [x] Docs only
- [ ] CLI / example
- [ ] Benchmark / evidence
- [ ] Code / tests
- [ ] Security-sensitive

## Verification

- [x] Validation commands were run or marked not applicable.
- [x] Claim hygiene checked.
- [x] No unsupported production, API-cost, benchmark, broad workload, or energy claims added.
- [x] No raw benchmark JSON artifacts committed.
- [x] No local absolute paths introduced.
- [x] No release, tag, package-version, or release-asset changes unless explicitly approved.

List commands run and results:

```text
main@fedora:~/Open-Source/KORA$ python3 -m kora studio --help
usage: kora.cli studio [-h] [--status] [--no-browser] [--open-browser] [--serve] [--host HOST] [--port PORT]

Launch the localhost-only KORA Studio preview server and open the local browser UI by default. Use --status to print planning/preview status only.

options:
  -h, --help      show this help message and exit
  --status        show planning/preview status
  --no-browser    start the local server without opening a browser
  --open-browser  open the default browser; this is already the default
  --serve         start the local-only Studio server; preserved for compatibility
  --host HOST     local host for Studio server (default: 127.0.0.1)
  --port PORT     local port for Studio server (default: 8765)

main@fedora:~/Open-Source/KORA$ git diff --check
main@fedora:~/Open-Source/KORA$ 

```

Useful references: [CONTRIBUTING.md](https://www.google.com/search?q=../CONTRIBUTING.md), [SECURITY.md](https://www.google.com/search?q=../SECURITY.md), [experiments/README.md](https://www.google.com/search?q=../experiments/README.md), and [docs/README.md](https://www.google.com/search?q=../docs/README.md).

## Scope check

* [x] No unrelated refactors
* [x] No public surface expansion without discussion
* [x] Deterministic-first behavior preserved
* [x] No hidden model calls introduced
* [x] README, docs, examples, and templates remain factual and alpha-scoped

## Notes for reviewer

This is my first contribution! I have followed the Maintainers instructions. And yes my username on my machine is just 'main'.

