### PR TITLE
Add OpenAI-compatible proxy example

### DIFF
--- a/OPEN_THIS_FIRST.md
+++ b/OPEN_THIS_FIRST.md
@@ -2,7 +2,7 @@
 
 Status: current public project breadcrumb.
 
-Last updated by: Goal 083C.
+Last updated by: Goal 084.
 
 ## Current Status
 
@@ -18,6 +18,7 @@ Current state:
 - first-value CLI commands exist and the editable-install path has been revalidated for local public-safe onboarding.
 - packaging strategy now documents the PyPI `kora` collision and the planned future distribution name `getkora`; latest-feature testing remains source-install from the current repository.
 - public first-run acceptance testing has been run against the README/source-install path, KORA Doctor, deterministic classification, and PyPI collision wording.
+- an offline OpenAI-compatible proxy example exists under `examples/openai_compatible_proxy/`, showing KORA routing OpenAI-style chat request objects through deterministic handlers, local cache reuse, or provider-needed fallback without provider calls.
 - a deterministic classification example pack exists under `examples/deterministic_classification/`, using KORA `TaskGraph` execution across support-ticket routing, issue triage, incident severity routing, document type routing, and log/event classification.
 - a KORA Doctor example exists under `examples/kora_doctor/`, using KORA `TaskGraph` execution to inspect a synthetic workload and explain deterministic candidates, provider-needed candidates, route rationale, counters, and next steps.
 - the KORA Doctor example now includes a report pack mode across four bundled offline workloads and a README refresh proposal for examples-driven positioning.
@@ -29,15 +30,32 @@ Current state:
 
 ## Current Branch
 
-- branch: `goal083c_public_first_run_acceptance`
+- branch: `goal084_openai_compatible_proxy`
 - public truth: `origin/main`
 - branch pushed to: not pushed in this worktree
-- open PR: none for Goal 083C
-- base commit: `f768a353fa02feb0dcf1f02055ae4c029117ad37` including pending local Goal 083B material
+- open PR: none for Goal 084
+- base commit: `b925a5163650ed60b97ebc7b1aa2b44d7fda4290`
 
 ## Last Completed Goal
 
-Goal 083C - Public First-Run Acceptance Test.
+Goal 084 - Implement OpenAI-Compatible Proxy Example.
+
+Goal 084 added an offline OpenAI-compatible proxy example under `examples/openai_compatible_proxy/`. The example uses KORA `TaskGraph` execution with the deterministic `classify_by_rules` handler for bounded support-ticket classification requests, local cache reuse for repeated sample requests, and provider-needed fallback labels for ambiguous/open-ended sample requests. It makes `0` provider calls.
+
+Primary report:
+
+- [Goal 084 OpenAI-compatible proxy example](docs/reports/goal084_openai_compatible_proxy_example.md)
+
+Example artifacts:
+
+- [OpenAI-compatible proxy example README](examples/openai_compatible_proxy/README.md)
+- [OpenAI-compatible proxy runnable script](examples/openai_compatible_proxy/run.py)
+- [OpenAI-compatible proxy request fixture](examples/openai_compatible_proxy/requests.json)
+- [OpenAI-compatible proxy expected counters](examples/openai_compatible_proxy/expected_counters.json)
+
+Claim boundary: In this offline OpenAI-style proxy example, KORA routes deterministic or cacheable sample requests without making provider calls and marks ambiguous/open-ended requests as provider-needed. It does not claim production proxy readiness, full OpenAI API compatibility, automatic cost reduction, real API-cost proof, benchmark superiority, or broad workload superiority.
+
+Previous completed Goal: Goal 083C - Public First-Run Acceptance Test.
 
 Goal 083C tested the README-only reviewer path, fresh source install path, PyPI collision awareness, and five-minute reviewer path using the pending Goal 083B distribution strategy material. It also added a short source-install availability note to the deterministic classification README.
 
@@ -225,6 +243,8 @@ Primary report:
 ## Primary Reports
 
 - [Review hub](REVIEW_HUB.md)
+- [Goal 084 OpenAI-compatible proxy example](docs/reports/goal084_openai_compatible_proxy_example.md)
+- [OpenAI-compatible proxy example README](examples/openai_compatible_proxy/README.md)
 - [Goal 083B getkora distribution strategy](docs/reports/goal083b_getkora_distribution_strategy.md)
 - [getkora distribution strategy](docs/packaging/getkora_distribution_strategy.md)
 - [Goal 083 KORA Doctor CLI](docs/reports/goal083_kora_doctor_cli.md)

--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ Current implemented surfaces in this GitHub repository include:
 - Run offline examples through the KORA example runner: `python3 -m kora run <example>`
 - Run KORA Doctor sample workload inspection from the first-class CLI: `python3 -m kora doctor examples/kora_doctor/customer_support_workload.json`
 - Run the deterministic classification expansion pack.
+- Run the offline OpenAI-compatible proxy example.
 - Run first-value CLI paths: `kora inspect`, `kora compare`, `kora run`, `kora doctor`, and `kora report`
 - Execute deterministic sample tasks through KORA `TaskGraph` paths.
 - Produce local JSON and Markdown/text reports from bundled examples.
