### PR TITLE
Prepare AI Champion GPU/API dry-run readiness

### DIFF
--- a/docs/benchmarks/ai-champion-claim-boundaries.md
+++ b/docs/benchmarks/ai-champion-claim-boundaries.md
@@ -1,0 +1,57 @@
+# AI Champion Claim Boundaries
+
+Status: public wording guardrail for pre-access GPU/API benchmark preparation.
+
+## Safe Public Wording
+
+The current approved claim remains:
+
+> In a reproducible 100-task deterministic-heavy benchmark workload, KORA-controlled execution avoided 80 of 100 simulated model invocations versus a naive direct baseline.
+
+For Task 521 additions, safe wording is:
+
+- KORA has a dry-run provider routing harness for planned AI Champion GPU/API benchmark work.
+- The harness validates placeholder provider definitions and emits synthetic dry-run summaries.
+- The harness covers planned routes for deterministic, cache, local model, H100, AWS, Azure, OpenAI, Claude, and Gemini providers.
+- Real GPU/API benchmark execution remains blocked until access, credentials, smoke tests, and benchmark approval are complete.
+
+## Forbidden Claims
+
+Do not claim:
+
+- production cost reduction proof
+- real API-cost reduction proof
+- production benchmark proof
+- broad workload superiority proof
+- energy reduction evidence
+- formal government validation
+- real GPU/API benchmark results
+- real H100 performance results
+- real cloud/provider model quality results
+- real latency comparisons
+- real provider cost comparisons
+
+## Required Qualifiers
+
+Use these qualifiers when discussing Task 521 outputs:
+
+- synthetic
+- dry-run only
+- planning harness
+- placeholder config
+- blocked real execution
+- not production evidence
+- not real API/GPU benchmark evidence
+
+## Publication Review Gate
+
+Before publishing any future real benchmark claim, require:
+
+- workload version and benchmark scope review
+- provider identity and model version review
+- raw artifact handling decision
+- cost accounting method review
+- reproducibility instructions
+- claim-to-evidence audit
+- secret scan
+- legal/data policy review where applicable

