### PR TITLE
Document getkora strategy and first-run acceptance

### DIFF
--- a/OPEN_THIS_FIRST.md
+++ b/OPEN_THIS_FIRST.md
@@ -2,7 +2,7 @@
 
 Status: current public project breadcrumb.
 
-Last updated by: Goal 083B.
+Last updated by: Goal 083C.
 
 ## Current Status
 
@@ -17,6 +17,7 @@ Current state:
 - baseline equivalence and output-fidelity evidence exists over public fixtures.
 - first-value CLI commands exist and the editable-install path has been revalidated for local public-safe onboarding.
 - packaging strategy now documents the PyPI `kora` collision and the planned future distribution name `getkora`; latest-feature testing remains source-install from the current repository.
+- public first-run acceptance testing has been run against the README/source-install path, KORA Doctor, deterministic classification, and PyPI collision wording.
 - a deterministic classification example pack exists under `examples/deterministic_classification/`, using KORA `TaskGraph` execution across support-ticket routing, issue triage, incident severity routing, document type routing, and log/event classification.
 - a KORA Doctor example exists under `examples/kora_doctor/`, using KORA `TaskGraph` execution to inspect a synthetic workload and explain deterministic candidates, provider-needed candidates, route rationale, counters, and next steps.
 - the KORA Doctor example now includes a report pack mode across four bundled offline workloads and a README refresh proposal for examples-driven positioning.
@@ -28,15 +29,25 @@ Current state:
 
 ## Current Branch
 
-- branch: `goal083b_getkora_distribution_strategy`
+- branch: `goal083c_public_first_run_acceptance`
 - public truth: `origin/main`
 - branch pushed to: not pushed in this worktree
-- open PR: none for Goal 083B
-- base commit: `09c28f15413e9c3ed8498a046f5352eb0ad7b791`
+- open PR: none for Goal 083C
+- base commit: `f768a353fa02feb0dcf1f02055ae4c029117ad37` including pending local Goal 083B material
 
 ## Last Completed Goal
 
-Goal 083B - Distribution Strategy and getkora Packaging Plan.
+Goal 083C - Public First-Run Acceptance Test.
+
+Goal 083C tested the README-only reviewer path, fresh source install path, PyPI collision awareness, and five-minute reviewer path using the pending Goal 083B distribution strategy material. It also added a short source-install availability note to the deterministic classification README.
+
+Primary report:
+
+- [Goal 083C public first-run acceptance test](docs/reports/goal083c_public_first_run_acceptance_test.md)
+
+Claim boundary: this goal did not add product features, publish a package, create a release, create a tag, or claim `getkora` is published.
+
+Previous completed Goal: Goal 083B - Distribution Strategy and getkora Packaging Plan.
 
 Goal 083B documented the distribution strategy after verifying that PyPI `kora` is occupied by an unrelated package and that `getkora` has no matching distribution by package-index lookup. The docs now state that latest KORA examples and `kora doctor` should be tested from the current repository/source checkout, while future PyPI distribution is planned under `getkora`.
 

--- a/OPEN_THIS_FIRST.md
+++ b/OPEN_THIS_FIRST.md
@@ -2,7 +2,7 @@
 
 Status: current public project breadcrumb.
 
-Last updated by: Goal 083.
+Last updated by: Goal 083B.
 
 ## Current Status
 
@@ -16,6 +16,7 @@ Current state:
 - bounded H100 subset, repo-owned H100 harness, and expanded H100 representativeness evidence exist.
 - baseline equivalence and output-fidelity evidence exists over public fixtures.
 - first-value CLI commands exist and the editable-install path has been revalidated for local public-safe onboarding.
+- packaging strategy now documents the PyPI `kora` collision and the planned future distribution name `getkora`; latest-feature testing remains source-install from the current repository.
 - a deterministic classification example pack exists under `examples/deterministic_classification/`, using KORA `TaskGraph` execution across support-ticket routing, issue triage, incident severity routing, document type routing, and log/event classification.
 - a KORA Doctor example exists under `examples/kora_doctor/`, using KORA `TaskGraph` execution to inspect a synthetic workload and explain deterministic candidates, provider-needed candidates, route rationale, counters, and next steps.
 - the KORA Doctor example now includes a report pack mode across four bundled offline workloads and a README refresh proposal for examples-driven positioning.
@@ -27,15 +28,26 @@ Current state:
 
 ## Current Branch
 
-- branch: `goal083_kora_doctor_cli`
+- branch: `goal083b_getkora_distribution_strategy`
 - public truth: `origin/main`
 - branch pushed to: not pushed in this worktree
-- open PR: none for Goal 083
-- base commit: `009f11601161fc1d8944e14f3869309e86239e28`
+- open PR: none for Goal 083B
+- base commit: `09c28f15413e9c3ed8498a046f5352eb0ad7b791`
 
 ## Last Completed Goal
 
-Goal 083 - Implement KORA Doctor CLI.
+Goal 083B - Distribution Strategy and getkora Packaging Plan.
+
+Goal 083B documented the distribution strategy after verifying that PyPI `kora` is occupied by an unrelated package and that `getkora` has no matching distribution by package-index lookup. The docs now state that latest KORA examples and `kora doctor` should be tested from the current repository/source checkout, while future PyPI distribution is planned under `getkora`.
+
+Primary artifacts:
+
+- [getkora distribution strategy](docs/packaging/getkora_distribution_strategy.md)
+- [Goal 083B getkora distribution strategy](docs/reports/goal083b_getkora_distribution_strategy.md)
+
+Claim boundary: this goal did not publish a package, create a release, create a tag, create a GitHub Release, reserve a PyPI project, or claim that `pip install getkora` works.
+
+Previous completed Goal: Goal 083 - Implement KORA Doctor CLI.
 
 Goal 083 promoted the KORA Doctor example into a first-class CLI command. Users can now run a single offline workload-control report with `python3 -m kora doctor examples/kora_doctor/customer_support_workload.json` or an aggregate bundled report with `python3 -m kora doctor --all examples/kora_doctor/`.
 