@@ -109,12 +110,37 @@ After installing from the current repository, start here:
 python3 -m kora examples list
 python3 -m kora doctor examples/kora_doctor/customer_support_workload.json
 python3 -m kora doctor --all examples/kora_doctor/
+python3 examples/openai_compatible_proxy/run.py
 python3 examples/kora_doctor/run.py
 python3 examples/kora_doctor/run.py --all
 python3 examples/deterministic_classification/run.py
 ```
 
 The examples require no provider credentials and make no provider calls.
+
+### OpenAI-Compatible Proxy
+
+The OpenAI-compatible proxy example shows KORA sitting in front of OpenAI-style chat request objects. It routes deterministic classification requests through KORA `TaskGraph` execution, reuses a local cache for repeated sample requests, and marks ambiguous or open-ended sample requests as provider-needed.
+
+Run the example:
+
+```bash
+python3 examples/openai_compatible_proxy/run.py
+```
+
+Expected counters:
+
+- total requests: `6`
+- deterministic handled: `3`
+- cache hits: `1`
+- provider-needed: `2`
+- avoided simulated provider/model invocations: `4`
+- provider calls actually made: `0`
+
+Docs:
+
+- [OpenAI-compatible proxy example README](examples/openai_compatible_proxy/README.md)
+- [Goal 084 OpenAI-compatible proxy example](docs/reports/goal084_openai_compatible_proxy_example.md)
 
 ### KORA Doctor
 

--- a/REVIEW_HUB.md
+++ b/REVIEW_HUB.md
@@ -2,7 +2,7 @@
 
 Status: current public review and continuation hub.
 
-Last updated by: Goal 083C.
+Last updated by: Goal 084.
 
 ## Project Identity
 
@@ -14,11 +14,11 @@ KRK means KORA Routing Kernel. KRK is the deterministic-first execution routing 
 
 - repository: `https://github.com/Krako-Labs/KORA`
 - public truth branch: `origin/main`
-- active evidence branch: `goal083c_public_first_run_acceptance`
-- worktree label: `goal083c_public_first_run_acceptance`
+- active evidence branch: `goal084_openai_compatible_proxy`
+- worktree label: `goal084_openai_compatible_proxy`
 - branch pushed to: not pushed in this worktree
-- open PR: none for Goal 083C
-- base commit: `f768a353fa02feb0dcf1f02055ae4c029117ad37` including pending local Goal 083B material
+- open PR: none for Goal 084
+- base commit: `b925a5163650ed60b97ebc7b1aa2b44d7fda4290`
 
 ## Current State Summary
 
@@ -35,6 +35,7 @@ KORA now has a public-safe first-value path and an evidence package that covers:
 - install-revalidated local first-value CLI workflow.
 - distribution strategy documents PyPI `kora` collision, source-install current path, and planned future PyPI distribution name `getkora`.
 - public first-run acceptance testing covers README-only onboarding, fresh source install, KORA Doctor, deterministic classification, and PyPI collision wording.
+- OpenAI-compatible proxy example with offline OpenAI-style chat request fixtures, KORA deterministic routing, local cache reuse, provider-needed fallback labels, and `0` provider calls.
 - deterministic classification example pack with KORA `TaskGraph` execution across support-ticket routing, issue triage, incident severity routing, document type routing, and log/event classification.
 - KORA Doctor first-value developer example with KORA `TaskGraph` execution, deterministic candidate/provider-needed candidate inspection, route rationale, counters, and next-step recommendations.
 - KORA Doctor report pack with four bundled offline workloads, aggregate report mode, and a README refresh proposal for examples-driven routing/control positioning.
@@ -78,6 +79,7 @@ This is a sufficient recent history backfill, not a complete reconstruction.
 | Goal 083 | Promoted KORA Doctor into a first-class offline CLI command for single-workload and aggregate workload-control reports. | [Goal 083 KORA Doctor CLI](docs/reports/goal083_kora_doctor_cli.md) |
 | Goal 083B | Documented the `getkora` future distribution strategy after verifying the PyPI `kora` collision and current source-install path. | [Goal 083B getkora distribution strategy](docs/reports/goal083b_getkora_distribution_strategy.md) |
 | Goal 083C | Ran public first-run acceptance testing over README onboarding, fresh source install, KORA Doctor, deterministic classification, and PyPI collision wording. | [Goal 083C public first-run acceptance test](docs/reports/goal083c_public_first_run_acceptance_test.md) |
+| Goal 084 | Added an offline OpenAI-compatible proxy example that routes OpenAI-style sample requests through KORA deterministic handling, cache reuse, or provider-needed fallback. | [Goal 084 OpenAI-compatible proxy example](docs/reports/goal084_openai_compatible_proxy_example.md) |
 
 ## Evidence Index
 
@@ -104,6 +106,8 @@ Generated summaries:
 Current reviewer path:
 
 - [Goal 082B narrative repositioning](docs/reports/goal082b_narrative_repositioning.md)
+- [Goal 084 OpenAI-compatible proxy example](docs/reports/goal084_openai_compatible_proxy_example.md)
+- [OpenAI-compatible proxy example README](examples/openai_compatible_proxy/README.md)
 - [Goal 083C public first-run acceptance test](docs/reports/goal083c_public_first_run_acceptance_test.md)
 - [Goal 083B getkora distribution strategy](docs/reports/goal083b_getkora_distribution_strategy.md)
 - [getkora distribution strategy](docs/packaging/getkora_distribution_strategy.md)