--- a/docs/benchmarks/ai-champion-gpu-api-test-plan.md
+++ b/docs/benchmarks/ai-champion-gpu-api-test-plan.md
@@ -1,0 +1,75 @@
+# AI Champion GPU/API Test Plan
+
+Status: planning and dry-run readiness only.
+
+This plan prepares the AI Champion GPU/API benchmark track before formal access to GPU servers, cloud generative AI resources, or external LLM APIs is available. It does not authorize real GPU execution, cloud model calls, external API calls, model downloads, production benchmark claims, or raw benchmark artifact publication.
+
+## Current Approved Claim
+
+Safe public wording remains:
+
+> In a reproducible 100-task deterministic-heavy benchmark workload, KORA-controlled execution avoided 80 of 100 simulated model invocations versus a naive direct baseline.
+
+This claim is based on deterministic-heavy simulated model invocation accounting. It is not real API-cost evidence, production cost evidence, production benchmark evidence, broad workload superiority evidence, energy evidence, or government validation.
+
+## Planned Future Resources
+
+The following resources are expected or possible but blocked until formally allocated:
+
+- H100 class GPU capacity, expected as two H100 GPUs.
+- Usage window expected from 2026-06-01 through 2026-06-30.
+- Approximately 2,500 GB disk capacity.
+- GPU server network details, credentials, and access policy are not committed in this repository.
+- AWS and Azure generative AI resources may become available.
+- External LLM APIs may include OpenAI, Claude, Gemini, and provider-hosted models.
+
+Treat all listed resources as unavailable for benchmark execution until access, credentials, quotas, cost controls, and smoke tests are complete.
+
+## Dry-Run Harness
+
+The prepared dry-run harness is:
+
+```bash
+python3 experiments/provider_routing/run_dry_run.py \
+  --config experiments/provider_routing/config.example.yaml \
+  --output /tmp/kora_ai_champion_provider_routing.dry_run.json
+```
+
+The harness validates placeholder provider definitions and simulates routing among:
+
+- `deterministic`
+- `cache`
+- `local_small_model`
+- `local_h100_model`
+- `aws_model`
+- `azure_model`
+- `openai_api`
+- `claude_api`
+- `gemini_api`
+
+All output is synthetic and dry-run only. The script must not initiate network, provider, GPU, cloud, or local model runtime calls.
+
+## Blocked Real Execution
+
+Real execution remains blocked until all of the following are true:
+
+- GPU access is formally allocated.
+- Cloud/API accounts, credentials, quotas, budgets, and data policy are approved.
+- Provider-specific smoke tests pass.
+- Local configs are stored outside version control or in ignored paths.
+- Real-run code paths have explicit opt-in gates that default to disabled.
+- Benchmark scope, prompts, workload, cost accounting, logging, and artifact policy are reviewed.
+
+## Future Smoke Test Task
+
+Task 522 should perform the H100 access/environment smoke test. It should verify only minimal environment facts such as login, driver visibility, GPU count, disk availability, Python environment, and no-benchmark dry-run readiness. It should not run real benchmarks.
+
+Task 523 should perform AWS/Azure/API credential smoke tests. It should verify authentication and minimal non-benchmark request wiring only after credentials are formally provided and cost controls are active.
+
+## Future Real Benchmark Task
+
+Task 524 should integrate the runtime hybrid benchmark after smoke tests pass. It should define the real workload, provider matrix, routing policy, accounting fields, output artifact policy, and public claim review before any result is published.
+
+## Evidence Policy
+
+Raw generated benchmark outputs should stay in `/tmp` or another ignored path unless a later release process explicitly selects frozen evidence. Do not commit secrets, API keys, credentials, private host details, raw provider responses, or local-only ChatGPT context.

--- a/docs/benchmarks/ai-champion-provider-routing-matrix.md
+++ b/docs/benchmarks/ai-champion-provider-routing-matrix.md
@@ -1,0 +1,45 @@
+# AI Champion Provider Routing Matrix
+
+Status: dry-run planning matrix. No real provider calls are enabled.
+
+| Route | Current dry-run status | Future activation requirement | Current evidence level |
+|---|---|---|---|
+| `deterministic` | Ready for synthetic dry run | Keep deterministic resolver tests passing | Existing simulated invocation accounting plus dry-run routing |
+| `cache` | Ready for synthetic dry run | Define cache key, invalidation, hit accounting, and replay policy | Synthetic route only |
+| `local_small_model` | Planned, blocked | Approved local model, disk policy, dependency plan, and no-large-download review | Synthetic route only |
+| `local_h100_model` | Planned, blocked | Formal H100 access, environment smoke test, model/runtime approval, cost and artifact policy | Synthetic route only |
+| `aws_model` | Planned, blocked | AWS account/resource allocation, credentials, quota, budget, data policy, smoke test | Synthetic route only |
+| `azure_model` | Planned, blocked | Azure resource allocation, credentials, quota, budget, data policy, smoke test | Synthetic route only |
+| `openai_api` | Planned, blocked | OpenAI API credential, model/version selection, quota, budget, smoke test | Synthetic route only |
+| `claude_api` | Planned, blocked | Claude API credential, model/version selection, quota, budget, smoke test | Synthetic route only |
+| `gemini_api` | Planned, blocked | Gemini API credential, model/version selection, quota, budget, smoke test | Synthetic route only |
+
+## Routing Principles
+
+- Prefer deterministic execution when the task can be resolved without model inference.
+- Prefer cache only when a replay-safe cache key and response provenance are available.
+- Use local small model routes only after model acquisition and dependency policy are approved.
+- Use H100 routes only after Task 522 confirms formal access and environment readiness.
+- Use cloud/API routes only after Task 523 confirms credentials, quota, budget, model IDs, and data handling policy.
+- Keep provider selection explainable in the emitted benchmark record.
+- Keep dry-run and real-run outputs visibly separated.
+
+## Required Accounting Fields For Future Real Runs
+
+Future real benchmark outputs should include:
+
+- route selected
+- provider family
+- model identifier and version where applicable
+- deterministic/cache bypass reason where applicable
+- real call attempted flag
+- request token estimate or provider token accounting where applicable
+- latency
+- status code or provider error class where applicable
+- cost estimate source
+- retry count
+- cache hit/miss state
+- benchmark run ID
+- workload version
+
+These fields are not populated with real values in the current dry-run harness.