@@ -202,6 +214,8 @@ Primary report:
 ## Primary Reports
 
 - [Review hub](REVIEW_HUB.md)
+- [Goal 083B getkora distribution strategy](docs/reports/goal083b_getkora_distribution_strategy.md)
+- [getkora distribution strategy](docs/packaging/getkora_distribution_strategy.md)
 - [Goal 083 KORA Doctor CLI](docs/reports/goal083_kora_doctor_cli.md)
 - [Goal 082B narrative repositioning](docs/reports/goal082b_narrative_repositioning.md)
 - [KORA Workload Control Layer](docs/vision/kora_workload_control_layer.md)

--- a/README.md
+++ b/README.md
@@ -8,6 +8,38 @@ Many AI systems treat every task as a model problem. Many tasks are actually cla
 
 Current examples are offline and synthetic. They demonstrate KORA's routing/control surfaces, not production readiness, production cost reduction, benchmark superiority, or model replacement.
 
+## Current Availability
+
+Use the current GitHub repository for the latest examples and CLI commands.
+
+Do not use plain `python3 -m pip install kora` for this project. A packaging check on June 18, 2026 found that `kora` on PyPI is already occupied by an unrelated Colab utility package (`kora 0.9.20`). That package is not `Krako-Labs/KORA` and should not be used to test the KORA Doctor CLI.
+
+Planned distribution strategy:
+
+- Public brand: KORA.
+- GitHub repository: `Krako-Labs/KORA`.
+- Future PyPI distribution package: `getkora`.
+- CLI command: `kora`.
+- Python import package: `kora`.
+
+`getkora` is the planned future distribution name; this README does not claim it is published. Until a package is published, install from the current repository:
+
+```bash
+git clone https://github.com/Krako-Labs/KORA.git
+cd KORA
+
+python3 -m venv .venv
+source .venv/bin/activate
+
+python3 -m pip install --upgrade pip setuptools wheel
+python3 -m pip install -e .
+
+python3 -m kora doctor examples/kora_doctor/customer_support_workload.json
+python3 -m kora doctor --all examples/kora_doctor/
+```
+
+Use `python3 -m pip install -e ".[dev]"` when you also need test dependencies.
+
 ## What KORA Is
 
 KORA sits between an AI request and provider/model execution.
@@ -53,10 +85,11 @@ Read more:
 - [KORA Workload Control Layer vision](docs/vision/kora_workload_control_layer.md)
 - [KORA Review Hub](REVIEW_HUB.md)
 - [Open This First](OPEN_THIS_FIRST.md)
+- [getkora distribution strategy](docs/packaging/getkora_distribution_strategy.md)
 
 ## What KORA Can Do Today
 
-Current implemented surfaces include:
+Current implemented surfaces in this GitHub repository include:
 
 - List runnable examples: `python3 -m kora examples list`
 - Run offline examples through the KORA example runner: `python3 -m kora run <example>`
@@ -70,7 +103,7 @@ These are first-value developer examples and bounded evidence paths. They are no
 
 ## Examples
 
-Start here:
+After installing from the current repository, start here:
 
 ```bash
 python3 -m kora examples list
@@ -181,6 +214,7 @@ KORA still includes KRK-oriented evidence and first-value reports. Current evide
 Key evidence and reports:
 
 - [KORA five-minute first-value quickstart](docs/quickstart-five-minute-first-value.md)
+- [getkora distribution strategy](docs/packaging/getkora_distribution_strategy.md)
 - [KRK evidence package](docs/evidence/krk-evidence-package-v0.md)
 - [KRK performance table](docs/evidence/krk-performance-table-v0.md)
 - [KRK route-selectivity results](docs/evidence/krk-route-selectivity-results-v0.md)
@@ -215,6 +249,13 @@ Not claimed:
 KORA uses `pyproject.toml`-based Python packaging.
 
 Packaged support is Python 3.11 or newer, as declared in `pyproject.toml`.
+
+Installation paths:
+
+- PyPI `kora`: do not use for this project; it is an unrelated package.
+- Current latest features: clone `Krako-Labs/KORA` and install from the source checkout with `python3 -m pip install -e .`.
+- Local development and tests: use `python3 -m pip install -e ".[dev]"`.
+- Future package distribution: planned as `getkora`, with CLI command `kora`; do not use `python3 -m pip install getkora` unless a future release explicitly announces publication.
 
 ```bash
 git clone https://github.com/Krako-Labs/KORA.git

--- a/REVIEW_HUB.md
+++ b/REVIEW_HUB.md
@@ -2,7 +2,7 @@
 
 Status: current public review and continuation hub.
 
-Last updated by: Goal 083B.
+Last updated by: Goal 083C.
 
 ## Project Identity
 
@@ -14,11 +14,11 @@ KRK means KORA Routing Kernel. KRK is the deterministic-first execution routing 
 
 - repository: `https://github.com/Krako-Labs/KORA`
 - public truth branch: `origin/main`
-- active evidence branch: `goal083b_getkora_distribution_strategy`
-- worktree label: `goal083b_getkora_distribution_strategy`
+- active evidence branch: `goal083c_public_first_run_acceptance`
+- worktree label: `goal083c_public_first_run_acceptance`
 - branch pushed to: not pushed in this worktree