@@ -151,6 +155,7 @@ Supported:
 - KORA has an offline Doctor report pack where KORA Doctor identifies deterministic candidates and provider-needed candidates across four bundled sample workloads without making provider calls.
 - KORA has a first-class `kora doctor` CLI command for running the same offline Doctor inspection over sample workload JSON files and bundled workload directories.
 - KORA's planned future PyPI distribution package name is `getkora`; current latest-feature testing requires source install from the repository.
+- KORA has an offline OpenAI-style proxy example where sample chat requests are routed through deterministic handling, local cache reuse, or provider-needed fallback without provider calls.
 - Current evidence supports bounded statements about route selectivity, dry-run runtime integration, provider-path validation, bounded H100 execution, expanded H100 representativeness, and fixture-derived output fidelity.
 - KORA has reusable public-safe Project Operating System templates for breadcrumbs, review hubs, ADRs, reports, evidence, claim registries, bootstrap checklists, and project prompts.
 
@@ -355,10 +360,10 @@ Boundary: this is positioning grounded in current examples and evidence. It does
 
 ## Recommended Next Goals
 
-1. Goal 084 - Public reviewer walkthrough and example catalog refresh.
-2. Goal 085 - Contributor issue seed for examples-first onboarding.
-3. Goal 086 - Contributor issue seed for first-value examples.
-4. Goal 087 - Wheel and source distribution smoke validation.
+1. Goal 085 - Public reviewer walkthrough and example catalog refresh.
+2. Goal 086 - Contributor issue seed for examples-first onboarding.
+3. Goal 087 - Contributor issue seed for first-value examples.
+4. Goal 088 - Wheel and source distribution smoke validation.
 
 ## How To Resume With ChatGPT
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -32,10 +32,12 @@ python3 -m kora doctor examples/kora_doctor/customer_support_workload.json
 - [Open this first](../OPEN_THIS_FIRST.md)
 - [Review hub](../REVIEW_HUB.md)
 - [Goal 083C public first-run acceptance test](reports/goal083c_public_first_run_acceptance_test.md)
+- [Goal 084 OpenAI-compatible proxy example](reports/goal084_openai_compatible_proxy_example.md)
 - [Goal 083B getkora distribution strategy](reports/goal083b_getkora_distribution_strategy.md)
 - [getkora distribution strategy](packaging/getkora_distribution_strategy.md)
 - [KORA Workload Control Layer vision](vision/kora_workload_control_layer.md)
 - [KORA Doctor README](../examples/kora_doctor/README.md)