--- a/docs/benchmarks/ai-champion-readiness-checklist.md
+++ b/docs/benchmarks/ai-champion-readiness-checklist.md
@@ -1,0 +1,63 @@
+# AI Champion Readiness Checklist
+
+Status: pre-access readiness.
+
+## Ready Now
+
+- [x] Planning documents exist for GPU/API benchmark preparation.
+- [x] Provider routing matrix separates deterministic, cache, local, GPU, cloud, and external API routes.
+- [x] Dry-run provider routing harness exists under `experiments/provider_routing/`.
+- [x] Example config uses placeholders only.
+- [x] Dry-run CLI emits synthetic summaries.
+- [x] Tests cover config validation, dry-run routing, and placeholder-only config safety.
+- [x] Current claim boundary is documented.
+
+## Blocked Until Formal Access
+
+- [ ] H100 login/access confirmation.
+- [ ] H100 driver and runtime verification.
+- [ ] GPU disk and environment smoke test.
+- [ ] AWS generative AI access confirmation.
+- [ ] Azure generative AI access confirmation.
+- [ ] OpenAI API credential smoke test.
+- [ ] Claude API credential smoke test.
+- [ ] Gemini API credential smoke test.
+- [ ] Provider-hosted model smoke test if applicable.
+- [ ] Cost controls and quota limits documented.
+- [ ] Data handling and logging policy approved.
+- [ ] Real benchmark workload and artifact freeze policy approved.
+
+## Future Smoke Test Task
+
+Task 522: H100 access/environment smoke test.
+
+Expected scope:
+
+- Confirm formal access.
+- Verify GPU count and driver visibility.
+- Verify disk availability.
+- Verify Python/runtime basics.
+- Run no real benchmark.
+- Commit no credentials, host secrets, or raw sensitive environment dumps.
+
+Task 523: AWS/Azure/API credential smoke test.
+
+Expected scope:
+
+- Confirm credentials are formally provided.
+- Verify each provider with minimal smoke test only.
+- Record model IDs and quota/budget limits.
+- Run no real benchmark.
+- Commit no secrets or raw provider responses.
+
+## Future Real Benchmark Task
+
+Task 524: runtime-integrated hybrid benchmark.
+
+Expected scope:
+
+- Integrate deterministic, cache, local model, H100, cloud, and external API routes.
+- Add explicit opt-in gates for real calls.
+- Capture provider accounting fields.
+- Produce reviewable benchmark evidence only after smoke tests pass.
+- Update public claims only after evidence review.

