### PR TITLE
docs: add model escalation glossary entry

### DIFF
--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -83,6 +83,20 @@ Ensures:
 
 ---
 
+## Model Escalation
+
+The path used when deterministic handling is not safe or sufficient for a given task.
+
+Model escalation occurs when:
+- A task requires probabilistic reasoning
+- Deterministic rules cannot resolve the request
+- Schema validation fails and the task needs reinterpretation
+
+Escalation is a controlled fallback, not a default behavior. KORA's architecture ensures that escalation only happens after deterministic paths have been exhausted or explicitly bypassed by policy.
+
+Model escalation invokes the reasoning adapter with full budget governance and schema constraints.
+
+---
 ## Inference Reflexivity
 
 Architectural pattern where every request triggers a model invocation without evaluating necessity. KORA exists to eliminate inference reflexivity.


### PR DESCRIPTION
## Summary

Add a concise glossary entry explaining model escalation.

## Changes

- Added `## Model Escalation` entry to `docs/glossary.md`
- Defines escalation as the path used when deterministic handling is not safe or sufficient
- Explains when escalation occurs and how it's controlled

## Acceptance Criteria

- [x] Explains escalation as the path used when deterministic handling is not safe or sufficient, without implying production provider calls
- [x] Keeps the change small and suitable for a first contribution
- [x] Does not introduce secrets, private data, raw provider responses, or unsupported claims

## Validation

```bash
git diff --check
```

Closes #200