### PR TITLE
docs: add privacy checklist for sample fixtures

### DIFF
--- a/docs/kora-studio/fixtures/README.md
+++ b/docs/kora-studio/fixtures/README.md
@@ -30,6 +30,17 @@ Fixtures help future Studio development by providing stable sample data for the 
 - `standard-vs-kora-comparison.sample.json`
 - `local-harness-requests.sample.json`
 
+## Privacy & Security Checklist
+
+Before contributing a sample fixture, please verify that it complies with our data privacy and security standards:
+
+- [ ] **Synthetic Data Only:** The fixture relies entirely on fabricated, synthetic data.
+- [ ] **No Secrets:** The fixture contains no API keys, passwords, authentication tokens, or other credentials.
+- [ ] **No Private Data:** The fixture contains no Personally Identifiable Information (PII) or real user data.
+- [ ] **No Raw Prompts:** The fixture does not expose internal, system, or unaltered prompts.
+- [ ] **No Raw Provider Responses:** The fixture does not include direct, unaltered responses from AI providers.
+- [ ] **No Proprietary Datasets:** The fixture does not include restricted, copyrighted, or proprietary dataset information.
+
 ## Claim Boundary
 
 Fixtures do not create new evidence or claims. They exist only to support UI and implementation planning.


### PR DESCRIPTION

Resolves #211

## Summary

This PR adds a privacy and security checklist to the KORA Studio fixtures documentation (`docs/kora-studio/fixtures/README.md`). It ensures that all future sample fixtures strictly use synthetic data and do not contain secrets, PII, raw prompts, raw provider responses, or proprietary datasets.

## Type of change

- [x] Docs only
- [ ] CLI / example
- [ ] Benchmark / evidence
- [ ] Code / tests
- [ ] Security-sensitive

## Verification

- [x] Validation commands were run or marked not applicable.
- [x] Claim hygiene checked.
- [x] No unsupported production, API-cost, benchmark, broad workload, or energy claims added.
- [x] No raw benchmark JSON artifacts committed.
- [x] No local absolute paths introduced.
- [x] No release, tag, package-version, or release-asset changes unless explicitly approved.

List commands run and results:

```text
main@fedora:~/Open-Source/KORA$ git diff --check
main@fedora:~/Open-Source/KORA$ 

```

Useful references: [CONTRIBUTING.md](https://www.google.com/search?q=../CONTRIBUTING.md), [SECURITY.md](https://www.google.com/search?q=../SECURITY.md), [experiments/README.md](https://www.google.com/search?q=../experiments/README.md), and [docs/README.md](https://www.google.com/search?q=../docs/README.md).

## Scope check

* [x] No unrelated refactors
* [x] No public surface expansion without discussion
* [x] Deterministic-first behavior preserved
* [x] No hidden model calls introduced
* [x] README, docs, examples, and templates remain factual and alpha-scoped

## Notes for reviewer

Docs-only change to address #211. Kept minimal and scoped as a first contribution.