--- a/docs/reports/ai-champion-gpu-api-readiness-goal-report.md
+++ b/docs/reports/ai-champion-gpu-api-readiness-goal-report.md
@@ -1,0 +1,72 @@
+# AI Champion GPU/API Readiness Goal Report
+
+Task: 521
+
+Status: implemented for dry-run readiness. Real GPU/API execution remains blocked.
+
+## Files Created Or Changed
+
+- `docs/benchmarks/ai-champion-gpu-api-test-plan.md`
+- `docs/benchmarks/ai-champion-provider-routing-matrix.md`
+- `docs/benchmarks/ai-champion-readiness-checklist.md`
+- `docs/benchmarks/ai-champion-claim-boundaries.md`
+- `docs/reports/ai-champion-gpu-api-readiness-goal-report.md`
+- `experiments/provider_routing/README.md`
+- `experiments/provider_routing/config.example.yaml`
+- `experiments/provider_routing/run_dry_run.py`
+- `tests/test_provider_routing_dry_run.py`
+
+## Validation Results
+
+Validation completed:
+
+- `git status --short --branch` confirmed work occurred on `task521_ai_champion_gpu_api_readiness`, not local `main`.
+- `python3 experiments/provider_routing/run_dry_run.py --config experiments/provider_routing/config.example.yaml --output /tmp/kora_ai_champion_provider_routing.dry_run.json` passed and emitted a synthetic dry-run summary.
+- `git diff --check` passed.
+- `python3 -m pytest` passed with 262 tests.
+- Local secret scan over the added docs, experiment, and tests found no active API keys, cloud credentials, private-key headers, active API endpoints, or the candidate GPU host address.
+- No real network, provider, GPU, cloud, or local model runtime calls were attempted.
+
+The dry-run harness is designed to report:
+
+- `dry_run_only: true`
+- `synthetic_results_only: true`
+- `real_provider_calls_enabled: false`
+- `real_network_calls_attempted: false`
+- `real_gpu_calls_attempted: false`
+
+## Ready Now
+
+- AI Champion GPU/API benchmark planning docs are available.
+- Provider routing categories are named and separated.
+- Placeholder-only provider config exists.
+- Dry-run CLI validates provider definitions.
+- Dry-run CLI simulates routing across deterministic, cache, local small model, local H100 model, AWS, Azure, OpenAI, Claude, and Gemini routes.
+- Tests cover the dry-run config and routing behavior.
+- Public claim boundaries are documented.
+
+## Blocked Until GPU/API Access Is Active
+
+- Real H100 access and environment validation.
+- Real local GPU model runtime validation.
+- AWS/Azure resource and credential validation.
+- OpenAI, Claude, Gemini, and provider-hosted model credential validation.
+- Real provider smoke tests.
+- Real benchmark workload execution.
+- Real cost, latency, quality, energy, or production claims.
+
+## Next Recommended Tasks
+
+Task 522: H100 access/environment smoke test.
+
+Task 523: AWS/Azure/API credential smoke test.
+
+Task 524: runtime-integrated hybrid benchmark.
+
+## Claim Boundary
+
+Current approved public claim:
+
+> In a reproducible 100-task deterministic-heavy benchmark workload, KORA-controlled execution avoided 80 of 100 simulated model invocations versus a naive direct baseline.
+
+Task 521 does not add real GPU/API benchmark evidence and does not change this claim.

--- a/experiments/provider_routing/README.md
+++ b/experiments/provider_routing/README.md
@@ -1,0 +1,49 @@
+# AI Champion Provider Routing Dry Run
+
+This directory contains a dry-run-only provider routing experiment skeleton for the AI Champion GPU/API benchmark track.
+
+The harness prepares routing logic before real GPU, cloud, or external API access is formally available. It does not call H100 servers, AWS, Azure, OpenAI, Claude, Gemini, provider-hosted models, local model runtimes, or active network endpoints. All outputs are synthetic dry-run summaries.
+
+## Files
+
+- `config.example.yaml`: JSON-compatible YAML with placeholder-only provider definitions.
+- `run_dry_run.py`: dependency-free CLI that loads the example config, validates provider definitions, simulates routing, and emits a synthetic summary.
+
+## Dry-Run Command
+
+```bash
+python3 experiments/provider_routing/run_dry_run.py \
+  --config experiments/provider_routing/config.example.yaml \
+  --output /tmp/kora_ai_champion_provider_routing.dry_run.json
+```
+
+The output is safe for local inspection but remains synthetic. Do not treat it as real benchmark evidence.
+
+## Simulated Routes
+
+The dry-run config covers these planned routing categories:
+
+- `deterministic`
+- `cache`
+- `local_small_model`
+- `local_h100_model`
+- `aws_model`
+- `azure_model`
+- `openai_api`
+- `claude_api`
+- `gemini_api`
+
+Only `deterministic` and `cache` are marked `ready_dry_run`. All local model, GPU, cloud, and external API providers are marked `planned_blocked` until access, credentials, endpoints, smoke tests, logging policy, and benchmark approval are active.
+
+## Future Real-Provider Activation Path
+
+Real-provider execution requires a separate task after access is formally available:
+
+1. Keep this example config secret-free and committed as documentation.
+2. Create an ignored local config outside version control for real endpoint and credential references.
+3. Run provider-specific smoke tests that prove authentication and minimal request paths without running benchmarks.
+4. Add explicit real-run gates in code that default to disabled.
+5. Record provider versions, model identifiers, quota limits, data policy, and cost controls.
+6. Run the real benchmark only after the smoke tests pass and the claim boundaries are updated.
+
+Until those steps are complete, this experiment remains a dry-run planning harness only.

