### PR TITLE
Add KORA Doctor CLI

### DIFF
--- a/OPEN_THIS_FIRST.md
+++ b/OPEN_THIS_FIRST.md
@@ -2,7 +2,7 @@
 
 Status: current public project breadcrumb.
 
-Last updated by: Goal 082B.
+Last updated by: Goal 083.
 
 ## Current Status
 
@@ -19,6 +19,7 @@ Current state:
 - a deterministic classification example pack exists under `examples/deterministic_classification/`, using KORA `TaskGraph` execution across support-ticket routing, issue triage, incident severity routing, document type routing, and log/event classification.
 - a KORA Doctor example exists under `examples/kora_doctor/`, using KORA `TaskGraph` execution to inspect a synthetic workload and explain deterministic candidates, provider-needed candidates, route rationale, counters, and next steps.
 - the KORA Doctor example now includes a report pack mode across four bundled offline workloads and a README refresh proposal for examples-driven positioning.
+- `kora doctor` is now a first-class CLI command for running the offline Doctor workload-control report against a workload JSON file or all bundled Doctor workloads.
 - the public README and docs index now position KORA as an AI Workload Control Layer, with examples-first onboarding and explicit claim boundaries.
 - the breadcrumb/review-hub pattern has been extracted into a reusable Project Operating System package and validated on KORA as a continuation surface.
 - the active branch has a public-safe PR readiness packet with caveats.
@@ -26,15 +27,31 @@ Current state:
 
 ## Current Branch
 
-- branch: `goal082b_narrative_repositioning`
+- branch: `goal083_kora_doctor_cli`
 - public truth: `origin/main`
 - branch pushed to: not pushed in this worktree
-- open PR: none for Goal 082B
-- base commit: `b49617ce0402c3a73504ad3490dd668f0797891f`
+- open PR: none for Goal 083
+- base commit: `009f11601161fc1d8944e14f3869309e86239e28`
 
 ## Last Completed Goal
 
-Goal 082B - KORA Narrative Repositioning and README Transformation.
+Goal 083 - Implement KORA Doctor CLI.
+
+Goal 083 promoted the KORA Doctor example into a first-class CLI command. Users can now run a single offline workload-control report with `python3 -m kora doctor examples/kora_doctor/customer_support_workload.json` or an aggregate bundled report with `python3 -m kora doctor --all examples/kora_doctor/`.
+
+Primary report:
+
+- [Goal 083 KORA Doctor CLI](docs/reports/goal083_kora_doctor_cli.md)
+
+Updated public-facing docs:
+
+- [README](README.md)
+- [Documentation index](docs/README.md)
+- [KORA Doctor README](examples/kora_doctor/README.md)
+
+Claim boundary: In this offline CLI example, KORA Doctor identifies deterministic candidates and provider-needed candidates in sample workloads without making provider calls. It does not claim production diagnostic accuracy, automatic cost reduction, real API-cost proof, benchmark superiority, or broad workload superiority.
+
+Previous completed Goal: Goal 082B - KORA Narrative Repositioning and README Transformation.
 
 Goal 082B repositioned KORA public documentation around the AI Workload Control Layer narrative. The README now starts from developer-facing workload control, explains why not every task should be treated as a model problem, and foregrounds KORA Doctor plus deterministic classification examples.
 
@@ -185,6 +202,7 @@ Primary report:
 ## Primary Reports
 
 - [Review hub](REVIEW_HUB.md)
+- [Goal 083 KORA Doctor CLI](docs/reports/goal083_kora_doctor_cli.md)
 - [Goal 082B narrative repositioning](docs/reports/goal082b_narrative_repositioning.md)
 - [KORA Workload Control Layer](docs/vision/kora_workload_control_layer.md)
 - [Goal 082A KORA Doctor report pack](docs/reports/goal082a_kora_doctor_report_pack.md)
@@ -221,12 +239,12 @@ KORA makes AI workloads routable. The current KRK public alpha shows how workloa
 
 ## Recommended Next Goal
 
-Goal 083 - Public reviewer walkthrough and example catalog refresh.
+Goal 084 - Public reviewer walkthrough and example catalog refresh.
 
 Recommended scope:
 