+- [OpenAI-compatible proxy example README](../examples/openai_compatible_proxy/README.md)
 - [Goal 083 KORA Doctor CLI](reports/goal083_kora_doctor_cli.md)
 - [Deterministic classification example pack README](../examples/deterministic_classification/README.md)
 - [Current v0.3.0-alpha prerelease](https://github.com/Krako-Labs/KORA/releases/tag/v0.3.0-alpha)
@@ -159,6 +161,7 @@ KORA control layer architecture.
 ## Reports
 
 - [Goal 082B narrative repositioning](reports/goal082b_narrative_repositioning.md)
+- [Goal 084 OpenAI-compatible proxy example](reports/goal084_openai_compatible_proxy_example.md)
 - [Goal 083C public first-run acceptance test](reports/goal083c_public_first_run_acceptance_test.md)
 - [Goal 083B getkora distribution strategy](reports/goal083b_getkora_distribution_strategy.md)
 - [Goal 083 KORA Doctor CLI](reports/goal083_kora_doctor_cli.md)
@@ -239,6 +242,7 @@ python3 -m kora --help
 python3 -m kora examples list
 python3 -m kora doctor examples/kora_doctor/customer_support_workload.json
 python3 -m kora doctor --all examples/kora_doctor/
+python3 examples/openai_compatible_proxy/run.py
 python3 examples/kora_doctor/run.py
 python3 examples/kora_doctor/run.py --all
 python3 examples/deterministic_classification/run.py

--- a/docs/reports/goal084_openai_compatible_proxy_example.md
+++ b/docs/reports/goal084_openai_compatible_proxy_example.md
@@ -1,0 +1,163 @@
+# Goal 084 OpenAI-Compatible Proxy Example
+
+## Motivation
+
+Goal 084 adds a concrete offline example showing how KORA can sit in front of OpenAI-style provider requests and route deterministic or cacheable work before a model call would be needed.
+
+The purpose is developer comprehension: show an insertion point for KORA in an OpenAI-style workflow without claiming production proxy readiness or full API compatibility.
+
+## User-Facing Walkthrough
+
+Run:
+
+```bash
+python3 examples/openai_compatible_proxy/run.py
+```
+
+Write structured output:
+
+```bash
+python3 examples/openai_compatible_proxy/run.py \
+  --json-out /tmp/kora_goal084_openai_proxy.json \
+  --report-md /tmp/kora_goal084_openai_proxy.md
+```
+
+Expected report header:
+
+```text
+KORA OpenAI-Compatible Proxy Example
+
+Total requests: 6
+Deterministic handled: 3
+Cache hits: 1
+Provider-needed: 2
+Avoided simulated provider/model invocations: 4
+Provider calls actually made: 0
+```
+
+## Implementation Summary
+
+- Added `examples/openai_compatible_proxy/`.
+- Added synthetic OpenAI-style chat request fixtures in `requests.json`.
+- Added expected counters in `expected_counters.json`.
+- Added `run.py` that extracts chat request text, routes through KORA `TaskGraph` execution with `classify_by_rules`, caches repeated deterministic responses, and labels ambiguous/open-ended requests as provider-needed.
+- Added focused tests in `tests/test_openai_compatible_proxy_example.py`.
+- Updated example listing metadata so `python3 -m kora examples list` includes `openai_compatible_proxy`.
+- Updated README, docs index, `OPEN_THIS_FIRST.md`, and `REVIEW_HUB.md`.
+
+The example stays offline and makes no external API calls.
+
+## Request And Route Examples
+
+Example OpenAI-style request:
+
+```json
+{
+  "model": "gpt-4o-mini",
+  "messages": [
+    {
+      "role": "system",
+      "content": "Classify support tickets into bounded routing categories."
+    },
+    {
+      "role": "user",
+      "content": "Classify this ticket: Customer was charged twice"
+    }
+  ],
+  "temperature": 0
+}
+```
+
+Route result:
+
+- route: `deterministic`.
+- handler: `classify_by_rules`.
+- selected route: `proxy.det.support.billing`.
+- provider calls: `0`.
+
+Repeated request result:
+
+- route: `cache_hit`.
+- handler: `cache_reuse`.
+- provider calls: `0`.
+
+Open-ended request result:
+
+- route: `provider_required`.
+- handler: `provider_needed_fallback`.
+- provider calls actually made: `0`.
+
+## Evidence Counters
+
+- total requests: `6`
+- deterministic handled: `3`
+- cache hits: `1`
+- provider-needed: `2`
+- avoided simulated provider/model invocations: `4`
+- provider calls actually made: `0`
+
+## Validation Results
+
+```bash
+python3 examples/openai_compatible_proxy/run.py
+```
+
+Result: passed.
+
+```bash
+python3 examples/openai_compatible_proxy/run.py --json-out /tmp/kora_goal084_openai_proxy.json --report-md /tmp/kora_goal084_openai_proxy.md
+```
+
+Result: passed. JSON output reported `ok=True`, `6` total requests, `3` deterministic handled, `1` cache hit, `2` provider-needed, and `0` provider calls actually made. Markdown report was written.
+
+```bash
+python3 -m kora examples list
+```
+
+Result: passed. Output included `openai_compatible_proxy: offline OpenAI-style proxy routing example`.
+
+```bash
+python3 -m pytest tests/test_openai_compatible_proxy_example.py tests/test_kora_doctor_cli.py tests/test_first_value_cli.py
+```
+
+Result: passed as part of the relevant test set:
+
+```bash
+python3 -m pytest tests/test_openai_compatible_proxy_example.py tests/test_kora_doctor_cli.py tests/test_first_value_cli.py tests/test_deterministic_classification_expansion_pack.py
+```
+
+The run completed with `31 passed in 6.00s`.
+
+```bash
+python3 scripts/check_markdown_links_goal082b.py
+git diff --check
+```
+
+Result: markdown link validation passed with `Goal 082B markdown links OK`; `git diff --check` passed.
+
+## Limitations
+
+- This is an offline example, not a production proxy.
+- It simulates only a narrow OpenAI-style chat request shape.
+- It does not claim full OpenAI API compatibility.
+- It does not make provider calls.
+- Avoided provider/model invocations are simulated counters for this sample workload only.
+
+## Claim Boundaries
+
+Supported wording:
+
+> In this offline OpenAI-style proxy example, KORA routes deterministic or cacheable sample requests without making provider calls and marks ambiguous/open-ended requests as provider-needed.
+
+Not claimed:
+
+- production proxy readiness.
+- full OpenAI API compatibility.
+- automatic cost reduction.
+- real API-cost proof.
+- benchmark superiority.
+- broad workload superiority.
+
+## Recommended Next Goal
+
+Run a public reviewer walkthrough and example catalog refresh that compares the KORA Doctor, deterministic classification, and OpenAI-compatible proxy examples as first-run onboarding paths.

--- a/examples/openai_compatible_proxy/README.md
+++ b/examples/openai_compatible_proxy/README.md
@@ -1,0 +1,55 @@
+# OpenAI-Compatible Proxy Example
+
+This offline example shows KORA sitting in front of OpenAI-style chat request objects. It routes bounded classification requests through KORA deterministic handlers, reuses a local cache for repeated requests, and marks ambiguous or open-ended requests as provider-needed without making external API calls.
+
+Current availability: run this example from a current `Krako-Labs/KORA` checkout installed from source. Plain `python3 -m pip install kora` installs a different PyPI project and should not be used for these examples. Future package distribution is planned as `getkora`, but this README does not claim that package is published.
+
+## Quick Run
+
+```bash
+python3 examples/openai_compatible_proxy/run.py
+```
+
+Write structured JSON and a report:
+
+```bash
+python3 examples/openai_compatible_proxy/run.py \
+  --json-out /tmp/kora_goal084_openai_proxy.json \
+  --report-md /tmp/kora_goal084_openai_proxy.md
+```
+
+Run through the KORA example runner:
+
+```bash
+python3 -m kora run openai_compatible_proxy
+```
+
+## Expected Output
+
+```text
+KORA OpenAI-Compatible Proxy Example
+
+Total requests: 6
+Deterministic handled: 3
+Cache hits: 1
+Provider-needed: 2
+Avoided simulated provider/model invocations: 4
+Provider calls actually made: 0
+```
+
+## Expected Counters
+
+- total requests: `6`
+- deterministic handled: `3`
+- cache hits: `1`
+- provider-needed: `2`
+- avoided simulated provider/model invocations: `4`
+- provider calls actually made: `0`
+
+Expected counters are in [expected_counters.json](expected_counters.json). OpenAI-style request fixtures are in [requests.json](requests.json).
+
+## Claim Boundary
+
+In this offline OpenAI-style proxy example, KORA routes deterministic or cacheable sample requests without making provider calls and marks ambiguous/open-ended requests as provider-needed.
+
+This example does not claim production proxy readiness, full OpenAI API compatibility, automatic cost reduction, real API-cost proof, benchmark superiority, or broad workload superiority.

--- a/examples/openai_compatible_proxy/expected_counters.json
+++ b/examples/openai_compatible_proxy/expected_counters.json
@@ -1,0 +1,8 @@
+{
+  "total_requests": 6,
+  "deterministic_handled": 3,
+  "cache_hits": 1,
+  "provider_needed": 2,
+  "avoided_provider_invocations": 4,
+  "provider_calls_actually_made": 0
+}

--- a/examples/openai_compatible_proxy/requests.json
+++ b/examples/openai_compatible_proxy/requests.json
@@ -1,0 +1,137 @@
+{
+  "schema_version": "kora_openai_compatible_proxy_requests_v0",
+  "description": "Synthetic OpenAI-style chat requests for the offline KORA proxy example.",
+  "routes": [
+    {
+      "route_id": "proxy.det.support.billing",
+      "keywords": ["charged twice", "duplicate charge", "invoice", "billing"],
+      "output": {
+        "category": "billing",
+        "team": "support_billing",
+        "priority": "normal",
+        "response_template": "billing-review"
+      }
+    },
+    {
+      "route_id": "proxy.det.support.account_access",
+      "keywords": ["password reset", "cannot sign in", "login"],
+      "output": {
+        "category": "account_access",
+        "team": "support_account",
+        "priority": "normal",
+        "response_template": "account-access-reset"
+      }
+    },
+    {
+      "route_id": "proxy.det.support.technical_support",
+      "keywords": ["export fails", "timeout", "error"],
+      "output": {
+        "category": "technical_support",
+        "team": "support_technical",
+        "priority": "high",
+        "response_template": "technical-diagnostics"
+      }
+    }
+  ],
+  "provider_required_route": "proxy.provider.openai_style_fallback",
+  "requests": [
+    {
+      "id": "proxy-001",
+      "expected_route_kind": "deterministic",
+      "expected_handler": "classify_by_rules",
+      "request": {
+        "model": "gpt-4o-mini",
+        "messages": [
+          {
+            "role": "system",
+            "content": "Classify support tickets into bounded routing categories."
+          },
+          {
+            "role": "user",
+            "content": "Classify this ticket: Customer was charged twice"
+          }
+        ],
+        "temperature": 0
+      }
+    },
+    {
+      "id": "proxy-002",
+      "expected_route_kind": "cache_hit",
+      "expected_handler": "cache_reuse",
+      "request": {
+        "model": "gpt-4o-mini",
+        "messages": [
+          {
+            "role": "system",
+            "content": "Classify support tickets into bounded routing categories."
+          },
+          {
+            "role": "user",
+            "content": "Classify this ticket: Customer was charged twice"
+          }
+        ],
+        "temperature": 0
+      }
+    },
+    {
+      "id": "proxy-003",
+      "expected_route_kind": "deterministic",
+      "expected_handler": "classify_by_rules",
+      "request": {
+        "model": "gpt-4o-mini",
+        "messages": [
+          {
+            "role": "user",
+            "content": "Classify this ticket: Password reset link expired and I cannot sign in"
+          }
+        ],
+        "temperature": 0
+      }
+    },
+    {
+      "id": "proxy-004",
+      "expected_route_kind": "deterministic",
+      "expected_handler": "classify_by_rules",
+      "request": {
+        "model": "gpt-4o-mini",
+        "messages": [
+          {
+            "role": "user",
+            "content": "Classify this ticket: CSV export fails with timeout"
+          }
+        ],
+        "temperature": 0
+      }
+    },
+    {
+      "id": "proxy-005",
+      "expected_route_kind": "provider_required",
+      "expected_handler": "provider_needed_fallback",
+      "request": {
+        "model": "gpt-4o",
+        "messages": [
+          {
+            "role": "user",
+            "content": "Write a warm apology email and propose a custom retention offer."
+          }
+        ],
+        "temperature": 0.7
+      }
+    },
+    {
+      "id": "proxy-006",
+      "expected_route_kind": "provider_required",
+      "expected_handler": "provider_needed_fallback",
+      "request": {
+        "model": "gpt-4o",
+        "messages": [
+          {
+            "role": "user",
+            "content": "Classify this ticket: Billing invoice problem and login timeout error"
+          }
+        ],
+        "temperature": 0
+      }
+    }
+  ]
+}

--- a/examples/openai_compatible_proxy/run.py
+++ b/examples/openai_compatible_proxy/run.py
@@ -1,0 +1,293 @@
+"""Offline OpenAI-compatible proxy example using KORA task execution."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from kora.executor import run_graph
+from kora.task_ir import TaskGraph, normalize_graph, validate_graph
+
+EXAMPLE_DIR = Path(__file__).resolve().parent
+REQUESTS_PATH = EXAMPLE_DIR / "requests.json"
+EXPECTED_COUNTERS_PATH = EXAMPLE_DIR / "expected_counters.json"
+CLAIM_BOUNDARY = (
+    "In this offline OpenAI-style proxy example, KORA routes deterministic or "
+    "cacheable sample requests without making provider calls and marks "
+    "ambiguous/open-ended requests as provider-needed. It does not claim "
+    "production proxy readiness, full OpenAI API compatibility, automatic cost "
+    "reduction, real API-cost proof, benchmark superiority, or broad workload superiority."
+)
+
+
+def load_requests(path: Path = REQUESTS_PATH) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _message_text(request: dict[str, Any]) -> str:
+    messages = request.get("messages", [])
+    if not isinstance(messages, list):
+        return ""
+    parts: list[str] = []
+    for message in messages:
+        if not isinstance(message, dict):
+            continue
+        content = message.get("content", "")
+        if isinstance(content, str):
+            parts.append(content)
+        elif isinstance(content, list):
+            for item in content:
+                if isinstance(item, dict) and isinstance(item.get("text"), str):
+                    parts.append(str(item["text"]))
+    return " ".join(parts)
+
+
+def _request_cache_key(request: dict[str, Any]) -> str:
+    canonical = json.dumps(request, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+def _classification_graph(config: dict[str, Any], request_id: str, text: str) -> TaskGraph:
+    return TaskGraph.model_validate(
+        {
+            "graph_id": f"openai-compatible-proxy-{request_id}",
+            "version": "0.1",
+            "root": "classify",
+            "defaults": {"budget": {"max_time_ms": 1500, "max_tokens": 300, "max_retries": 0}},
+            "tasks": [
+                {
+                    "id": "classify",
+                    "type": "det.proxy.openai_compatible_classification",
+                    "deps": [],
+                    "in": {"text": text},
+                    "run": {
+                        "kind": "det",
+                        "spec": {
+                            "handler": "classify_by_rules",
+                            "args": {
+                                "scenario_id": "openai_compatible_proxy",
+                                "routes": config["routes"],
+                                "provider_required_route": config["provider_required_route"],
+                            },
+                        },
+                    },
+                    "policy": {"on_fail": "fail"},
+                    "tags": ["openai-compatible-proxy", "offline-example"],
+                }
+            ],
+        }
+    )
+
+
+def _run_kora_route(config: dict[str, Any], request_id: str, request: dict[str, Any]) -> dict[str, Any]:
+    text = _message_text(request)
+    graph = normalize_graph(_classification_graph(config, request_id, text))
+    validate_graph(graph)
+    result = run_graph(graph)
+    if not result.get("ok"):
+        raise RuntimeError(str(result.get("error")))
+    final = result.get("final")
+    if not isinstance(final, dict):
+        raise RuntimeError("proxy graph did not return an object")
+    routed = dict(final)
+    routed.update(
+        {
+            "kora_graph_id": result["graph_id"],
+            "kora_event_count": len(result.get("events", [])),
+        }
+    )
+    return routed
+
+
+def _openai_style_response(request_id: str, route: dict[str, Any], source: str) -> dict[str, Any]:
+    return {
+        "id": f"chatcmpl-kora-{request_id}",
+        "object": "chat.completion",
+        "choices": [
+            {
+                "index": 0,
+                "finish_reason": "stop",
+                "message": {
+                    "role": "assistant",
+                    "content": json.dumps(
+                        {
+                            "source": source,
+                            "route_kind": route["route_kind"],
+                            "selected_route": route["selected_route"],
+                            "classification_output": route.get("classification_output"),
+                            "provider_needed_reason": route.get("provider_needed_reason"),
+                        },
+                        sort_keys=True,
+                    ),
+                },
+            }
+        ],
+        "usage": {"prompt_tokens": 0, "completion_tokens": 0, "total_tokens": 0},
+        "provider_calls": 0,
+    }
+
+
+def build_proxy_summary(
+    *,
+    requests_path: Path = REQUESTS_PATH,
+    json_out: Path | None = None,
+) -> dict[str, Any]:
+    config = load_requests(requests_path)
+    cache: dict[str, dict[str, Any]] = {}
+    results: list[dict[str, Any]] = []
+
+    for item in config["requests"]:
+        request_id = str(item["id"])
+        request = item["request"]
+        cache_key = _request_cache_key(request)
+
+        if cache_key in cache:
+            cached = cache[cache_key]
+            route = dict(cached["route"])
+            route.update(
+                {
+                    "route_kind": "cache_hit",
+                    "selected_route": "proxy.cache.reuse",
+                    "provider_needed_reason": None,
+                }
+            )
+            handler = "cache_reuse"
+            source = "cache"
+            graph_id = cached["route"].get("kora_graph_id")
+            event_count = 0
+        else:
+            route = _run_kora_route(config, request_id, request)
+            handler = "classify_by_rules" if route["route_kind"] == "deterministic" else "provider_needed_fallback"
+            source = "kora_task_graph"
+            graph_id = route.get("kora_graph_id")
+            event_count = route.get("kora_event_count", 0)
+            if route["route_kind"] == "deterministic":
+                cache[cache_key] = {"route": route}
+
+        proxy_response = _openai_style_response(request_id, route, source)
+        results.append(
+            {
+                "id": request_id,
+                "openai_style_request": request,
+                "request_text": _message_text(request),
+                "route_kind": route["route_kind"],
+                "selected_route": route["selected_route"],
+                "handler": handler,
+                "classification_output": route.get("classification_output"),
+                "provider_needed_reason": route.get("provider_needed_reason"),
+                "provider_calls": 0,
+                "cache_key": cache_key,
+                "source": source,
+                "kora_graph_id": graph_id,
+                "kora_event_count": event_count,
+                "openai_style_response": proxy_response,
+                "expected_route_kind": item["expected_route_kind"],
+                "expected_handler": item["expected_handler"],
+            }
+        )
+
+    total_requests = len(results)
+    deterministic_handled = sum(1 for item in results if item["route_kind"] == "deterministic")
+    cache_hits = sum(1 for item in results if item["route_kind"] == "cache_hit")
+    provider_needed = sum(1 for item in results if item["route_kind"] == "provider_required")
+    provider_calls = sum(int(item["provider_calls"]) for item in results)
+    expected_match_count = sum(
+        1
+        for item in results
+        if item["route_kind"] == item["expected_route_kind"]
+        and item["handler"] == item["expected_handler"]
+    )
+    avoided_provider_invocations = deterministic_handled + cache_hits
+    counters = {
+        "total_requests": total_requests,
+        "deterministic_handled": deterministic_handled,
+        "cache_hits": cache_hits,
+        "provider_needed": provider_needed,
+        "avoided_provider_invocations": avoided_provider_invocations,
+        "provider_calls_actually_made": provider_calls,
+    }
+    expected_counters = json.loads(EXPECTED_COUNTERS_PATH.read_text(encoding="utf-8"))
+    summary: dict[str, Any] = {
+        "ok": counters == expected_counters and expected_match_count == total_requests,
+        "mode": "openai_compatible_proxy_example",
+        **counters,
+        "expected_match_count": expected_match_count,
+        "results": results,
+        "example_request": results[0],
+        "safe_example_claim": (
+            "In this offline OpenAI-style proxy example, KORA routes deterministic or "
+            "cacheable sample requests without making provider calls and marks "
+            "ambiguous/open-ended requests as provider-needed."
+        ),
+        "claim_boundary": CLAIM_BOUNDARY,
+    }
+    if json_out is not None:
+        json_out.parent.mkdir(parents=True, exist_ok=True)
+        json_out.write_text(json.dumps(summary, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return summary
+
+
+def render_report(summary: dict[str, Any]) -> str:
+    example = summary["example_request"]
+    lines = [
+        "KORA OpenAI-Compatible Proxy Example",
+        "",
+        f"Total requests: {summary['total_requests']}",
+        f"Deterministic handled: {summary['deterministic_handled']}",
+        f"Cache hits: {summary['cache_hits']}",
+        f"Provider-needed: {summary['provider_needed']}",
+        f"Avoided simulated provider/model invocations: {summary['avoided_provider_invocations']}",
+        f"Provider calls actually made: {summary['provider_calls_actually_made']}",
+        "",
+        "Example request:",
+        f"- OpenAI-style chat request: \"{example['request_text'].split(':', 1)[-1].strip()}\"",
+        f"- Route: {example['route_kind']}",
+        f"- Handler: {example['handler']}",
+        f"- Provider calls: {example['provider_calls']}",
+        "",
+        "Comparison surface:",
+    ]
+    for item in summary["results"]:
+        lines.append(
+            "- {id}: route={route}, handler={handler}, provider_calls={calls}, source={source}".format(
+                id=item["id"],
+                route=item["route_kind"],
+                handler=item["handler"],
+                calls=item["provider_calls"],
+                source=item["source"],
+            )
+        )
+    lines.extend(["", "Claim boundary:", summary["claim_boundary"]])
+    return "\n".join(lines) + "\n"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--requests", default=str(REQUESTS_PATH), help="OpenAI-style request fixture JSON")
+    parser.add_argument("--json-out", help="optional path for structured JSON output")
+    parser.add_argument("--report-md", help="optional path for rendered report output")
+    args = parser.parse_args()
+
+    summary = build_proxy_summary(
+        requests_path=Path(args.requests),
+        json_out=Path(args.json_out) if args.json_out else None,
+    )
+    report = render_report(summary)
+    if args.report_md:
+        report_path = Path(args.report_md)
+        report_path.parent.mkdir(parents=True, exist_ok=True)
+        report_path.write_text(report, encoding="utf-8")
+    print(report, end="")
+    return 0 if summary["ok"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/kora/cli.py
+++ b/kora/cli.py
@@ -50,6 +50,7 @@ def _example_descriptions() -> dict[str, str]:
         "deterministic_classification": "deterministic classification example pack",
         "direct_vs_kora": "direct call vs KORA-controlled path",
         "kora_doctor": "offline doctor-style workload inspection example",
+        "openai_compatible_proxy": "offline OpenAI-style proxy routing example",
         "real_workload_harness": "benchmark/report flow example",
         "real_model_call_validation_fake": "local no-network model-call validation example",
         "runtime_integrated_benchmark": "initial runtime-path benchmark harness",

--- a/tests/test_openai_compatible_proxy_example.py
+++ b/tests/test_openai_compatible_proxy_example.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+def _load_module():
+    script_path = Path("examples/openai_compatible_proxy/run.py")
+    spec = importlib.util.spec_from_file_location("openai_compatible_proxy_run", script_path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError("failed to load openai proxy module")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_openai_compatible_proxy_summary_matches_expected_counters() -> None:
+    module = _load_module()
+    expected = json.loads(
+        Path("examples/openai_compatible_proxy/expected_counters.json").read_text(encoding="utf-8")
+    )
+
+    summary = module.build_proxy_summary()
+
+    assert summary["ok"] is True
+    for key, value in expected.items():
+        assert summary[key] == value
+    assert summary["expected_match_count"] == summary["total_requests"]
+
+
+def test_openai_compatible_proxy_uses_kora_task_graph_path() -> None:
+    module = _load_module()
+
+    summary = module.build_proxy_summary()
+
+    deterministic = [item for item in summary["results"] if item["route_kind"] == "deterministic"]
+    provider_needed = [item for item in summary["results"] if item["route_kind"] == "provider_required"]
+    cache_hits = [item for item in summary["results"] if item["route_kind"] == "cache_hit"]
+    assert deterministic
+    assert provider_needed
+    assert cache_hits
+    assert all(str(item["kora_graph_id"]).startswith("openai-compatible-proxy-") for item in deterministic)
+    assert all(item["handler"] == "classify_by_rules" for item in deterministic)
+    assert cache_hits[0]["handler"] == "cache_reuse"
+    assert all(item["provider_calls"] == 0 for item in summary["results"])
+
+
+def test_openai_compatible_proxy_report_contains_required_sections() -> None:
+    module = _load_module()
+
+    report = module.render_report(module.build_proxy_summary())
+
+    assert "KORA OpenAI-Compatible Proxy Example" in report
+    assert "Total requests: 6" in report
+    assert "Deterministic handled: 3" in report
+    assert "Cache hits: 1" in report
+    assert "Provider-needed: 2" in report
+    assert "Provider calls actually made: 0" in report
+    assert "Claim boundary:" in report
+
+
+def test_openai_compatible_proxy_cli_writes_outputs(tmp_path: Path) -> None:
+    json_out = tmp_path / "proxy.json"
+    report_md = tmp_path / "proxy.md"
+
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "examples/openai_compatible_proxy/run.py",
+            "--json-out",
+            str(json_out),
+            "--report-md",
+            str(report_md),
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert completed.returncode == 0
+    assert "KORA OpenAI-Compatible Proxy Example" in completed.stdout
+    saved = json.loads(json_out.read_text(encoding="utf-8"))
+    assert saved["mode"] == "openai_compatible_proxy_example"
+    assert saved["total_requests"] == 6
+    assert saved["provider_calls_actually_made"] == 0
+    assert report_md.read_text(encoding="utf-8") == completed.stdout
+
+
+def test_openai_compatible_proxy_appears_in_example_listing() -> None:
+    completed = subprocess.run(
+        [sys.executable, "-m", "kora", "examples", "list"],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert completed.returncode == 0
+    assert "openai_compatible_proxy: offline OpenAI-style proxy routing example" in completed.stdout


### PR DESCRIPTION
## Summary
- add `examples/openai_compatible_proxy/` offline OpenAI-style proxy example
- route deterministic classification and cacheable repeated requests before simulated provider fallback
- add expected counters, README/report docs, tests, and CLI example listing entry

## Validation
- `python3 examples/openai_compatible_proxy/run.py`
- `python3 examples/openai_compatible_proxy/run.py --json-out /tmp/kora_goal084_openai_proxy.json --report-md /tmp/kora_goal084_openai_proxy.md`
- `python3 -m kora examples list`
- `python3 -m pytest tests/test_openai_compatible_proxy_example.py tests/test_kora_doctor_cli.py tests/test_first_value_cli.py tests/test_deterministic_classification_expansion_pack.py` -> 31 passed
- `python3 scripts/check_markdown_links_goal082b.py`
- `git diff --check`

## Claim Boundary
This is an offline example. It does not claim production proxy readiness, full OpenAI API compatibility, automatic cost reduction, real API-cost proof, benchmark superiority, or broad workload superiority.