--- a/experiments/provider_routing/config.example.yaml
+++ b/experiments/provider_routing/config.example.yaml
@@ -1,0 +1,87 @@
+{
+  "name": "ai_champion_provider_routing_dry_run",
+  "dry_run_only": true,
+  "synthetic_results_only": true,
+  "real_provider_calls_enabled": false,
+  "notes": [
+    "JSON-compatible YAML example for the dry-run harness.",
+    "All provider entries are placeholders only.",
+    "Do not add secrets, credentials, active endpoints, or host addresses."
+  ],
+  "providers": [
+    {
+      "id": "deterministic",
+      "kind": "deterministic",
+      "status": "ready_dry_run",
+      "endpoint": null,
+      "credential_ref": "PLACEHOLDER_ONLY"
+    },
+    {
+      "id": "cache",
+      "kind": "cache",
+      "status": "ready_dry_run",
+      "endpoint": null,
+      "credential_ref": "PLACEHOLDER_ONLY"
+    },
+    {
+      "id": "local_small_model",
+      "kind": "local_small_model",
+      "status": "planned_blocked",
+      "endpoint": null,
+      "credential_ref": "PLACEHOLDER_ONLY"
+    },
+    {
+      "id": "local_h100_model",
+      "kind": "local_h100_model",
+      "status": "planned_blocked",
+      "endpoint": null,
+      "credential_ref": "PLACEHOLDER_ONLY"
+    },
+    {
+      "id": "aws_model",
+      "kind": "aws_model",
+      "status": "planned_blocked",
+      "endpoint": null,
+      "credential_ref": "PLACEHOLDER_ONLY"
+    },
+    {
+      "id": "azure_model",
+      "kind": "azure_model",
+      "status": "planned_blocked",
+      "endpoint": null,
+      "credential_ref": "PLACEHOLDER_ONLY"
+    },
+    {
+      "id": "openai_api",
+      "kind": "openai_api",
+      "status": "planned_blocked",
+      "endpoint": null,
+      "credential_ref": "PLACEHOLDER_ONLY"
+    },
+    {
+      "id": "claude_api",
+      "kind": "claude_api",
+      "status": "planned_blocked",
+      "endpoint": null,
+      "credential_ref": "PLACEHOLDER_ONLY"
+    },
+    {
+      "id": "gemini_api",
+      "kind": "gemini_api",
+      "status": "planned_blocked",
+      "endpoint": null,
+      "credential_ref": "PLACEHOLDER_ONLY"
+    }
+  ],
+  "synthetic_tasks": [
+    {"id": "task_deterministic_001", "route_hint": "deterministic"},
+    {"id": "task_cache_001", "route_hint": "cache"},
+    {"id": "task_local_small_001", "route_hint": "local_small_model"},
+    {"id": "task_local_h100_001", "route_hint": "local_h100_model"},
+    {"id": "task_aws_001", "route_hint": "aws_model"},
+    {"id": "task_azure_001", "route_hint": "azure_model"},
+    {"id": "task_openai_001", "route_hint": "openai_api"},
+    {"id": "task_claude_001", "route_hint": "claude_api"},
+    {"id": "task_gemini_001", "route_hint": "gemini_api"}
+  ]
+}