-- review the new README narrative from a fresh visitor perspective.
-- verify KORA Doctor and deterministic classification quick starts.
+- review the README and KORA Doctor CLI narrative from a fresh visitor perspective.
+- verify KORA Doctor CLI, KORA Doctor example, and deterministic classification quick starts.
 - refresh contributor-facing example catalog pointers if needed.
 - preserve current evidence boundaries and avoid production or superiority claims.
 

--- a/README.md
+++ b/README.md
@@ -60,9 +60,9 @@ Current implemented surfaces include:
 
 - List runnable examples: `python3 -m kora examples list`
 - Run offline examples through the KORA example runner: `python3 -m kora run <example>`
-- Run KORA Doctor sample workload inspection.
+- Run KORA Doctor sample workload inspection from the first-class CLI: `python3 -m kora doctor examples/kora_doctor/customer_support_workload.json`
 - Run the deterministic classification expansion pack.
-- Run first-value CLI paths: `kora inspect`, `kora compare`, `kora run`, and `kora report`
+- Run first-value CLI paths: `kora inspect`, `kora compare`, `kora run`, `kora doctor`, and `kora report`
 - Execute deterministic sample tasks through KORA `TaskGraph` paths.
 - Produce local JSON and Markdown/text reports from bundled examples.
 
@@ -74,6 +74,8 @@ Start here:
 
 ```bash
 python3 -m kora examples list
+python3 -m kora doctor examples/kora_doctor/customer_support_workload.json
+python3 -m kora doctor --all examples/kora_doctor/
 python3 examples/kora_doctor/run.py
 python3 examples/kora_doctor/run.py --all
 python3 examples/deterministic_classification/run.py
@@ -99,7 +101,19 @@ Run the default Doctor workload:
 python3 examples/kora_doctor/run.py
 ```
 
+Run a workload through the first-class CLI:
+
+```bash
+python3 -m kora doctor examples/kora_doctor/customer_support_workload.json
+```
+
 Run the Doctor report pack across bundled sample workloads:
+
+```bash
+python3 -m kora doctor --all examples/kora_doctor/
+```
+
+The example script remains available:
 
 ```bash
 python3 examples/kora_doctor/run.py --all \
@@ -121,6 +135,7 @@ Docs:
 - [KORA Doctor README](examples/kora_doctor/README.md)
 - [Goal 082 KORA Doctor example](docs/reports/goal082_kora_doctor_example.md)
 - [Goal 082A KORA Doctor report pack](docs/reports/goal082a_kora_doctor_report_pack.md)
+- [Goal 083 KORA Doctor CLI](docs/reports/goal083_kora_doctor_cli.md)
 
 ### Deterministic Classification
 

--- a/REVIEW_HUB.md
+++ b/REVIEW_HUB.md
@@ -2,7 +2,7 @@
 
 Status: current public review and continuation hub.
 
-Last updated by: Goal 082B.
+Last updated by: Goal 083.
 
 ## Project Identity
 
@@ -14,11 +14,11 @@ KRK means KORA Routing Kernel. KRK is the deterministic-first execution routing 
 
 - repository: `https://github.com/Krako-Labs/KORA`
 - public truth branch: `origin/main`
-- active evidence branch: `goal082b_narrative_repositioning`
-- worktree label: `goal082b_narrative_repositioning`
+- active evidence branch: `goal083_kora_doctor_cli`
+- worktree label: `goal083_kora_doctor_cli`
 - branch pushed to: not pushed in this worktree
-- open PR: none for Goal 082B
-- base commit: `b49617ce0402c3a73504ad3490dd668f0797891f`
+- open PR: none for Goal 083
+- base commit: `009f11601161fc1d8944e14f3869309e86239e28`
 
 ## Current State Summary
 
@@ -36,6 +36,7 @@ KORA now has a public-safe first-value path and an evidence package that covers:
 - deterministic classification example pack with KORA `TaskGraph` execution across support-ticket routing, issue triage, incident severity routing, document type routing, and log/event classification.
 - KORA Doctor first-value developer example with KORA `TaskGraph` execution, deterministic candidate/provider-needed candidate inspection, route rationale, counters, and next-step recommendations.
 - KORA Doctor report pack with four bundled offline workloads, aggregate report mode, and a README refresh proposal for examples-driven routing/control positioning.
+- first-class `kora doctor` CLI command for offline single-workload and aggregate Doctor reports.
 - README and documentation index now present KORA as an AI Workload Control Layer with examples-first onboarding and explicit safe claim boundaries.
 - reusable Project Operating System templates, prompts, and adoption standard.
 - validated Project Operating System continuation path for KORA.