-- open PR: none for Goal 083B
-- base commit: `09c28f15413e9c3ed8498a046f5352eb0ad7b791`
+- open PR: none for Goal 083C
+- base commit: `f768a353fa02feb0dcf1f02055ae4c029117ad37` including pending local Goal 083B material
 
 ## Current State Summary
 
@@ -34,6 +34,7 @@ KORA now has a public-safe first-value path and an evidence package that covers:
 - baseline equivalence and output-fidelity evaluation.
 - install-revalidated local first-value CLI workflow.
 - distribution strategy documents PyPI `kora` collision, source-install current path, and planned future PyPI distribution name `getkora`.
+- public first-run acceptance testing covers README-only onboarding, fresh source install, KORA Doctor, deterministic classification, and PyPI collision wording.
 - deterministic classification example pack with KORA `TaskGraph` execution across support-ticket routing, issue triage, incident severity routing, document type routing, and log/event classification.
 - KORA Doctor first-value developer example with KORA `TaskGraph` execution, deterministic candidate/provider-needed candidate inspection, route rationale, counters, and next-step recommendations.
 - KORA Doctor report pack with four bundled offline workloads, aggregate report mode, and a README refresh proposal for examples-driven routing/control positioning.
@@ -76,6 +77,7 @@ This is a sufficient recent history backfill, not a complete reconstruction.
 | Goal 082B | Repositioned README and docs navigation around KORA as an AI Workload Control Layer while preserving current evidence boundaries. | [Goal 082B narrative repositioning](docs/reports/goal082b_narrative_repositioning.md) |
 | Goal 083 | Promoted KORA Doctor into a first-class offline CLI command for single-workload and aggregate workload-control reports. | [Goal 083 KORA Doctor CLI](docs/reports/goal083_kora_doctor_cli.md) |
 | Goal 083B | Documented the `getkora` future distribution strategy after verifying the PyPI `kora` collision and current source-install path. | [Goal 083B getkora distribution strategy](docs/reports/goal083b_getkora_distribution_strategy.md) |
+| Goal 083C | Ran public first-run acceptance testing over README onboarding, fresh source install, KORA Doctor, deterministic classification, and PyPI collision wording. | [Goal 083C public first-run acceptance test](docs/reports/goal083c_public_first_run_acceptance_test.md) |
 
 ## Evidence Index
 
@@ -102,6 +104,7 @@ Generated summaries:
 Current reviewer path:
 
 - [Goal 082B narrative repositioning](docs/reports/goal082b_narrative_repositioning.md)
+- [Goal 083C public first-run acceptance test](docs/reports/goal083c_public_first_run_acceptance_test.md)
 - [Goal 083B getkora distribution strategy](docs/reports/goal083b_getkora_distribution_strategy.md)
 - [getkora distribution strategy](docs/packaging/getkora_distribution_strategy.md)
 - [Goal 083 KORA Doctor CLI](docs/reports/goal083_kora_doctor_cli.md)

--- a/REVIEW_HUB.md
+++ b/REVIEW_HUB.md
@@ -2,7 +2,7 @@
 
 Status: current public review and continuation hub.
 
-Last updated by: Goal 083.
+Last updated by: Goal 083B.
 
 ## Project Identity
 
@@ -14,11 +14,11 @@ KRK means KORA Routing Kernel. KRK is the deterministic-first execution routing 
 
 - repository: `https://github.com/Krako-Labs/KORA`
 - public truth branch: `origin/main`
-- active evidence branch: `goal083_kora_doctor_cli`
-- worktree label: `goal083_kora_doctor_cli`
+- active evidence branch: `goal083b_getkora_distribution_strategy`
+- worktree label: `goal083b_getkora_distribution_strategy`
 - branch pushed to: not pushed in this worktree
-- open PR: none for Goal 083
-- base commit: `009f11601161fc1d8944e14f3869309e86239e28`
+- open PR: none for Goal 083B
+- base commit: `09c28f15413e9c3ed8498a046f5352eb0ad7b791`
 
 ## Current State Summary
 
@@ -33,6 +33,7 @@ KORA now has a public-safe first-value path and an evidence package that covers:
 - expanded H100 representativeness measurement.
 - baseline equivalence and output-fidelity evaluation.
 - install-revalidated local first-value CLI workflow.
+- distribution strategy documents PyPI `kora` collision, source-install current path, and planned future PyPI distribution name `getkora`.
 - deterministic classification example pack with KORA `TaskGraph` execution across support-ticket routing, issue triage, incident severity routing, document type routing, and log/event classification.
 - KORA Doctor first-value developer example with KORA `TaskGraph` execution, deterministic candidate/provider-needed candidate inspection, route rationale, counters, and next-step recommendations.
 - KORA Doctor report pack with four bundled offline workloads, aggregate report mode, and a README refresh proposal for examples-driven routing/control positioning.
@@ -74,6 +75,7 @@ This is a sufficient recent history backfill, not a complete reconstruction.
 | Goal 082A | Expanded KORA Doctor into a report pack across four offline workloads and added a README refresh proposal. | [Goal 082A KORA Doctor report pack](docs/reports/goal082a_kora_doctor_report_pack.md) |
 | Goal 082B | Repositioned README and docs navigation around KORA as an AI Workload Control Layer while preserving current evidence boundaries. | [Goal 082B narrative repositioning](docs/reports/goal082b_narrative_repositioning.md) |
 | Goal 083 | Promoted KORA Doctor into a first-class offline CLI command for single-workload and aggregate workload-control reports. | [Goal 083 KORA Doctor CLI](docs/reports/goal083_kora_doctor_cli.md) |