--- a/experiments/provider_routing/run_dry_run.py
+++ b/experiments/provider_routing/run_dry_run.py
@@ -1,0 +1,178 @@
+from __future__ import annotations
+
+import argparse
+import json
+from collections import Counter
+from pathlib import Path
+from typing import Any
+
+
+EXPECTED_PROVIDER_KINDS = {
+    "deterministic",
+    "cache",
+    "local_small_model",
+    "local_h100_model",
+    "aws_model",
+    "azure_model",
+    "openai_api",
+    "claude_api",
+    "gemini_api",
+}
+
+ALLOWED_PROVIDER_STATUSES = {"ready_dry_run", "planned_blocked"}
+DEFAULT_CONFIG_PATH = Path(__file__).with_name("config.example.yaml")
+
+
+class ProviderRoutingConfigError(ValueError):
+    """Raised when the dry-run provider routing config is unsafe or malformed."""
+
+
+def load_config(path: Path = DEFAULT_CONFIG_PATH) -> dict[str, Any]:
+    """Load the JSON-compatible YAML example without adding a YAML dependency."""
+    try:
+        config = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise ProviderRoutingConfigError(
+            "config.example.yaml must remain JSON-compatible YAML for dependency-free dry runs"
+        ) from exc
+
+    if not isinstance(config, dict):
+        raise ProviderRoutingConfigError("provider routing config must be an object")
+    return config
+
+
+def validate_provider_config(config: dict[str, Any]) -> dict[str, Any]:
+    if config.get("dry_run_only") is not True:
+        raise ProviderRoutingConfigError("dry_run_only must be true")
+    if config.get("synthetic_results_only") is not True:
+        raise ProviderRoutingConfigError("synthetic_results_only must be true")
+    if config.get("real_provider_calls_enabled") is not False:
+        raise ProviderRoutingConfigError("real_provider_calls_enabled must be false")
+
+    providers = config.get("providers")
+    if not isinstance(providers, list):
+        raise ProviderRoutingConfigError("providers must be a list")
+
+    seen_ids: set[str] = set()
+    seen_kinds: set[str] = set()
+    for index, provider in enumerate(providers):
+        if not isinstance(provider, dict):
+            raise ProviderRoutingConfigError(f"provider at index {index} must be an object")
+
+        provider_id = provider.get("id")
+        kind = provider.get("kind")
+        status = provider.get("status")
+        if not isinstance(provider_id, str) or not provider_id:
+            raise ProviderRoutingConfigError(f"provider at index {index} must have a non-empty id")
+        if provider_id in seen_ids:
+            raise ProviderRoutingConfigError(f"duplicate provider id: {provider_id}")
+        if kind not in EXPECTED_PROVIDER_KINDS:
+            raise ProviderRoutingConfigError(f"unsupported provider kind for {provider_id}: {kind}")
+        if status not in ALLOWED_PROVIDER_STATUSES:
+            raise ProviderRoutingConfigError(f"unsupported status for {provider_id}: {status}")
+        if provider.get("endpoint") is not None:
+            raise ProviderRoutingConfigError(f"{provider_id} must not define an active endpoint")
+        if provider.get("credential_ref") != "PLACEHOLDER_ONLY":
+            raise ProviderRoutingConfigError(f"{provider_id} credential_ref must be PLACEHOLDER_ONLY")
+
+        seen_ids.add(provider_id)
+        seen_kinds.add(kind)
+
+    missing = sorted(EXPECTED_PROVIDER_KINDS - seen_kinds)
+    if missing:
+        raise ProviderRoutingConfigError(f"missing provider kinds: {', '.join(missing)}")
+
+    tasks = config.get("synthetic_tasks")
+    if not isinstance(tasks, list) or not tasks:
+        raise ProviderRoutingConfigError("synthetic_tasks must be a non-empty list")
+    for index, task in enumerate(tasks):
+        if not isinstance(task, dict):
+            raise ProviderRoutingConfigError(f"synthetic task at index {index} must be an object")
+        task_id = task.get("id")
+        route_hint = task.get("route_hint")
+        if not isinstance(task_id, str) or not task_id:
+            raise ProviderRoutingConfigError(f"synthetic task at index {index} must have a non-empty id")
+        if route_hint not in EXPECTED_PROVIDER_KINDS:
+            raise ProviderRoutingConfigError(f"synthetic task {task_id} has unsupported route_hint: {route_hint}")
+
+    return {
+        "provider_count": len(providers),
+        "provider_kinds": sorted(seen_kinds),
+        "synthetic_task_count": len(tasks),
+    }
+
+
+def simulate_routing(config: dict[str, Any]) -> dict[str, Any]:
+    validation = validate_provider_config(config)
+    providers_by_kind = {provider["kind"]: provider for provider in config["providers"]}
+
+    routed_tasks = []
+    provider_counts: Counter[str] = Counter()
+    blocked_real_execution_count = 0
+    for task in config["synthetic_tasks"]:
+        route_hint = task["route_hint"]
+        provider = providers_by_kind[route_hint]
+        dry_run_status = "synthetic_route_ready"
+        if provider["status"] == "planned_blocked":
+            dry_run_status = "synthetic_route_blocked_for_real_execution"
+            blocked_real_execution_count += 1
+
+        provider_counts[provider["id"]] += 1
+        routed_tasks.append(
+            {
+                "task_id": task["id"],
+                "selected_provider": provider["id"],
+                "provider_kind": provider["kind"],
+                "provider_status": provider["status"],
+                "dry_run_status": dry_run_status,
+                "real_call_attempted": False,
+            }
+        )
+
+    return {
+        "name": config.get("name", "ai_champion_provider_routing_dry_run"),
+        "status": "ok",
+        "mode": "dry-run",
+        "dry_run_only": True,
+        "synthetic_results_only": True,
+        "real_provider_calls_enabled": False,
+        "real_network_calls_attempted": False,
+        "real_gpu_calls_attempted": False,
+        "validation": validation,
+        "summary": {
+            "synthetic_tasks": len(routed_tasks),
+            "providers_used": dict(sorted(provider_counts.items())),
+            "blocked_real_execution_routes": blocked_real_execution_count,
+        },
+        "routed_tasks": routed_tasks,
+        "claim_boundary": "Synthetic dry-run routing only; no real GPU, API, cost, latency, quality, energy, or production benchmark result.",
+    }
+
+
+def write_summary(summary: dict[str, Any], output_path: Path | None) -> None:
+    if output_path is None:
+        return
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(json.dumps(summary, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Run the AI Champion provider routing dry-run harness.")
+    parser.add_argument(
+        "--config",
+        type=Path,
+        default=DEFAULT_CONFIG_PATH,
+        help="Path to JSON-compatible YAML config. Defaults to config.example.yaml.",
+    )
+    parser.add_argument("--output", type=Path, help="Optional path for the dry-run JSON summary.")
+    args = parser.parse_args(argv)
+
+    config = load_config(args.config)
+    summary = simulate_routing(config)
+    write_summary(summary, args.output)
+    print(json.dumps(summary, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_provider_routing_dry_run.py
+++ b/tests/test_provider_routing_dry_run.py
@@ -1,0 +1,81 @@
+import json
+from pathlib import Path
+
+import pytest
+
+from experiments.provider_routing.run_dry_run import (
+    EXPECTED_PROVIDER_KINDS,
+    ProviderRoutingConfigError,
+    load_config,
+    main,
+    simulate_routing,
+    validate_provider_config,
+)
+
+
+CONFIG_PATH = Path("experiments/provider_routing/config.example.yaml")
+
+
+def test_provider_routing_config_validation_accepts_example() -> None:
+    config = load_config(CONFIG_PATH)
+
+    validation = validate_provider_config(config)
+
+    assert validation["provider_count"] == 9
+    assert set(validation["provider_kinds"]) == EXPECTED_PROVIDER_KINDS
+    assert validation["synthetic_task_count"] == 9
+
+
+def test_provider_routing_dry_run_routes_all_provider_kinds() -> None:
+    summary = simulate_routing(load_config(CONFIG_PATH))
+
+    assert summary["mode"] == "dry-run"
+    assert summary["synthetic_results_only"] is True
+    assert summary["real_network_calls_attempted"] is False
+    assert summary["real_gpu_calls_attempted"] is False
+    assert summary["summary"]["synthetic_tasks"] == 9
+    assert summary["summary"]["blocked_real_execution_routes"] == 7
+    assert {task["provider_kind"] for task in summary["routed_tasks"]} == EXPECTED_PROVIDER_KINDS
+    assert all(task["real_call_attempted"] is False for task in summary["routed_tasks"])
+
+
+def test_provider_routing_rejects_active_endpoint() -> None:
+    config = load_config(CONFIG_PATH)
+    config["providers"][0]["endpoint"] = "https://example.invalid/provider"
+
+    with pytest.raises(ProviderRoutingConfigError, match="must not define an active endpoint"):
+        validate_provider_config(config)
+
+
+def test_provider_routing_example_contains_placeholders_only() -> None:
+    text = CONFIG_PATH.read_text(encoding="utf-8")
+
+    forbidden_fragments = [
+        "sk-",
+        "A" + "KIA",
+        "BEGIN " + "PRIVATE KEY",
+        "aws_secret" + "_access_key",
+        "api_key",
+        "https://" + "api.",
+        "http://",
+        ".".join(["121", "160", "51", "114"]),
+    ]
+    for fragment in forbidden_fragments:
+        assert fragment not in text
+
+    config = json.loads(text)
+    assert all(provider["endpoint"] is None for provider in config["providers"])
+    assert {provider["credential_ref"] for provider in config["providers"]} == {"PLACEHOLDER_ONLY"}
+
+
+def test_provider_routing_cli_writes_dry_run_summary(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    output_path = tmp_path / "provider-routing-summary.json"
+
+    exit_code = main(["--config", str(CONFIG_PATH), "--output", str(output_path)])
+
+    captured = capsys.readouterr()
+    saved = json.loads(output_path.read_text(encoding="utf-8"))
+    printed = json.loads(captured.out)
+    assert exit_code == 0
+    assert saved == printed
+    assert saved["claim_boundary"].startswith("Synthetic dry-run routing only")


### PR DESCRIPTION
## Summary
- Add AI Champion GPU/API benchmark planning docs, routing matrix, readiness checklist, claim boundaries, and goal report.
- Add a provider routing dry-run experiment skeleton with placeholder-only config and dependency-free CLI.
- Add tests for config validation, synthetic routing, and placeholder-only safety.

## Validation
- git diff --check
- python3 experiments/provider_routing/run_dry_run.py --config experiments/provider_routing/config.example.yaml --output /tmp/kora_ai_champion_provider_routing.dry_run.json
- python3 -m pytest
- targeted secret scan over added Task 521 files

## Boundaries
- No real GPU, cloud, provider, network, or local model runtime calls were attempted.
- No secrets, credentials, active endpoints, raw benchmark outputs, or local-only ChatGPT context are included.
- This PR does not add real GPU/API benchmark evidence and does not change the current approved public claim.