### PR TITLE
docs: cross-link local validation reviewer packet

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -24,6 +24,7 @@ KORA control layer architecture.
 - [KORA Public Language Guide](claims/kora-public-language-guide.md)
 - [Telemetry and observability counters](telemetry-and-observability.md#current-public-counters)
 - [Testing and validation strategy](testing-and-validation-strategy.md)
+- [Local validation reviewer packet](benchmarks/local-validation-reviewer-packet.md)
 - [Research agenda](research-agenda.md)
 - [Whitepaper](whitepaper.md)
 


### PR DESCRIPTION
## Summary
Add a top-level docs index link to the local validation reviewer packet so validation-related guidance is easier to find from `docs/README.md`.

## Type of change
- [x] Docs only
- [ ] CLI / example
- [ ] Benchmark / evidence
- [ ] Code / tests
- [ ] Security-sensitive

## Verification
- [x] Validation commands were run or marked not applicable.
- [x] Claim hygiene checked.
- [x] No unsupported production, API-cost, benchmark, broad workload, or energy claims added.
- [x] No raw benchmark JSON artifacts committed.
- [x] No local absolute paths introduced.
- [x] No release, tag, package-version, or release-asset changes unless explicitly approved.

List commands run and results:

```text
git diff --check
# passed
```

Useful references: [CONTRIBUTING.md](../CONTRIBUTING.md), [SECURITY.md](../SECURITY.md), [experiments/README.md](../experiments/README.md), and [docs/README.md](../docs/README.md).

## Scope check
- [x] No unrelated refactors
- [x] No public surface expansion without discussion
- [x] Deterministic-first behavior preserved
- [x] No hidden model calls introduced
- [x] README, docs, examples, and templates remain factual and alpha-scoped

## Notes for reviewer
This keeps the change to a single docs index line and leaves the existing reviewer packet content untouched.