+| Goal 083B | Documented the `getkora` future distribution strategy after verifying the PyPI `kora` collision and current source-install path. | [Goal 083B getkora distribution strategy](docs/reports/goal083b_getkora_distribution_strategy.md) |
 
 ## Evidence Index
 
@@ -100,6 +102,8 @@ Generated summaries:
 Current reviewer path:
 
 - [Goal 082B narrative repositioning](docs/reports/goal082b_narrative_repositioning.md)
+- [Goal 083B getkora distribution strategy](docs/reports/goal083b_getkora_distribution_strategy.md)
+- [getkora distribution strategy](docs/packaging/getkora_distribution_strategy.md)
 - [Goal 083 KORA Doctor CLI](docs/reports/goal083_kora_doctor_cli.md)
 - [KORA Workload Control Layer](docs/vision/kora_workload_control_layer.md)
 - [Goal 082A KORA Doctor report pack](docs/reports/goal082a_kora_doctor_report_pack.md)
@@ -143,6 +147,7 @@ Supported:
 - KORA has an offline Doctor example where KORA Doctor identifies deterministic candidates and provider-needed candidates in a sample workload without making provider calls.
 - KORA has an offline Doctor report pack where KORA Doctor identifies deterministic candidates and provider-needed candidates across four bundled sample workloads without making provider calls.
 - KORA has a first-class `kora doctor` CLI command for running the same offline Doctor inspection over sample workload JSON files and bundled workload directories.
+- KORA's planned future PyPI distribution package name is `getkora`; current latest-feature testing requires source install from the repository.
 - Current evidence supports bounded statements about route selectivity, dry-run runtime integration, provider-path validation, bounded H100 execution, expanded H100 representativeness, and fixture-derived output fidelity.
 - KORA has reusable public-safe Project Operating System templates for breadcrumbs, review hubs, ADRs, reports, evidence, claim registries, bootstrap checklists, and project prompts.
 
@@ -174,6 +179,7 @@ Not supported:
 First-value CLI:
 
 ```bash
+# Install from the current repository/source checkout before running these commands.
 kora inspect
 kora compare
 kora run
@@ -185,6 +191,7 @@ kora report --json-out /tmp/kora-first-value.json --md-out /tmp/kora-first-value
 Module form:
 
 ```bash
+# Install from the current repository/source checkout before running these commands.
 python3 -m kora inspect
 python3 -m kora compare
 python3 -m kora run

--- a/docs/README.md
+++ b/docs/README.md
@@ -31,6 +31,7 @@ python3 -m kora doctor examples/kora_doctor/customer_support_workload.json
 - [Main README](../README.md)
 - [Open this first](../OPEN_THIS_FIRST.md)
 - [Review hub](../REVIEW_HUB.md)
+- [Goal 083C public first-run acceptance test](reports/goal083c_public_first_run_acceptance_test.md)
 - [Goal 083B getkora distribution strategy](reports/goal083b_getkora_distribution_strategy.md)
 - [getkora distribution strategy](packaging/getkora_distribution_strategy.md)
 - [KORA Workload Control Layer vision](vision/kora_workload_control_layer.md)
@@ -158,6 +159,7 @@ KORA control layer architecture.
 ## Reports
 
 - [Goal 082B narrative repositioning](reports/goal082b_narrative_repositioning.md)
