### PR TITLE
docs: cross-link local validation reviewer packet

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -24,6 +24,7 @@ KORA control layer architecture.
 - [KORA Public Language Guide](claims/kora-public-language-guide.md)
 - [Telemetry and observability counters](telemetry-and-observability.md#current-public-counters)
 - [Testing and validation strategy](testing-and-validation-strategy.md)
+- [Local validation reviewer packet](benchmarks/local-validation-reviewer-packet.md)
 - [Research agenda](research-agenda.md)
 - [Whitepaper](whitepaper.md)
 


### PR DESCRIPTION
## Summary

Add a direct docs-index link to the local validation reviewer packet next to the existing testing and validation entry point so reviewers can find the packet without scanning the full evidence section.

Closes #202.

## Type of change

- [x] Docs only
- [ ] CLI / example
- [ ] Benchmark / evidence
- [ ] Code / tests
- [ ] Security-sensitive

## Verification

- [x] Validation commands were run or marked not applicable.
- [x] Claim hygiene checked.
- [x] No unsupported production, API-cost, benchmark, broad workload, or energy claims added.
- [x] No raw benchmark JSON artifacts committed.
- [x] No local absolute paths introduced.
- [x] No release, tag, package-version, or release-asset changes unless explicitly approved.

List commands run and results:

```text
git diff --check
```

## Scope check

- [x] No unrelated refactors
- [x] No public surface expansion without discussion
- [x] Deterministic-first behavior preserved
- [x] No hidden model calls introduced
- [x] README, docs, examples, and templates remain factual and alpha-scoped

## Notes for reviewer

The packet link already exists in the deeper evidence index. This change adds one earlier cross-link near the validation overview only.