@@ -72,6 +73,7 @@ This is a sufficient recent history backfill, not a complete reconstruction.
 | Goal 082 | Added an offline KORA Doctor example that inspects a synthetic workload and explains deterministic versus provider-needed candidates without provider calls. | [Goal 082 KORA Doctor example](docs/reports/goal082_kora_doctor_example.md) |
 | Goal 082A | Expanded KORA Doctor into a report pack across four offline workloads and added a README refresh proposal. | [Goal 082A KORA Doctor report pack](docs/reports/goal082a_kora_doctor_report_pack.md) |
 | Goal 082B | Repositioned README and docs navigation around KORA as an AI Workload Control Layer while preserving current evidence boundaries. | [Goal 082B narrative repositioning](docs/reports/goal082b_narrative_repositioning.md) |
+| Goal 083 | Promoted KORA Doctor into a first-class offline CLI command for single-workload and aggregate workload-control reports. | [Goal 083 KORA Doctor CLI](docs/reports/goal083_kora_doctor_cli.md) |
 
 ## Evidence Index
 
@@ -98,6 +100,7 @@ Generated summaries:
 Current reviewer path:
 
 - [Goal 082B narrative repositioning](docs/reports/goal082b_narrative_repositioning.md)
+- [Goal 083 KORA Doctor CLI](docs/reports/goal083_kora_doctor_cli.md)
 - [KORA Workload Control Layer](docs/vision/kora_workload_control_layer.md)
 - [Goal 082A KORA Doctor report pack](docs/reports/goal082a_kora_doctor_report_pack.md)
 - [Goal 082A README refresh proposal](docs/reports/goal082a_readme_refresh_proposal.md)
@@ -139,6 +142,7 @@ Supported:
 - KORA has a deterministic classification example pack where KORA routes `21` of `32` synthetic sample classification tasks to deterministic handlers, avoiding simulated provider/model invocation for those sample tasks while making `0` provider calls.
 - KORA has an offline Doctor example where KORA Doctor identifies deterministic candidates and provider-needed candidates in a sample workload without making provider calls.
 - KORA has an offline Doctor report pack where KORA Doctor identifies deterministic candidates and provider-needed candidates across four bundled sample workloads without making provider calls.
+- KORA has a first-class `kora doctor` CLI command for running the same offline Doctor inspection over sample workload JSON files and bundled workload directories.
 - Current evidence supports bounded statements about route selectivity, dry-run runtime integration, provider-path validation, bounded H100 execution, expanded H100 representativeness, and fixture-derived output fidelity.
 - KORA has reusable public-safe Project Operating System templates for breadcrumbs, review hubs, ADRs, reports, evidence, claim registries, bootstrap checklists, and project prompts.
 
@@ -173,6 +177,8 @@ First-value CLI:
 kora inspect
 kora compare
 kora run
+kora doctor examples/kora_doctor/customer_support_workload.json
+kora doctor --all examples/kora_doctor/
 kora report --json-out /tmp/kora-first-value.json --md-out /tmp/kora-first-value.md
 ```
 
@@ -182,6 +188,8 @@ Module form:
 python3 -m kora inspect
 python3 -m kora compare
 python3 -m kora run
+python3 -m kora doctor examples/kora_doctor/customer_support_workload.json
+python3 -m kora doctor --all examples/kora_doctor/
 python3 -m kora report --json-out /tmp/kora-first-value.json --md-out /tmp/kora-first-value.md
 ```
 
@@ -337,10 +345,10 @@ Boundary: this is positioning grounded in current examples and evidence. It does
 
 ## Recommended Next Goals
 
-1. Goal 083 - Public reviewer walkthrough and example catalog refresh.
-2. Goal 084 - Contributor issue seed for examples-first onboarding.
-3. Goal 085 - Contributor issue seed for first-value examples.
-4. Goal 086 - Wheel and source distribution smoke validation.
+1. Goal 084 - Public reviewer walkthrough and example catalog refresh.
+2. Goal 085 - Contributor issue seed for examples-first onboarding.
+3. Goal 086 - Contributor issue seed for first-value examples.
+4. Goal 087 - Wheel and source distribution smoke validation.
 
 ## How To Resume With ChatGPT
 
