### PR TITLE
Fix telemetry CLI: user-friendly errors for missing/misdirected input

### DIFF
--- a/kora/cli.py
+++ b/kora/cli.py
@@ -192,7 +192,11 @@ def main(argv: list[str] | None = None) -> int:
 
     if args.command == "telemetry":
         input_path = Path(args.input)
-        obj = load_json(input_path)
+        try:
+            obj = load_json(input_path)
+        except (FileNotFoundError, IsADirectoryError) as e:
+            print(e, file=sys.stderr)
+            return 1
         summary = summarize_run(obj, price_input=args.price_input, price_output=args.price_output)
         json_out = Path(args.json_out) if args.json_out else _default_json_out(input_path)
         md_out = Path(args.md_out) if args.md_out else _default_md_out(input_path)

--- a/kora/telemetry.py
+++ b/kora/telemetry.py
@@ -10,7 +10,18 @@ from kora.cost_model import estimate_cost
 
 
 def load_json(path: str | Path) -> dict[str, Any]:
-    payload = json.loads(Path(path).read_text(encoding="utf-8"))
+    p = Path(path)
+    if p.is_dir():
+        raise IsADirectoryError(
+            f"'{p}' is a directory, not a file. "
+            "Provide the path to a KORA run or report JSON file with --input."
+        )
+    if not p.exists():
+        raise FileNotFoundError(
+            f"run JSON not found: {p}. "
+            "Provide the path to a KORA run or report JSON file with --input."
+        )
+    payload = json.loads(p.read_text(encoding="utf-8"))
     if not isinstance(payload, dict):
         raise ValueError("input JSON must be an object")
     return payload

--- a/tests/test_telemetry_cli.py
+++ b/tests/test_telemetry_cli.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+from kora.cli import main as cli_main
+
+
+def test_telemetry_missing_input() -> None:
+    """Telemetry command exits non-zero and shows a clear error when --input is absent."""
+    result = subprocess.run(
+        [sys.executable, "-m", "kora", "telemetry"],
+        capture_output=True, text=True,
+    )
+    assert result.returncode == 2
+    assert "--input" in result.stderr
+    assert "required" in result.stderr.lower()
+
+
+def test_telemetry_input_file_not_found() -> None:
+    """Telemetry command exits non-zero with a helpful message when the input file doesn't exist."""
+    result = subprocess.run(
+        [sys.executable, "-m", "kora", "telemetry", "--input", "/tmp/no_such_file.json"],
+        capture_output=True, text=True,
+    )
+    assert result.returncode == 1
+    # No raw Python traceback should leak to the user
+    assert "Traceback" not in result.stderr
+    assert "FileNotFoundError" not in result.stderr
+    # The path and context should be visible in the error
+    assert "no_such_file.json" in result.stderr
+    assert "run JSON" in result.stderr
+
+
+def test_telemetry_input_not_a_file() -> None:
+    """Telemetry command fails cleanly when --input points to a directory."""
+    result = subprocess.run(
+        [sys.executable, "-m", "kora", "telemetry", "--input", "/tmp"],
+        capture_output=True, text=True,
+    )
+    assert result.returncode == 1
+    assert "Traceback" not in result.stderr
+    assert "KORA run" in result.stderr
+
+
+def test_telemetry_load_json_missing_file_error_message(tmp_path: Path) -> None:
+    """load_json raises FileNotFoundError with a helpful message when the file does not exist."""
+    from kora.telemetry import load_json
+
+    missing = tmp_path / "does_not_exist.json"
+    try:
+        load_json(missing)
+        assert False, "should have raised FileNotFoundError"
+    except FileNotFoundError as e:
+        msg = str(e)
+        assert str(missing) in msg
+        assert "run JSON" in msg
+        assert "Provide the path to a KORA run" in msg
+
+
+def test_telemetry_load_json_directory_error_message(tmp_path: Path) -> None:
+    """load_json raises IsADirectoryError with a helpful message when the path is a directory."""
+    from kora.telemetry import load_json
+
+    try:
+        load_json(tmp_path)
+        assert False, "should have raised IsADirectoryError"
+    except IsADirectoryError as e:
+        msg = str(e)
+        assert str(tmp_path) in msg
+        assert "directory" in msg
+        assert "Provide the path to a KORA run" in msg


### PR DESCRIPTION
## Summary

Fixes two failure modes in `kora telemetry` when the required `--input` is missing or misdirected:

1. **No `--input` flag** — argparse already exits non-zero with a clear message. Added a test to lock in that behavior.
2. **File not found / directory** — previously leaked a raw Python traceback. Now prints a single-line user-friendly error and exits non-zero.

## Changes

**`kora/telemetry.py`** — `load_json` now validates the path before reading:
- Raises `IsADirectoryError` with message when path is a directory
- Raises `FileNotFoundError` with message when path does not exist

**`kora/cli.py`** — catches `(FileNotFoundError, IsADirectoryError)` in the telemetry handler and prints the error to stderr instead of letting it propagate as a traceback.

**`tests/test_telemetry_cli.py`** — new file with 5 tests covering all three failure modes and the direct `load_json` error paths.

## Testing

```bash
python3 -m pytest tests/test_telemetry_cli.py -v
# 5 passed
```

## Validation

```bash
# Missing --input: exit 2, argparse message
kora telemetry
# → usage: ... error: the following arguments are required: --input

# Missing file: exit 1, clean message
kora telemetry --input /tmp/no_such.json
# → run JSON not found: /tmp/no_such.json. Provide the path to a KORA run or report JSON file with --input.

# Directory: exit 1, clean message
kora telemetry --input /tmp
# → '/tmp' is a directory, not a file. Provide the path to a KORA run or report JSON file with --input.
```

---

Fixes Krako-Labs/KORA#208