+- [Goal 083C public first-run acceptance test](reports/goal083c_public_first_run_acceptance_test.md)
 - [Goal 083B getkora distribution strategy](reports/goal083b_getkora_distribution_strategy.md)
 - [Goal 083 KORA Doctor CLI](reports/goal083_kora_doctor_cli.md)
 - [Goal 082A KORA Doctor report pack](reports/goal082a_kora_doctor_report_pack.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,11 +8,31 @@ KORA is an AI Workload Control Layer. It helps developers inspect AI work, ident
 
 The current public examples are offline and synthetic. They demonstrate routing/control surfaces and bounded evidence, not production readiness or automatic savings.
 
+## Current Availability
+
+Use a current GitHub checkout for the latest KORA examples and CLI commands.
+
+As of the Goal 083B packaging check on June 18, 2026, plain `python3 -m pip install kora` resolves to an unrelated PyPI project named `kora` (`0.9.20`, a Colab utility package), not this `Krako-Labs/KORA` project. Do not use that command to validate `kora doctor`.
+
+The planned future PyPI distribution name is `getkora`; it is not documented as published here. Until a future release explicitly announces a package, install from source:
+
+```bash
+git clone https://github.com/Krako-Labs/KORA.git
+cd KORA
+python3 -m venv .venv
+source .venv/bin/activate
+python3 -m pip install --upgrade pip setuptools wheel
+python3 -m pip install -e .
+python3 -m kora doctor examples/kora_doctor/customer_support_workload.json
+```
+
 ## Start
 
 - [Main README](../README.md)
 - [Open this first](../OPEN_THIS_FIRST.md)
 - [Review hub](../REVIEW_HUB.md)
+- [Goal 083B getkora distribution strategy](reports/goal083b_getkora_distribution_strategy.md)
+- [getkora distribution strategy](packaging/getkora_distribution_strategy.md)
 - [KORA Workload Control Layer vision](vision/kora_workload_control_layer.md)
 - [KORA Doctor README](../examples/kora_doctor/README.md)
 - [Goal 083 KORA Doctor CLI](reports/goal083_kora_doctor_cli.md)
@@ -39,6 +59,7 @@ KORA control layer architecture.
 ## Strategy
 
 - [KORA Routable AI Workloads Master Plan v0.1](strategy/kora-routable-ai-workloads-master-plan-v0-1.md)
+- [getkora distribution strategy](packaging/getkora_distribution_strategy.md)
 
 ## Product
 
@@ -137,6 +158,7 @@ KORA control layer architecture.
 ## Reports
 
 - [Goal 082B narrative repositioning](reports/goal082b_narrative_repositioning.md)
+- [Goal 083B getkora distribution strategy](reports/goal083b_getkora_distribution_strategy.md)
 - [Goal 083 KORA Doctor CLI](reports/goal083_kora_doctor_cli.md)
 - [Goal 082A KORA Doctor report pack](reports/goal082a_kora_doctor_report_pack.md)
 - [Goal 082A README refresh proposal](reports/goal082a_readme_refresh_proposal.md)
@@ -183,6 +205,9 @@ KORA Studio is future planning only. It is not implemented yet.
 Local setup prerequisites:
 
 - Packaged support is Python 3.11 or newer, as declared in `pyproject.toml`.
+- Plain `python3 -m pip install kora` currently resolves to a different PyPI project and should not be used for this repository's latest examples.
+- Future package distribution is planned as `getkora`, but this documentation does not claim it is published.
+- Use a current GitHub checkout plus `python3 -m pip install -e .` for latest CLI examples.
 - Python 3.9.6 has been observed to run the offline `direct_vs_kora` example in one user environment.
 - Treat Python 3.9.6 as a troubleshooting datapoint, not as the advertised package support floor until clean Python 3.9 compatibility testing is completed.
 - KORA uses `pyproject.toml`-based packaging.

--- a/docs/packaging/getkora_distribution_strategy.md
+++ b/docs/packaging/getkora_distribution_strategy.md
@@ -1,0 +1,162 @@
+# getkora Distribution Strategy
+
+## Decision
+
+- Public brand: KORA.
+- GitHub repository: `Krako-Labs/KORA`.
+- Future PyPI distribution package: `getkora`.
+- CLI command: `kora`.
+- Python import package: `kora`.
+
+This document is a packaging strategy, not a release announcement. It does not publish a package, create a release, create a tag, or claim that `getkora` is available for installation today.
+
+## Current PyPI Collision
+
+Plain `python3 -m pip install kora` must not be used for this project.
+
+Observed package-index state on June 18, 2026:
+
+- `python3 -m pip index versions kora` reported `kora (0.9.20)` with many existing versions.
+- Goal 083A isolated install validation found that PyPI `kora 0.9.20` is an unrelated Colab utility package, not `Krako-Labs/KORA`.
+- `python3 -m pip index versions getkora` reported `ERROR: No matching distribution found for getkora`.
+
+Interpretation: `getkora` appears available by package-index lookup, but availability is not ownership. A future release still needs normal PyPI account, project creation, token, Trusted Publisher, and publication checks.
+
+## Current Safe Install Path
+
+Current latest-feature path:
+
+```bash
+git clone https://github.com/Krako-Labs/KORA.git
+cd KORA
+
+python3 -m venv .venv
+source .venv/bin/activate
+
+python3 -m pip install --upgrade pip setuptools wheel
+python3 -m pip install -e .
+
+python3 -m kora doctor examples/kora_doctor/customer_support_workload.json
+```
+
+Development/test path:
+
+```bash
+python3 -m pip install -e ".[dev]"
+```
+
+Do not document `python3 -m pip install getkora` as working until a future packaging goal actually publishes it and validates installation from PyPI.
+
+## Packaging Audit
+
+Current `pyproject.toml` state:
+
+```toml
+[project]
+name = "kora"
+version = "0.1.0a0"
+description = "Open-source execution control for AI systems"
+requires-python = ">=3.11"
+
+[project.urls]
+Homepage = "https://github.com/Krako-Labs/KORA"
+Repository = "https://github.com/Krako-Labs/KORA"
+Issues = "https://github.com/Krako-Labs/KORA/issues"
+
+[project.scripts]
+kora = "kora.cli:main"
+
+[tool.setuptools.packages.find]
+include = ["kora*"]
+```
+
+No `setup.py`, `setup.cfg`, or `MANIFEST.in` file is present in the repository root. Packaging metadata is centralized in `pyproject.toml`.
+
+Package layout:
+
+- Import package: `kora/`.
+- Module entry point: `kora/__main__.py`.
+- CLI implementation: `kora/cli.py`.
+- Console script: `kora = "kora.cli:main"`.
+
+## Future Metadata Changes
+
+For a future PyPI distribution under `getkora`, update package metadata in `pyproject.toml`:
+
+```toml
+[project]
+name = "getkora"
+```
+
+Keep:
+
+```toml
+[project.scripts]
+kora = "kora.cli:main"
+
+[tool.setuptools.packages.find]
+include = ["kora*"]
+```
+
+Recommended additional metadata before publication:
+
+- Set an explicit maintainer email or project contact route.
+- Add a `CHANGELOG` or release notes link if publishing public versions.
+- Confirm README install examples refer to `getkora` only after publication.
+- Verify source distribution and wheel contents include required runtime package data.
+- Run isolated `pip install getkora` validation after publication.
+
+## CLI Decision
+
+Keep the CLI command as `kora`.
+
+Reasoning:
+
+- The public brand is KORA.
+- Existing documentation and examples use `python3 -m kora` and `kora`.
+- The console script is user-facing and should match the brand.
+- Changing the CLI command would add unnecessary user-facing churn.
+
+Risk:
+
+- If another installed package provides a `kora` console script, user environments could have command conflicts. Current validation should prefer virtual environments and `python3 -m kora` examples.
+
+## Python Import Decision
+
+Keep the Python import package as `kora`.
+
+Reasoning:
+
+- The repository source layout is already `kora/`.
+- The module invocation path `python3 -m kora` depends on that package.
+- Distribution package names and import package names do not need to match.
+- Renaming the import package would require broad code, test, documentation, and user-facing migration work without clear benefit at this stage.
+
+Risk:
+
+- A user who installs the unrelated PyPI `kora` package will get a different import package. This is addressed by not documenting plain `pip install kora` and by using source install until `getkora` is published.
+
+## Release Boundary
+
+This strategy does not:
+
+- publish `getkora`.
+- reserve a PyPI project name.
+- create a release.
+- create a tag.
+- create a GitHub Release.
+- claim `pip install getkora` works.
+- claim PyPI has latest KORA features.
+
+## Future Release Gate
+
+Before publishing, run a dedicated packaging goal that:
+
+- updates `pyproject.toml` distribution name to `getkora`.
+- builds source distribution and wheel.
+- inspects wheel and sdist contents.
+- installs the wheel into an isolated environment.
+- verifies `python3 -m kora --help`.
+- verifies `python3 -m kora doctor examples/kora_doctor/customer_support_workload.json` from an installed checkout or packaged sample strategy.
+- confirms the CLI command `kora` is installed.
+- only then publishes to PyPI, if explicitly approved.

--- a/docs/reports/goal083b_getkora_distribution_strategy.md
+++ b/docs/reports/goal083b_getkora_distribution_strategy.md
@@ -1,0 +1,172 @@
+# Goal 083B getkora Distribution Strategy
+
+## Motivation
+
+Goal 083B defines the packaging strategy after discovering that plain `python3 -m pip install kora` installs an unrelated PyPI package. The goal is to keep the public brand KORA while avoiding the existing PyPI `kora` collision.
+
+## Decision
+
+- Public brand: KORA.
+- GitHub repository: `Krako-Labs/KORA`.
+- Future PyPI distribution package: `getkora`.
+- CLI command: `kora`.
+- Python import package: `kora`.
+
+This goal did not publish anything.
+
+## PyPI Checks
+
+Command:
+
+```bash
+python3 -m pip index versions getkora
+```
+
+Result:
+
+```text
+ERROR: No matching distribution found for getkora
+```
+
+Interpretation: `getkora` appears available by package-index lookup, but this does not reserve the name or prove future publishability.
+
+Command:
+
+```bash
+python3 -m pip index versions kora
+```
+
+Result: PyPI `kora` exists, with latest version `0.9.20`. Goal 083A isolated install validation found that package is an unrelated Colab utility package, not this `Krako-Labs/KORA` project.
+
+## Packaging Audit
+
+Current `pyproject.toml`:
+
+- `[project].name` is `kora`.
+- `[project].version` is `0.1.0a0`.
+- Project URLs point to `https://github.com/Krako-Labs/KORA`.
+- Console script is `kora = "kora.cli:main"`.
+- Package discovery includes `kora*`.
+- Runtime dependencies are `pydantic` and `jsonschema`.
+- Optional dependency groups are `openai` and `dev`.
+
+No root `setup.py`, `setup.cfg`, or `MANIFEST.in` file is present. Packaging metadata is centralized in `pyproject.toml`.
+
+Current import and CLI layout:
+
+- Import package: `kora`.
+- Module entry point: `kora/__main__.py`.
+- CLI implementation: `kora/cli.py`.
+- Console command: `kora`.
+
+## Proposed Future Metadata Change
+
+For a future packaging goal, change:
+
+```toml
+[project]
+name = "getkora"
+```
+
+Keep:
+
+```toml
+[project.scripts]
+kora = "kora.cli:main"
+
+[tool.setuptools.packages.find]
+include = ["kora*"]
+```
+
+The distribution name can be `getkora` while the import package and CLI remain `kora`.
+
+## CLI Decision
+
+Keep the CLI command as `kora`.
+
+Reason: it matches the public brand and current docs. Changing it would create unnecessary user-facing churn.
+
+## Import Package Decision
+
+Keep the Python import package as `kora`.
+
+Reason: the source layout, tests, module invocation path, and docs already use `kora`. Distribution package names and import package names do not need to match.
+
+## Documentation Updates
+
+Updated:
+
+- `README.md`
+- `docs/README.md`
+- `OPEN_THIS_FIRST.md`
+- `REVIEW_HUB.md`
+- `examples/kora_doctor/README.md`
+- `docs/packaging/getkora_distribution_strategy.md`
+
+The docs now state:
+
+- plain `python3 -m pip install kora` is not this project.
+- current latest-feature path is source install from the repository.
+- future PyPI distribution package is planned as `getkora`.
+- `pip install getkora` must not be documented as working until a future publication validates it.
+
+## Validation Results
+
+```bash
+python3 -m pip index versions getkora
+```
+
+Result: `ERROR: No matching distribution found for getkora`.
+
+```bash
+python3 -m pip index versions kora
+```
+
+Result: PyPI `kora` exists; latest reported version was `0.9.20`.
+
+```bash
+python3 -m kora doctor examples/kora_doctor/customer_support_workload.json
+```
+
+Result: passed; reported `6` total tasks, `4` deterministic candidates, `2` provider-needed candidates, and `0` provider calls.
+
+```bash
+python3 -m kora doctor --all examples/kora_doctor/
+```
+
+Result: passed; reported `4` workloads, `25` total tasks, `16` deterministic candidates, `9` provider-needed candidates, and `0` provider calls.
+
+```bash
+python3 -m kora examples list
+```
+
+Result: passed; listed `kora_doctor`.
+
+```bash
+python3 -m pytest tests/test_kora_doctor_cli.py tests/test_first_value_cli.py
+```
+
+Result: passed, `14 passed in 3.88s`.
+
+```bash
+python3 scripts/check_markdown_links_goal082b.py
+git diff --check
+```
+
+Result: markdown link validation passed with `Goal 082B markdown links OK`; `git diff --check` passed.
+
+## Release Boundary
+
+This goal did not:
+
+- publish to PyPI.
+- reserve a PyPI package.
+- create a release.
+- create a tag.
+- create a GitHub Release.
+- claim `pip install getkora` works.
+- claim PyPI contains the latest KORA features.
+
+## Recommended Next Goal
+
+Run a dedicated packaging implementation goal that changes `pyproject.toml` to `name = "getkora"`, builds wheel and source distributions, inspects package contents, and validates isolated wheel install without publishing.

--- a/docs/reports/goal083c_public_first_run_acceptance_test.md
+++ b/docs/reports/goal083c_public_first_run_acceptance_test.md
@@ -1,0 +1,179 @@
+# Goal 083C Public First-Run Acceptance Test
+
+## Summary
+
+Goal 083C tested whether a new external reviewer can start from public repository documentation, install the current source version safely, run KORA Doctor, run deterministic classification, and understand the PyPI package-name boundary.
+
+Result: pass with one small documentation fix.
+
+The tested source included pending local Goal 083B material at commit `f768a353fa02feb0dcf1f02055ae4c029117ad37`.
+
+## Environment
+
+Acceptance test environment:
+
+- Date: June 18, 2026.
+- OS context: local macOS shell.
+- Fresh install directory: `/tmp/kora083c_fresh.O9XvF6`.
+- Fresh source checkout HEAD: `f768a353fa02feb0dcf1f02055ae4c029117ad37`.
+- Python: `Python 3.13.5`.
+- pip: `pip 26.1.2`.
+- Install mode: editable source install with `python3 -m pip install -e .`.
+
+Repository validation environment:
+
+- Worktree: `goal083c_public_first_run_acceptance`.
+- Base material: pending Goal 083B distribution strategy.
+
+## Scenario A - README-Only Reviewer
+
+Procedure:
+
+1. Started from `README.md` only.
+2. Read the project intro, current availability section, install block, examples section, and evidence limits.
+3. Followed the documented current install path in a fresh source checkout.
+4. Ran the first KORA Doctor command documented in the current availability and examples sections.
+
+Result: pass.
+
+Findings:
+
+- A new user can understand within 30 seconds that KORA is an AI Workload Control Layer for deciding what should reach a model, what can be deterministic, and how work moves through an AI system.
+- The README warns that plain `python3 -m pip install kora` is not this project.
+- The README says `getkora` is the planned future distribution name and does not claim it is published.
+- The README gives source install commands before the latest example commands.
+
+Ambiguities or failures:
+
+- The deterministic classification README had runnable commands but did not repeat the source-install/PyPI collision note. This was fixed.
+
+## Scenario B - Fresh Source Install
+
+Commands:
+
+```bash
+git clone --no-local <goal083c-source-worktree> /tmp/kora083c_fresh.O9XvF6/KORA
+cd /tmp/kora083c_fresh.O9XvF6/KORA
+python3 -m venv .venv
+. .venv/bin/activate
+python3 -m pip install --upgrade pip setuptools wheel
+python3 -m pip install -e .
+python3 -m kora doctor examples/kora_doctor/customer_support_workload.json
+python3 -m kora doctor --all examples/kora_doctor/
+python3 examples/deterministic_classification/run.py
+```
+
+Result: pass.
+
+Observed:
+
+- `python3 -m kora doctor examples/kora_doctor/customer_support_workload.json` exited `0`.
+- The single Doctor report showed `6` total tasks, `4` deterministic candidates, `2` provider-needed candidates, and `0` provider calls actually made.
+- `python3 -m kora doctor --all examples/kora_doctor/` exited `0`.
+- The aggregate Doctor report showed `4` workloads, `25` total tasks, `16` deterministic candidates, `9` provider-needed candidates, and `0` provider calls actually made.
+- `python3 examples/deterministic_classification/run.py` exited `0`.
+- The deterministic classification output showed `32` total tasks and `0` provider calls actually made.
+
+## Scenario C - PyPI Collision Awareness
+
+Procedure:
+
+Scanned public docs for:
+
+- `pip install kora`.
+- `python3 -m pip install kora`.
+- `getkora`.
+- `pip install getkora`.
+- claims that `getkora` is published.
+
+Result: pass.
+
+Findings:
+
+- `README.md`, `docs/README.md`, `examples/kora_doctor/README.md`, and `examples/deterministic_classification/README.md` now warn that plain `python3 -m pip install kora` is not this project.
+- `README.md` and `docs/README.md` identify `getkora` as a planned future distribution name.
+- No public doc claims that `python3 -m pip install getkora` works today.
+- The docs say source install from the current repository is the latest-feature path.
+
+## Scenario D - 5-Minute Reviewer Path
+
+Procedure:
+
+1. Read the README intro and current availability section.
+2. Installed from source in a fresh virtual environment.
+3. Ran KORA Doctor single workload.
+4. Ran KORA Doctor aggregate report.
+5. Ran deterministic classification.
+6. Read safe claim boundaries.
+
+Result: pass.
+
+Findings:
+
+- The flow is feasible within a five-minute reviewer path after dependencies are available.
+- The first useful output is a concise KORA Doctor report.
+- The deterministic classification example is runnable from the README path.
+- Evidence limits are visible before the installation section and again near the example/report docs.
+
+## Documentation Fixes Applied
+
+Applied one direct fix:
+
+- Added a current-availability note to `examples/deterministic_classification/README.md` stating that the example should be run from a current `Krako-Labs/KORA` source checkout, that plain `python3 -m pip install kora` installs a different PyPI project, and that `getkora` is planned but not documented as published.
+
+Updated continuation surfaces:
+
+- `OPEN_THIS_FIRST.md`
+- `REVIEW_HUB.md`
+- `docs/README.md`
+
+## Validation Commands
+
+Fresh source install:
+
+```bash
+git clone --no-local <goal083c-source-worktree> /tmp/kora083c_fresh.O9XvF6/KORA
+cd /tmp/kora083c_fresh.O9XvF6/KORA
+python3 -m venv .venv
+. .venv/bin/activate
+python3 -m pip install --upgrade pip setuptools wheel
+python3 -m pip install -e .
+python3 -m kora doctor examples/kora_doctor/customer_support_workload.json
+python3 -m kora doctor --all examples/kora_doctor/
+python3 examples/deterministic_classification/run.py
+```
+
+Repository validation:
+
+```bash
+python3 -m kora doctor examples/kora_doctor/customer_support_workload.json
+python3 -m kora doctor --all examples/kora_doctor/
+python3 examples/deterministic_classification/run.py
+python3 -m kora examples list
+python3 -m pytest tests/test_kora_doctor_cli.py tests/test_first_value_cli.py tests/test_deterministic_classification_expansion_pack.py
+python3 scripts/check_markdown_links_goal082b.py
+git diff --check
+```
+
+Results:
+
+- `python3 -m pytest tests/test_kora_doctor_cli.py tests/test_first_value_cli.py tests/test_deterministic_classification_expansion_pack.py` passed with `26 passed in 5.54s`.
+- `python3 scripts/check_markdown_links_goal082b.py` passed with `Goal 082B markdown links OK`.
+- `git diff --check` passed.
+
+## Blockers
+
+No acceptance blockers remain.
+
+## Remaining Limitations
+
+- Latest-feature installation remains source-based until a future packaging goal publishes a distribution.
+- `getkora` is only a planned future PyPI distribution name; it is not documented as published.
+- The examples are offline and synthetic.
+- The deterministic classification output is verbose JSON; it is useful as evidence but not as polished as the Doctor report.
+
+## Recommendation
+
+Proceed to Goal 084.
+
+Reason: first-run source installation, KORA Doctor, deterministic classification, package-collision warnings, `getkora` caveats, and evidence limits are clear enough for the next public reviewer walkthrough and example catalog refresh.

--- a/examples/deterministic_classification/README.md
+++ b/examples/deterministic_classification/README.md
@@ -2,6 +2,8 @@
 
 This example pack shows KORA routing synthetic classification tasks to deterministic handlers before provider/model fallback is needed. Every item runs through a KORA `TaskGraph` and the deterministic `classify_by_rules` handler.
 
+Current availability: run this example from a current `Krako-Labs/KORA` checkout installed from source. Plain `python3 -m pip install kora` installs a different PyPI project and should not be used for these examples. Future package distribution is planned as `getkora`, but this README does not claim that package is published.
+
 Scenarios:
 
 - support ticket routing

--- a/examples/kora_doctor/README.md
+++ b/examples/kora_doctor/README.md
@@ -2,6 +2,17 @@
 
 This offline example shows how KORA can inspect small project-like workloads before deeper integration. It identifies deterministic candidates, provider-needed candidates, route rationale, summary counters, and next-step recommendations.
 
+Current availability: run this example from a current `Krako-Labs/KORA` checkout installed from source. Plain `python3 -m pip install kora` installs a different PyPI project and should not be used to test `kora doctor`. Future package distribution is planned as `getkora`, but this README does not claim that package is published.
+
+Recommended setup:
+
+```bash
+python3 -m venv .venv
+source .venv/bin/activate
+python3 -m pip install --upgrade pip setuptools wheel
+python3 -m pip install -e .
+```
+
 Run from the repository root:
 
 ```bash


### PR DESCRIPTION
## Summary
- Adds the getkora distribution strategy and documents the existing PyPI `kora` collision.
- Clarifies current latest-feature install path as source install from the repository, with `getkora` only as a planned future distribution name.
- Adds the public first-run acceptance test report covering README-only onboarding, fresh source install, KORA Doctor, deterministic classification, and package-availability wording.

## Validation
- `python3 -m kora doctor examples/kora_doctor/customer_support_workload.json` -> passed
- `python3 -m kora doctor --all examples/kora_doctor/` -> passed
- `python3 examples/deterministic_classification/run.py` -> passed
- `python3 -m kora examples list` -> passed
- `python3 -m pytest tests/test_kora_doctor_cli.py tests/test_first_value_cli.py tests/test_deterministic_classification_expansion_pack.py` -> passed (`26 passed`)
- `python3 scripts/check_markdown_links_goal082b.py` -> passed
- `git diff --check origin/main...HEAD` -> passed

## Audits
- Scope audit: limited to distribution strategy docs, install guidance docs, acceptance report, README/docs updates, example README updates, and breadcrumb updates.
- Boundary audit: no local-only ChatGPT context, private paths, Permea references, AI Champion/K-EXAONE/H100/private-resource references, or secret-like tokens found in added diff.
- Package availability audit: docs do not claim `pip install getkora` works today, do not claim `pip install kora` installs this project, clearly state PyPI `kora` is unrelated, and state the current latest-feature path is source install.
- Documentation audit: README, docs index, example READMEs, OPEN_THIS_FIRST, REVIEW_HUB, packaging strategy, and Goal 083B/083C reports are present.