@@ -348,7 +356,7 @@ Paste a new Goal with this instruction:
 
 ```text
 Start by reading OPEN_THIS_FIRST.md and REVIEW_HUB.md.
-Use the active branch goal082b_narrative_repositioning.
+Use the active branch goal083_kora_doctor_cli.
 Keep public/private and claim boundaries from REVIEW_HUB.md.
 Update OPEN_THIS_FIRST.md and REVIEW_HUB.md before committing unless explicitly exempted.
 ```

--- a/docs/README.md
+++ b/docs/README.md
@@ -15,6 +15,7 @@ The current public examples are offline and synthetic. They demonstrate routing/
 - [Review hub](../REVIEW_HUB.md)
 - [KORA Workload Control Layer vision](vision/kora_workload_control_layer.md)
 - [KORA Doctor README](../examples/kora_doctor/README.md)
+- [Goal 083 KORA Doctor CLI](reports/goal083_kora_doctor_cli.md)
 - [Deterministic classification example pack README](../examples/deterministic_classification/README.md)
 - [Current v0.3.0-alpha prerelease](https://github.com/Krako-Labs/KORA/releases/tag/v0.3.0-alpha)
 - [KORA Category Thesis](vision/2026-05-06-kora-category-thesis.md)
@@ -136,6 +137,7 @@ KORA control layer architecture.
 ## Reports
 
 - [Goal 082B narrative repositioning](reports/goal082b_narrative_repositioning.md)
+- [Goal 083 KORA Doctor CLI](reports/goal083_kora_doctor_cli.md)
 - [Goal 082A KORA Doctor report pack](reports/goal082a_kora_doctor_report_pack.md)
 - [Goal 082A README refresh proposal](reports/goal082a_readme_refresh_proposal.md)
 - [Goal 082 KORA Doctor example](reports/goal082_kora_doctor_example.md)
@@ -208,6 +210,8 @@ Core local commands:
 ```bash
 python3 -m kora --help
 python3 -m kora examples list
+python3 -m kora doctor examples/kora_doctor/customer_support_workload.json
+python3 -m kora doctor --all examples/kora_doctor/
 python3 examples/kora_doctor/run.py
 python3 examples/kora_doctor/run.py --all
 python3 examples/deterministic_classification/run.py

--- a/docs/reports/goal083_kora_doctor_cli.md
+++ b/docs/reports/goal083_kora_doctor_cli.md
@@ -1,0 +1,124 @@
+# Goal 083 KORA Doctor CLI
+
+## Motivation
+
+Goal 083 promotes the offline KORA Doctor example into a first-class CLI command. The example already showed how KORA can inspect sample workloads and identify deterministic candidates and provider-needed candidates through KORA `TaskGraph` execution. The CLI makes that developer experience available directly as `kora doctor`.
+
+## User-Facing Walkthrough
+
+Run a single workload-control report:
+
+```bash
+python3 -m kora doctor examples/kora_doctor/customer_support_workload.json
+```
+
+Run the aggregate report pack across bundled Doctor workloads:
+
+```bash
+python3 -m kora doctor --all examples/kora_doctor/
+```
+
+Write structured output:
+
+```bash
+python3 -m kora doctor examples/kora_doctor/workloads/customer_support_workload.json \
+  --json-out /tmp/kora_doctor_customer_support.json \
+  --report-md /tmp/kora_doctor_customer_support.md
+```
+
+The CLI output includes:
+
+- workload name.
+- total tasks.
+- deterministic candidates.
+- provider-needed candidates.
+- suggested deterministic handlers.
+- provider/model fallback reasons.
+- avoided simulated provider/model invocations.
+- provider calls actually made: `0`.
+
+## Implementation Summary
+
+- Added a first-class `doctor` subcommand to `kora/cli.py`.
+- Reused the existing KORA Doctor implementation from `examples/kora_doctor/run.py`.
+- Preserved the example script path for compatibility.
+- Added aggregate-directory support to the Doctor summary builder.
+- Added report output lines for workload identity and avoided simulated provider/model invocations.
+- Added focused CLI tests in `tests/test_kora_doctor_cli.py`.
+- Updated README, docs index, KORA Doctor README, `OPEN_THIS_FIRST.md`, and `REVIEW_HUB.md`.
+
+The command stays offline and does not call external APIs.
+
+## Command Examples
+
+Single workload:
+
+```bash
+python3 -m kora doctor examples/kora_doctor/customer_support_workload.json
+```
+
+Aggregate workloads:
+
+```bash
+python3 -m kora doctor --all examples/kora_doctor/
+```
+
+Example catalog:
+
+```bash
+python3 -m kora examples list
+```
+
+## Validation Results
+
+Validation was run from the Goal 083 worktree:
+
+```bash
+python3 -m kora doctor examples/kora_doctor/customer_support_workload.json
+```
+
+Result: passed. Output reported `kora_doctor_customer_support_workload_v0`, `6` total tasks, `4` deterministic candidates, `2` provider-needed candidates, `4` avoided simulated provider/model invocations, and `0` provider calls actually made.
+
+```bash
+python3 -m kora doctor --all examples/kora_doctor/
+```
+
+Result: passed. Output reported `4` workloads, `25` total tasks, `16` deterministic candidates, `9` provider-needed candidates, `16` avoided simulated provider/model invocations, and `0` provider calls actually made.
+
+```bash
+python3 -m kora examples list
+```
+
+Result: passed. Output included `kora_doctor: offline doctor-style workload inspection example`.
+
+```bash
+python3 -m pytest tests/test_kora_doctor_cli.py tests/test_first_value_cli.py tests/test_executor.py tests/test_kora_doctor_example.py tests/test_kora_doctor_report_pack.py
+```
+
+Result: passed, `43 passed in 6.55s`.
+
+## Limitations
+
+- The CLI currently operates over the bundled offline Doctor workload format.
+- The workload examples are synthetic.
+- Provider-needed routes are reported as recommendations; no provider calls are made.
+- The CLI is not a production diagnostic system.
+
+## Claim Boundaries
+
+Supported narrow wording:
+
+> In this offline CLI example, KORA Doctor identifies deterministic candidates and provider-needed candidates in sample workloads without making provider calls.
+
+Not claimed:
+
+- production diagnostic accuracy.
+- automatic cost reduction.
+- real API-cost proof.
+- benchmark superiority.
+- broad workload superiority.
+- model replacement.
+
+## Recommended Next Goal
+
+Add `kora doctor --json-out` usage to a lightweight onboarding quickstart and define the minimal external workload schema expected by third-party users.

--- a/examples/kora_doctor/README.md
+++ b/examples/kora_doctor/README.md
@@ -8,7 +8,21 @@ Run from the repository root:
 python3 examples/kora_doctor/run.py
 ```
 
+Run a workload through the first-class CLI:
+
+```bash
+python3 -m kora doctor examples/kora_doctor/customer_support_workload.json
+```
+
 Write structured JSON and a report:
+
+```bash
+python3 -m kora doctor examples/kora_doctor/workloads/customer_support_workload.json \
+  --json-out /tmp/kora_doctor_customer_support.json \
+  --report-md /tmp/kora_doctor_customer_support.md
+```
+
+The example script remains available:
 
 ```bash
 python3 examples/kora_doctor/run.py \
@@ -17,6 +31,12 @@ python3 examples/kora_doctor/run.py \
 ```
 
 Run the full Doctor report pack across all bundled sample workloads:
+
+```bash
+python3 -m kora doctor --all examples/kora_doctor/
+```
+
+The example script remains available for the same report pack:
 
 ```bash
 python3 examples/kora_doctor/run.py --all \
@@ -55,4 +75,4 @@ The default sample workload is [workload.json](workload.json). Additional worklo
 
 Expected counters are in [expected_counters.json](expected_counters.json) and [expected_counters_all.json](expected_counters_all.json).
 
-Claim boundary: this is a first-value developer report pack over synthetic data. It does not claim production diagnostic accuracy, automatic cost reduction, real API-cost proof, benchmark superiority, broad workload superiority, or production proxy readiness.
+Claim boundary: In this offline CLI example, KORA Doctor identifies deterministic candidates and provider-needed candidates in sample workloads without making provider calls. This is a first-value developer report pack over synthetic data. It does not claim production diagnostic accuracy, automatic cost reduction, real API-cost proof, benchmark superiority, broad workload superiority, or production proxy readiness.

--- a/examples/kora_doctor/run.py
+++ b/examples/kora_doctor/run.py
@@ -31,10 +31,13 @@ def load_workload(path: Path = DEFAULT_WORKLOAD) -> dict[str, Any]:
     return json.loads(path.read_text(encoding="utf-8"))
 
 
-def sample_workload_paths() -> list[Path]:
-    paths = [DEFAULT_WORKLOAD]
-    if WORKLOADS_DIR.exists():
-        paths.extend(sorted(WORKLOADS_DIR.glob("*.json")))
+def sample_workload_paths(workloads_root: Path | None = None) -> list[Path]:
+    root = workloads_root or EXAMPLE_DIR
+    default_workload = root / "workload.json"
+    workloads_dir = root / "workloads"
+    paths = [default_workload]
+    if workloads_dir.exists():
+        paths.extend(sorted(workloads_dir.glob("*.json")))
     return paths
 
 
@@ -162,8 +165,12 @@ def build_doctor_summary(
     return summary
 
 
-def build_aggregate_summary(*, json_out: Path | None = None) -> dict[str, Any]:
-    workload_summaries = [build_doctor_summary(path) for path in sample_workload_paths()]
+def build_aggregate_summary(
+    workloads_root: Path | None = None,
+    *,
+    json_out: Path | None = None,
+) -> dict[str, Any]:
+    workload_summaries = [build_doctor_summary(path) for path in sample_workload_paths(workloads_root)]
     total_tasks = sum(item["total_tasks"] for item in workload_summaries)
     deterministic_candidates = sum(item["deterministic_candidates"] for item in workload_summaries)
     provider_needed_candidates = sum(item["provider_needed_candidates"] for item in workload_summaries)
@@ -188,6 +195,7 @@ def build_aggregate_summary(*, json_out: Path | None = None) -> dict[str, Any]:
     summary: dict[str, Any] = {
         "ok": all(item["ok"] for item in workload_summaries) and provider_calls == 0,
         "mode": "kora_doctor_report_pack",
+        "workloads_root": str(workloads_root or EXAMPLE_DIR),
         "workload_count": len(workload_summaries),
         "workload_ids": [item["workload_id"] for item in workload_summaries],
         "total_tasks": total_tasks,
@@ -222,6 +230,7 @@ def render_text_report(summary: dict[str, Any]) -> str:
     lines = [
         title,
         "",
+        f"Workload: {summary['workload_id']}" if summary["mode"] != "kora_doctor_report_pack" else f"Workloads: {summary['workload_count']}",
         f"Total tasks: {summary['total_tasks']}",
         f"Deterministic candidates: {summary['deterministic_candidates']}",
         f"Provider-needed candidates: {summary['provider_needed_candidates']}",
@@ -236,6 +245,7 @@ def render_text_report(summary: dict[str, Any]) -> str:
     lines.extend(
         [
             "",
+            f"Avoided simulated provider/model invocations: {summary['avoided_provider_invocations']}",
             f"Provider calls actually made: {summary['provider_calls_actually_made']}",
         "",
         ]

--- a/kora/cli.py
+++ b/kora/cli.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import argparse
+import importlib.util
 import json
 import os
 import subprocess
@@ -35,6 +36,10 @@ def _default_md_out(input_path: Path) -> Path:
 
 def _examples_root() -> Path:
     return Path(__file__).resolve().parent.parent / "examples"
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parent.parent
 
 
 def _example_descriptions() -> dict[str, str]:
@@ -76,6 +81,73 @@ def _discover_examples() -> list[dict[str, object]]:
     return examples
 
 
+def _load_doctor_module():
+    doctor_path = _examples_root() / "kora_doctor" / "run.py"
+    spec = importlib.util.spec_from_file_location("kora_doctor_cli_runtime", doctor_path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"failed to load KORA Doctor module from {doctor_path}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _resolve_doctor_workload_path(path_text: str) -> Path:
+    path = Path(path_text)
+    if path.exists():
+        return path
+
+    doctor_root = _examples_root() / "kora_doctor"
+    workload_candidate = doctor_root / "workloads" / path.name
+    if path.parent.name == "kora_doctor" and workload_candidate.exists():
+        return workload_candidate
+
+    return path
+
+
+def _run_doctor_command(
+    workload_path: str | None,
+    *,
+    all_workloads: bool,
+    json_out: str | None,
+    report_md: str | None,
+) -> int:
+    doctor = _load_doctor_module()
+    try:
+        if all_workloads:
+            workloads_root = Path(workload_path) if workload_path else _examples_root() / "kora_doctor"
+            if not workloads_root.exists() or not workloads_root.is_dir():
+                print(f"KORA Doctor workload directory not found: {workloads_root}", file=sys.stderr)
+                return 2
+            summary = doctor.build_aggregate_summary(
+                workloads_root=workloads_root,
+                json_out=Path(json_out) if json_out else None,
+            )
+        else:
+            resolved_workload = (
+                _resolve_doctor_workload_path(workload_path)
+                if workload_path
+                else _examples_root() / "kora_doctor" / "workload.json"
+            )
+            if not resolved_workload.exists() or not resolved_workload.is_file():
+                print(f"KORA Doctor workload JSON not found: {resolved_workload}", file=sys.stderr)
+                return 2
+            summary = doctor.build_doctor_summary(
+                resolved_workload,
+                json_out=Path(json_out) if json_out else None,
+            )
+    except (json.JSONDecodeError, KeyError, RuntimeError, ValueError) as e:
+        print(f"KORA Doctor failed: {e}", file=sys.stderr)
+        return 1
+
+    report = doctor.render_text_report(summary)
+    if report_md:
+        report_path = Path(report_md)
+        report_path.parent.mkdir(parents=True, exist_ok=True)
+        report_path.write_text(report, encoding="utf-8")
+    print(report, end="")
+    return 0 if summary["ok"] else 1
+
+
 def _print_examples_list() -> None:
     examples = _discover_examples()
     if not examples:
@@ -99,7 +171,7 @@ def _run_example(example_name: str, extra_args: list[str]) -> int:
         return 2
 
     command = [sys.executable, str(example_map[example_name]), *extra_args]
-    repo_root = Path(__file__).resolve().parent.parent
+    repo_root = _repo_root()
     env = os.environ.copy()
     existing_pythonpath = env.get("PYTHONPATH")
     env["PYTHONPATH"] = (
@@ -235,6 +307,23 @@ def main(argv: list[str] | None = None) -> int:
     )
     compare_parser.add_argument("--json-out", help="optional path for structured JSON output")
 
+    doctor_parser = subparsers.add_parser(
+        "doctor",
+        help="inspect a workload for deterministic and provider-needed candidates",
+        description=(
+            "Run the offline KORA Doctor workload-control report for a workload JSON file, "
+            "or aggregate bundled workloads with --all."
+        ),
+    )
+    doctor_parser.add_argument(
+        "workload_path",
+        nargs="?",
+        help="workload JSON path, or workload directory when used with --all",
+    )
+    doctor_parser.add_argument("--all", action="store_true", help="run all workloads in a Doctor workload directory")
+    doctor_parser.add_argument("--json-out", help="optional path for structured JSON output")
+    doctor_parser.add_argument("--report-md", help="optional path for the rendered text report")
+
     run_parser = subparsers.add_parser(
         "run",
         help="run the public-safe first-value fixture path or a named example",
@@ -291,6 +380,14 @@ def main(argv: list[str] | None = None) -> int:
 
     if args.command == "compare":
         return _run_first_value_step("compare", json_out=args.json_out)
+
+    if args.command == "doctor":
+        return _run_doctor_command(
+            args.workload_path,
+            all_workloads=args.all,
+            json_out=args.json_out,
+            report_md=args.report_md,
+        )
 
     if args.command == "run":
         if args.example is None:

--- a/tests/test_first_value_cli.py
+++ b/tests/test_first_value_cli.py
@@ -35,12 +35,13 @@ def test_top_level_help_lists_first_value_commands() -> None:
     assert completed.returncode == 0
     assert "inspect" in completed.stdout
     assert "compare" in completed.stdout
+    assert "doctor" in completed.stdout
     assert "run" in completed.stdout
     assert "report" in completed.stdout
 
 
 def test_first_value_command_help_works() -> None:
-    for command in ("inspect", "compare", "run", "report"):
+    for command in ("inspect", "compare", "doctor", "run", "report"):
         completed = _run_kora(command, "--help")
         assert completed.returncode == 0
         assert command in completed.stdout

--- a/tests/test_kora_doctor_cli.py
+++ b/tests/test_kora_doctor_cli.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+def _run_kora(*args: str) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    env.pop("OPENAI_API_KEY", None)
+    env.pop("ANTHROPIC_API_KEY", None)
+    return subprocess.run(
+        [sys.executable, "-m", "kora", *args],
+        check=False,
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+
+def test_kora_doctor_help_is_available() -> None:
+    completed = _run_kora("doctor", "--help")
+
+    assert completed.returncode == 0
+    assert "workload JSON path" in completed.stdout
+    assert "--all" in completed.stdout
+
+
+def test_kora_doctor_single_workload_uses_existing_doctor_logic(tmp_path: Path) -> None:
+    json_out = tmp_path / "doctor.json"
+    report_md = tmp_path / "doctor.md"
+
+    completed = _run_kora(
+        "doctor",
+        "examples/kora_doctor/workloads/customer_support_workload.json",
+        "--json-out",
+        str(json_out),
+        "--report-md",
+        str(report_md),
+    )
+
+    assert completed.returncode == 0
+    assert "KORA Doctor Example" in completed.stdout
+    assert "Workload: kora_doctor_customer_support_workload_v0" in completed.stdout
+    assert "Provider calls actually made: 0" in completed.stdout
+    saved = json.loads(json_out.read_text(encoding="utf-8"))
+    assert saved["mode"] == "kora_doctor_example"
+    assert saved["workload_id"] == "kora_doctor_customer_support_workload_v0"
+    assert saved["total_tasks"] == 6
+    assert saved["deterministic_candidates"] == 4
+    assert saved["provider_needed_candidates"] == 2
+    assert saved["provider_calls_actually_made"] == 0
+    assert report_md.read_text(encoding="utf-8") == completed.stdout
+
+
+def test_kora_doctor_single_workload_accepts_friendly_example_path() -> None:
+    completed = _run_kora("doctor", "examples/kora_doctor/customer_support_workload.json")
+
+    assert completed.returncode == 0
+    assert "Workload: kora_doctor_customer_support_workload_v0" in completed.stdout
+    assert "Avoided simulated provider/model invocations: 4" in completed.stdout
+
+
+def test_kora_doctor_aggregate_mode_uses_workload_directory(tmp_path: Path) -> None:
+    json_out = tmp_path / "doctor_pack.json"
+
+    completed = _run_kora(
+        "doctor",
+        "--all",
+        "examples/kora_doctor/",
+        "--json-out",
+        str(json_out),
+    )
+
+    assert completed.returncode == 0
+    assert "KORA Doctor Report Pack" in completed.stdout
+    assert "Workloads: 4" in completed.stdout
+    assert "Provider calls actually made: 0" in completed.stdout
+    saved = json.loads(json_out.read_text(encoding="utf-8"))
+    assert saved["mode"] == "kora_doctor_report_pack"
+    assert saved["workload_count"] == 4
+    assert saved["total_tasks"] == 25
+    assert saved["deterministic_candidates"] == 16
+    assert saved["provider_needed_candidates"] == 9
+    assert saved["provider_calls_actually_made"] == 0


### PR DESCRIPTION
## Summary
- Adds first-class `kora doctor` CLI support for offline KORA Doctor workload-control reports.
- Supports single workload JSON mode and aggregate `--all` mode over `examples/kora_doctor/`.
- Reuses the existing KORA Doctor example logic, updates docs/handoff files, and adds focused CLI tests.

## Validation
- `python3 -m kora doctor examples/kora_doctor/customer_support_workload.json` -> passed
- `python3 -m kora doctor --all examples/kora_doctor/` -> passed
- `python3 -m kora examples list` -> passed
- `python3 -m pytest tests/test_kora_doctor_cli.py tests/test_first_value_cli.py tests/test_executor.py tests/test_kora_doctor_example.py tests/test_kora_doctor_report_pack.py` -> passed (`43 passed`)
- `python3 scripts/check_markdown_links_goal082b.py` -> passed
- `git diff --check origin/main...HEAD` -> passed

## Audits
- Scope audit: limited to KORA Doctor CLI, Doctor example support, docs, reports, and tests.
- Boundary audit: no local-only ChatGPT context, private paths, Permea references, AI Champion/K-EXAONE/H100/private-resource references, or secret-like tokens in committed content.
- Claim audit: wording remains within offline sample-workload evidence and explicit non-claim boundaries.
- Documentation audit: README/docs, KORA Doctor README, OPEN_THIS_FIRST.md, REVIEW_HUB.md, and Goal 083 report are updated.
