### PR TITLE
Add branch naming tip for first-time contributors

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -218,6 +218,8 @@ Good branch names:
 - `test/offline-runner-smoke`
 - `feature/dev-error-reporting`
 
+**Tip for first-time contributors:** pick a branch name that describes your change in a few words. Short names like `docs/fix-typo-readme` are easier to read in PR lists than long or generic ones like `my-changes`. The prefixes above are suggestions, not strict requirements.
+
 ### Fork workflow for external contributors
 
 Use this workflow if you do not have write access to `Krako-Labs/KORA`.


### PR DESCRIPTION
## Summary

Add a short tip after the branch naming examples in CONTRIBUTING.md to help first-time contributors choose clear, descriptive branch names. closes #203 

## Type of change

- [x] Docs only
- [ ] CLI / example
- [ ] Benchmark / evidence
- [ ] Code / tests
- [ ] Security-sensitive

## Verification

- [x] Validation commands were run or marked not applicable.
- [x] Claim hygiene checked.
- [x] No unsupported production, API-cost, benchmark, broad workload, or energy claims added.
- [x] No raw benchmark JSON artifacts committed.
- [x] No local absolute paths introduced.
- [x] No release, tag, package-version, or release-asset changes unless explicitly approved.

List commands run and results:

```text
 create mode 100644 docs/kora-studio/kora-studio-v0-8-final-ui-implementation-plan.md
main@fedora:~/Open-Source/KORA$ git diff --check
main@fedora:~/Open-Source/KORA$ 

```

Useful references: [CONTRIBUTING.md](../CONTRIBUTING.md), [SECURITY.md](../SECURITY.md), [experiments/README.md](../experiments/README.md), and [docs/README.md](../docs/README.md).

## Scope check

- [x] No unrelated refactors
- [x] No public surface expansion without discussion
- [x] Deterministic-first behavior preserved
- [x] No hidden model calls introduced
- [x] README, docs, examples, and templates remain factual and alpha-scoped

## Notes for reviewer

Two-line addition only. No behavioral or CLI changes. The tip uses the existing `<type>/<short-description>` convention as a suggestion, not a strict policy.
