### PR TITLE
Add reusable OpenAI proxy demo CLI

### DIFF
--- a/OPEN_THIS_FIRST.md
+++ b/OPEN_THIS_FIRST.md
@@ -2,7 +2,7 @@
 
 Status: current public project breadcrumb.
 
-Last updated by: Goal 084.
+Last updated by: Goal 085.
 
 ## Current Status
 
@@ -19,6 +19,7 @@ Current state:
 - packaging strategy now documents the PyPI `kora` collision and the planned future distribution name `getkora`; latest-feature testing remains source-install from the current repository.
 - public first-run acceptance testing has been run against the README/source-install path, KORA Doctor, deterministic classification, and PyPI collision wording.
 - an offline OpenAI-compatible proxy example exists under `examples/openai_compatible_proxy/`, showing KORA routing OpenAI-style chat request objects through deterministic handlers, local cache reuse, or provider-needed fallback without provider calls.
+- the OpenAI-style proxy demo routing logic is now reusable from `kora.openai_proxy_demo`, and `python3 -m kora proxy-demo examples/openai_compatible_proxy/requests.json` runs the same offline no-provider-call path from the first-class CLI.
 - a deterministic classification example pack exists under `examples/deterministic_classification/`, using KORA `TaskGraph` execution across support-ticket routing, issue triage, incident severity routing, document type routing, and log/event classification.
 - a KORA Doctor example exists under `examples/kora_doctor/`, using KORA `TaskGraph` execution to inspect a synthetic workload and explain deterministic candidates, provider-needed candidates, route rationale, counters, and next steps.
 - the KORA Doctor example now includes a report pack mode across four bundled offline workloads and a README refresh proposal for examples-driven positioning.
@@ -30,15 +31,33 @@ Current state:
 
 ## Current Branch
 
-- branch: `goal084_openai_compatible_proxy`
+- branch: `goal085_openai_proxy_module_cli`
 - public truth: `origin/main`
 - branch pushed to: not pushed in this worktree
-- open PR: none for Goal 084
-- base commit: `b925a5163650ed60b97ebc7b1aa2b44d7fda4290`
+- open PR: none for Goal 085
+- base commit: `651ab79e037d334339463efb1df61e9e8812371c`
 
 ## Last Completed Goal
 
-Goal 084 - Implement OpenAI-Compatible Proxy Example.
+Goal 085 - Implement OpenAI Proxy Reusable Module and CLI.
+
+Goal 085 promoted the Goal 084 proxy example's routing logic into `kora.openai_proxy_demo` and added the first-class offline CLI command `python3 -m kora proxy-demo examples/openai_compatible_proxy/requests.json`. The existing `examples/openai_compatible_proxy/run.py` script remains a compatibility wrapper over the reusable module. Both paths make `0` provider calls.
+
+Primary report:
+
+- [Goal 085 OpenAI proxy reusable module and CLI](docs/reports/goal085_openai_proxy_reusable_module_cli.md)
+
+Primary artifacts:
+
+- [Reusable OpenAI proxy demo module](kora/openai_proxy_demo.py)
+- [OpenAI-compatible proxy example README](examples/openai_compatible_proxy/README.md)
+- [OpenAI-compatible proxy runnable wrapper](examples/openai_compatible_proxy/run.py)
+- [OpenAI-compatible proxy request fixture](examples/openai_compatible_proxy/requests.json)
+- [OpenAI-compatible proxy expected counters](examples/openai_compatible_proxy/expected_counters.json)
+
+Claim boundary: In this offline proxy demo, KORA routes deterministic or cacheable OpenAI-style sample requests without making provider calls and marks ambiguous/open-ended requests as provider-needed. It does not claim production proxy readiness, full OpenAI API compatibility, automatic cost reduction, real API-cost proof, benchmark superiority, or broad workload superiority.
+
+Previous completed Goal: Goal 084 - Implement OpenAI-Compatible Proxy Example.
 
 Goal 084 added an offline OpenAI-compatible proxy example under `examples/openai_compatible_proxy/`. The example uses KORA `TaskGraph` execution with the deterministic `classify_by_rules` handler for bounded support-ticket classification requests, local cache reuse for repeated sample requests, and provider-needed fallback labels for ambiguous/open-ended sample requests. It makes `0` provider calls.
 
@@ -284,7 +303,7 @@ KORA makes AI workloads routable. The current KRK public alpha shows how workloa
 
 ## Recommended Next Goal
 
-Goal 084 - Public reviewer walkthrough and example catalog refresh.
+Goal 086 - Public reviewer walkthrough and example catalog refresh.
 
 Recommended scope:
 

--- a/README.md
+++ b/README.md
@@ -94,9 +94,10 @@ Current implemented surfaces in this GitHub repository include:
 - List runnable examples: `python3 -m kora examples list`
 - Run offline examples through the KORA example runner: `python3 -m kora run <example>`
 - Run KORA Doctor sample workload inspection from the first-class CLI: `python3 -m kora doctor examples/kora_doctor/customer_support_workload.json`
+- Run the reusable offline OpenAI-style proxy demo from the first-class CLI: `python3 -m kora proxy-demo examples/openai_compatible_proxy/requests.json`
 - Run the deterministic classification expansion pack.
 - Run the offline OpenAI-compatible proxy example.
-- Run first-value CLI paths: `kora inspect`, `kora compare`, `kora run`, `kora doctor`, and `kora report`
+- Run first-value CLI paths: `kora inspect`, `kora compare`, `kora run`, `kora doctor`, `kora proxy-demo`, and `kora report`
 - Execute deterministic sample tasks through KORA `TaskGraph` paths.
 - Produce local JSON and Markdown/text reports from bundled examples.
 
@@ -110,6 +111,7 @@ After installing from the current repository, start here:
 python3 -m kora examples list
 python3 -m kora doctor examples/kora_doctor/customer_support_workload.json
 python3 -m kora doctor --all examples/kora_doctor/
+python3 -m kora proxy-demo examples/openai_compatible_proxy/requests.json
 python3 examples/openai_compatible_proxy/run.py
 python3 examples/kora_doctor/run.py
 python3 examples/kora_doctor/run.py --all
@@ -120,9 +122,15 @@ The examples require no provider credentials and make no provider calls.
 
 ### OpenAI-Compatible Proxy
 
-The OpenAI-compatible proxy example shows KORA sitting in front of OpenAI-style chat request objects. It routes deterministic classification requests through KORA `TaskGraph` execution, reuses a local cache for repeated sample requests, and marks ambiguous or open-ended sample requests as provider-needed.
+The OpenAI-compatible proxy example shows KORA sitting in front of OpenAI-style chat request objects. It routes deterministic classification requests through reusable KORA proxy-demo logic and KORA `TaskGraph` execution, reuses a local cache for repeated sample requests, and marks ambiguous or open-ended sample requests as provider-needed.
 
-Run the example:
+Run the first-class CLI demo:
+
+```bash
+python3 -m kora proxy-demo examples/openai_compatible_proxy/requests.json
+```
+
+Run the example wrapper:
 
 ```bash
 python3 examples/openai_compatible_proxy/run.py
@@ -141,6 +149,7 @@ Docs:
 
 - [OpenAI-compatible proxy example README](examples/openai_compatible_proxy/README.md)
 - [Goal 084 OpenAI-compatible proxy example](docs/reports/goal084_openai_compatible_proxy_example.md)
+- [Goal 085 OpenAI proxy reusable module and CLI](docs/reports/goal085_openai_proxy_reusable_module_cli.md)
 
 ### KORA Doctor
 

--- a/REVIEW_HUB.md
+++ b/REVIEW_HUB.md
@@ -2,7 +2,7 @@
 
 Status: current public review and continuation hub.
 
-Last updated by: Goal 084.
+Last updated by: Goal 085.
 
 ## Project Identity
 
@@ -14,11 +14,11 @@ KRK means KORA Routing Kernel. KRK is the deterministic-first execution routing 
 
 - repository: `https://github.com/Krako-Labs/KORA`
 - public truth branch: `origin/main`
-- active evidence branch: `goal084_openai_compatible_proxy`
-- worktree label: `goal084_openai_compatible_proxy`
+- active evidence branch: `goal085_openai_proxy_module_cli`
+- worktree label: `goal085_openai_proxy_module_cli`
 - branch pushed to: not pushed in this worktree
-- open PR: none for Goal 084
-- base commit: `b925a5163650ed60b97ebc7b1aa2b44d7fda4290`
+- open PR: none for Goal 085
+- base commit: `651ab79e037d334339463efb1df61e9e8812371c`
 
 ## Current State Summary
 
@@ -36,6 +36,7 @@ KORA now has a public-safe first-value path and an evidence package that covers:
 - distribution strategy documents PyPI `kora` collision, source-install current path, and planned future PyPI distribution name `getkora`.
 - public first-run acceptance testing covers README-only onboarding, fresh source install, KORA Doctor, deterministic classification, and PyPI collision wording.
 - OpenAI-compatible proxy example with offline OpenAI-style chat request fixtures, KORA deterministic routing, local cache reuse, provider-needed fallback labels, and `0` provider calls.
+- reusable OpenAI-style proxy demo module and first-class `kora proxy-demo` CLI command for running the offline proxy/control path over sample request JSON.
 - deterministic classification example pack with KORA `TaskGraph` execution across support-ticket routing, issue triage, incident severity routing, document type routing, and log/event classification.
 - KORA Doctor first-value developer example with KORA `TaskGraph` execution, deterministic candidate/provider-needed candidate inspection, route rationale, counters, and next-step recommendations.
 - KORA Doctor report pack with four bundled offline workloads, aggregate report mode, and a README refresh proposal for examples-driven routing/control positioning.
@@ -80,6 +81,7 @@ This is a sufficient recent history backfill, not a complete reconstruction.
 | Goal 083B | Documented the `getkora` future distribution strategy after verifying the PyPI `kora` collision and current source-install path. | [Goal 083B getkora distribution strategy](docs/reports/goal083b_getkora_distribution_strategy.md) |
 | Goal 083C | Ran public first-run acceptance testing over README onboarding, fresh source install, KORA Doctor, deterministic classification, and PyPI collision wording. | [Goal 083C public first-run acceptance test](docs/reports/goal083c_public_first_run_acceptance_test.md) |
 | Goal 084 | Added an offline OpenAI-compatible proxy example that routes OpenAI-style sample requests through KORA deterministic handling, cache reuse, or provider-needed fallback. | [Goal 084 OpenAI-compatible proxy example](docs/reports/goal084_openai_compatible_proxy_example.md) |
+| Goal 085 | Promoted the OpenAI-style proxy demo into reusable module logic and a first-class offline `kora proxy-demo` CLI command. | [Goal 085 OpenAI proxy reusable module and CLI](docs/reports/goal085_openai_proxy_reusable_module_cli.md) |
 
 ## Evidence Index
 
@@ -106,6 +108,7 @@ Generated summaries:
 Current reviewer path:
 
 - [Goal 082B narrative repositioning](docs/reports/goal082b_narrative_repositioning.md)
+- [Goal 085 OpenAI proxy reusable module and CLI](docs/reports/goal085_openai_proxy_reusable_module_cli.md)
 - [Goal 084 OpenAI-compatible proxy example](docs/reports/goal084_openai_compatible_proxy_example.md)
 - [OpenAI-compatible proxy example README](examples/openai_compatible_proxy/README.md)
 - [Goal 083C public first-run acceptance test](docs/reports/goal083c_public_first_run_acceptance_test.md)
@@ -156,6 +159,7 @@ Supported:
 - KORA has a first-class `kora doctor` CLI command for running the same offline Doctor inspection over sample workload JSON files and bundled workload directories.
 - KORA's planned future PyPI distribution package name is `getkora`; current latest-feature testing requires source install from the repository.
 - KORA has an offline OpenAI-style proxy example where sample chat requests are routed through deterministic handling, local cache reuse, or provider-needed fallback without provider calls.
+- KORA has a reusable offline proxy demo module and first-class `kora proxy-demo` CLI command for routing OpenAI-style sample request JSON without provider calls.
 - Current evidence supports bounded statements about route selectivity, dry-run runtime integration, provider-path validation, bounded H100 execution, expanded H100 representativeness, and fixture-derived output fidelity.
 - KORA has reusable public-safe Project Operating System templates for breadcrumbs, review hubs, ADRs, reports, evidence, claim registries, bootstrap checklists, and project prompts.
 
@@ -193,6 +197,7 @@ kora compare
 kora run
 kora doctor examples/kora_doctor/customer_support_workload.json
 kora doctor --all examples/kora_doctor/
+kora proxy-demo examples/openai_compatible_proxy/requests.json
 kora report --json-out /tmp/kora-first-value.json --md-out /tmp/kora-first-value.md
 ```
 
@@ -205,6 +210,7 @@ python3 -m kora compare
 python3 -m kora run
 python3 -m kora doctor examples/kora_doctor/customer_support_workload.json
 python3 -m kora doctor --all examples/kora_doctor/
+python3 -m kora proxy-demo examples/openai_compatible_proxy/requests.json
 python3 -m kora report --json-out /tmp/kora-first-value.json --md-out /tmp/kora-first-value.md
 ```
 
@@ -360,7 +366,7 @@ Boundary: this is positioning grounded in current examples and evidence. It does
 
 ## Recommended Next Goals
 
-1. Goal 085 - Public reviewer walkthrough and example catalog refresh.
+1. Goal 086 - Public reviewer walkthrough and example catalog refresh.
 2. Goal 086 - Contributor issue seed for examples-first onboarding.
 3. Goal 087 - Contributor issue seed for first-value examples.
 4. Goal 088 - Wheel and source distribution smoke validation.

--- a/docs/README.md
+++ b/docs/README.md
@@ -32,6 +32,7 @@ python3 -m kora doctor examples/kora_doctor/customer_support_workload.json
 - [Open this first](../OPEN_THIS_FIRST.md)
 - [Review hub](../REVIEW_HUB.md)
 - [Goal 083C public first-run acceptance test](reports/goal083c_public_first_run_acceptance_test.md)
+- [Goal 085 OpenAI proxy reusable module and CLI](reports/goal085_openai_proxy_reusable_module_cli.md)
 - [Goal 084 OpenAI-compatible proxy example](reports/goal084_openai_compatible_proxy_example.md)
 - [Goal 083B getkora distribution strategy](reports/goal083b_getkora_distribution_strategy.md)
 - [getkora distribution strategy](packaging/getkora_distribution_strategy.md)
@@ -161,6 +162,7 @@ KORA control layer architecture.
 ## Reports
 
 - [Goal 082B narrative repositioning](reports/goal082b_narrative_repositioning.md)
+- [Goal 085 OpenAI proxy reusable module and CLI](reports/goal085_openai_proxy_reusable_module_cli.md)
 - [Goal 084 OpenAI-compatible proxy example](reports/goal084_openai_compatible_proxy_example.md)
 - [Goal 083C public first-run acceptance test](reports/goal083c_public_first_run_acceptance_test.md)
 - [Goal 083B getkora distribution strategy](reports/goal083b_getkora_distribution_strategy.md)
@@ -242,6 +244,7 @@ python3 -m kora --help
 python3 -m kora examples list
 python3 -m kora doctor examples/kora_doctor/customer_support_workload.json
 python3 -m kora doctor --all examples/kora_doctor/
+python3 -m kora proxy-demo examples/openai_compatible_proxy/requests.json
 python3 examples/openai_compatible_proxy/run.py
 python3 examples/kora_doctor/run.py
 python3 examples/kora_doctor/run.py --all

--- a/docs/reports/goal085_openai_proxy_reusable_module_cli.md
+++ b/docs/reports/goal085_openai_proxy_reusable_module_cli.md
@@ -1,0 +1,147 @@
+# Goal 085 OpenAI Proxy Reusable Module and CLI
+
+## Motivation
+
+Goal 084 showed that KORA can sit in front of OpenAI-style sample requests and route deterministic or cacheable work without making provider calls. Goal 085 promotes that example-local logic into a reusable KORA-owned module and adds a first-class CLI command.
+
+The purpose is reuse for later offline examples such as RAG routing, agent workflow control, cache reuse, and provider-needed fallback demonstrations. This remains an offline demo path, not a production proxy claim.
+
+## User-Facing Walkthrough
+
+Run the reusable CLI demo from a current source checkout:
+
+```bash
+python3 -m kora proxy-demo examples/openai_compatible_proxy/requests.json
+```
+
+Expected high-level output:
+
+```text
+KORA OpenAI Proxy Demo
+
+Total requests: 6
+Deterministic handled: 3
+Cache hits: 1
+Provider-needed: 2
+Avoided simulated provider/model invocations: 4
+Provider calls actually made: 0
+```
+
+The original example wrapper still works:
+
+```bash
+python3 examples/openai_compatible_proxy/run.py
+```
+
+Structured outputs are available from either path:
+
+```bash
+python3 -m kora proxy-demo examples/openai_compatible_proxy/requests.json \
+  --json-out /tmp/kora_goal085_openai_proxy_cli.json \
+  --report-md /tmp/kora_goal085_openai_proxy_cli.md
+```
+
+## Implementation Summary
+
+- Added `kora.openai_proxy_demo` as the reusable offline proxy demo module.
+- Moved request loading, OpenAI-style message extraction, stable request cache keys, KORA `TaskGraph` construction, route execution, OpenAI-style response envelope generation, counter aggregation, JSON writing, and report rendering into the module.
+- Kept `examples/openai_compatible_proxy/run.py` as a compatibility wrapper over the reusable module.
+- Added `python3 -m kora proxy-demo examples/openai_compatible_proxy/requests.json`.
+- Added tests for the reusable module and the CLI command.
+- Updated README/docs and continuation breadcrumbs.
+
+The reusable path still routes every non-cache request through KORA `TaskGraph` execution and the deterministic `classify_by_rules` handler. Cache hits reuse prior deterministic output without provider calls. Ambiguous/open-ended requests are marked provider-needed without external API calls.
+
+## Command Examples
+
+```bash
+python3 -m kora proxy-demo examples/openai_compatible_proxy/requests.json
+python3 -m kora proxy-demo examples/openai_compatible_proxy/requests.json \
+  --json-out /tmp/kora_goal085_openai_proxy_cli.json \
+  --report-md /tmp/kora_goal085_openai_proxy_cli.md
+python3 examples/openai_compatible_proxy/run.py
+python3 -m kora run openai_compatible_proxy
+```
+
+## Evidence Counters
+
+Using `examples/openai_compatible_proxy/requests.json`:
+
+- total requests: `6`
+- deterministic handled: `3`
+- cache hits: `1`
+- provider-needed: `2`
+- avoided simulated provider/model invocations: `4`
+- provider calls actually made: `0`
+
+The counters are sample-fixture counters only.
+
+## Validation Results
+
+Final validation was run from the Goal 085 worktree:
+
+```bash
+python3 examples/openai_compatible_proxy/run.py
+```
+
+Result: passed. The command reported `Total requests: 6`, `Deterministic handled: 3`, `Cache hits: 1`, `Provider-needed: 2`, and `Provider calls actually made: 0`.
+
+```bash
+python3 -m kora proxy-demo examples/openai_compatible_proxy/requests.json
+```
+
+Result: passed. The command reported `KORA OpenAI Proxy Demo` with the same counters and `Provider calls actually made: 0`.
+
+```bash
+python3 -m kora examples list
+```
+
+Result: passed. The output includes `openai_compatible_proxy: offline OpenAI-style proxy routing example`.
+
+```bash
+python3 -m pytest tests/test_openai_proxy_demo_cli.py tests/test_openai_compatible_proxy_example.py tests/test_kora_doctor_cli.py tests/test_first_value_cli.py tests/test_deterministic_classification_expansion_pack.py
+```
+
+Result: passed with `36 passed in 15.43s`.
+
+```bash
+python3 scripts/check_markdown_links_goal082b.py
+```
+
+Result: passed with `Goal 082B markdown links OK`.
+
+```bash
+git diff --check
+```
+
+Result: passed with no output.
+
+## Limitations
+
+- The proxy demo accepts a small repository-owned OpenAI-style fixture format; it is not a full OpenAI API implementation.
+- It does not start an HTTP server.
+- It does not call OpenAI or any other external provider.
+- Cache reuse is local to a single demo run.
+- Route rules are synthetic and bounded to the sample requests.
+- Provider-needed means "would require provider/model handling in a real system"; no provider invocation is made here.
+
+## Claim Boundaries
+
+Supported narrow wording:
+
+> In this offline proxy demo, KORA routes deterministic or cacheable OpenAI-style sample requests without making provider calls and marks ambiguous/open-ended requests as provider-needed.
+
+Not claimed:
+
+- production proxy readiness.
+- full OpenAI API compatibility.
+- automatic cost reduction.
+- real API-cost proof.
+- benchmark superiority.
+- broad workload superiority.
+- production validation.
+- model replacement.
+
+## Recommended Next Goal
+
+Goal 086 should refresh the public reviewer path around the example catalog and make the fastest first-run route explicit now that KORA has first-class `doctor` and `proxy-demo` CLI surfaces.

--- a/examples/openai_compatible_proxy/README.md
+++ b/examples/openai_compatible_proxy/README.md
@@ -1,10 +1,18 @@
 # OpenAI-Compatible Proxy Example
 
-This offline example shows KORA sitting in front of OpenAI-style chat request objects. It routes bounded classification requests through KORA deterministic handlers, reuses a local cache for repeated requests, and marks ambiguous or open-ended requests as provider-needed without making external API calls.
+This offline example shows KORA sitting in front of OpenAI-style chat request objects. It routes bounded classification requests through reusable KORA proxy-demo logic and KORA deterministic handlers, reuses a local cache for repeated requests, and marks ambiguous or open-ended requests as provider-needed without making external API calls.
 
 Current availability: run this example from a current `Krako-Labs/KORA` checkout installed from source. Plain `python3 -m pip install kora` installs a different PyPI project and should not be used for these examples. Future package distribution is planned as `getkora`, but this README does not claim that package is published.
 
 ## Quick Run
+
+Run the first-class CLI demo:
+
+```bash
+python3 -m kora proxy-demo examples/openai_compatible_proxy/requests.json
+```
+
+Run the example wrapper:
 
 ```bash
 python3 examples/openai_compatible_proxy/run.py
@@ -14,8 +22,16 @@ Write structured JSON and a report:
 
 ```bash
 python3 examples/openai_compatible_proxy/run.py \
-  --json-out /tmp/kora_goal084_openai_proxy.json \
-  --report-md /tmp/kora_goal084_openai_proxy.md
+  --json-out /tmp/kora_goal085_openai_proxy.json \
+  --report-md /tmp/kora_goal085_openai_proxy.md
+```
+
+Write structured JSON and a report from the CLI:
+
+```bash
+python3 -m kora proxy-demo examples/openai_compatible_proxy/requests.json \
+  --json-out /tmp/kora_goal085_openai_proxy_cli.json \
+  --report-md /tmp/kora_goal085_openai_proxy_cli.md
 ```
 
 Run through the KORA example runner:
@@ -48,8 +64,10 @@ Provider calls actually made: 0
 
 Expected counters are in [expected_counters.json](expected_counters.json). OpenAI-style request fixtures are in [requests.json](requests.json).
 
+The reusable proxy demo implementation lives in `kora.openai_proxy_demo`. The example script is a compatibility wrapper around that module.
+
 ## Claim Boundary
 
-In this offline OpenAI-style proxy example, KORA routes deterministic or cacheable sample requests without making provider calls and marks ambiguous/open-ended requests as provider-needed.
+In this offline proxy demo, KORA routes deterministic or cacheable OpenAI-style sample requests without making provider calls and marks ambiguous/open-ended requests as provider-needed.
 
 This example does not claim production proxy readiness, full OpenAI API compatibility, automatic cost reduction, real API-cost proof, benchmark superiority, or broad workload superiority.

--- a/examples/openai_compatible_proxy/run.py
+++ b/examples/openai_compatible_proxy/run.py
@@ -1,272 +1,41 @@
-"""Offline OpenAI-compatible proxy example using KORA task execution."""
+"""Offline OpenAI-compatible proxy example using reusable KORA routing logic."""
 
 from __future__ import annotations
 
 import argparse
-import hashlib
-import json
 import sys
 from pathlib import Path
-from typing import Any
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
-from kora.executor import run_graph
-from kora.task_ir import TaskGraph, normalize_graph, validate_graph
+from kora.openai_proxy_demo import (
+    build_proxy_summary as build_reusable_proxy_summary,
+    render_report as render_reusable_report,
+    write_report,
+)
 
 EXAMPLE_DIR = Path(__file__).resolve().parent
 REQUESTS_PATH = EXAMPLE_DIR / "requests.json"
 EXPECTED_COUNTERS_PATH = EXAMPLE_DIR / "expected_counters.json"
-CLAIM_BOUNDARY = (
-    "In this offline OpenAI-style proxy example, KORA routes deterministic or "
-    "cacheable sample requests without making provider calls and marks "
-    "ambiguous/open-ended requests as provider-needed. It does not claim "
-    "production proxy readiness, full OpenAI API compatibility, automatic cost "
-    "reduction, real API-cost proof, benchmark superiority, or broad workload superiority."
-)
-
-
-def load_requests(path: Path = REQUESTS_PATH) -> dict[str, Any]:
-    return json.loads(path.read_text(encoding="utf-8"))
-
-
-def _message_text(request: dict[str, Any]) -> str:
-    messages = request.get("messages", [])
-    if not isinstance(messages, list):
-        return ""
-    parts: list[str] = []
-    for message in messages:
-        if not isinstance(message, dict):
-            continue
-        content = message.get("content", "")
-        if isinstance(content, str):
-            parts.append(content)
-        elif isinstance(content, list):
-            for item in content:
-                if isinstance(item, dict) and isinstance(item.get("text"), str):
-                    parts.append(str(item["text"]))
-    return " ".join(parts)
-
-
-def _request_cache_key(request: dict[str, Any]) -> str:
-    canonical = json.dumps(request, sort_keys=True, separators=(",", ":"))
-    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
-
-
-def _classification_graph(config: dict[str, Any], request_id: str, text: str) -> TaskGraph:
-    return TaskGraph.model_validate(
-        {
-            "graph_id": f"openai-compatible-proxy-{request_id}",
-            "version": "0.1",
-            "root": "classify",
-            "defaults": {"budget": {"max_time_ms": 1500, "max_tokens": 300, "max_retries": 0}},
-            "tasks": [
-                {
-                    "id": "classify",
-                    "type": "det.proxy.openai_compatible_classification",
-                    "deps": [],
-                    "in": {"text": text},
-                    "run": {
-                        "kind": "det",
-                        "spec": {
-                            "handler": "classify_by_rules",
-                            "args": {
-                                "scenario_id": "openai_compatible_proxy",
-                                "routes": config["routes"],
-                                "provider_required_route": config["provider_required_route"],
-                            },
-                        },
-                    },
-                    "policy": {"on_fail": "fail"},
-                    "tags": ["openai-compatible-proxy", "offline-example"],
-                }
-            ],
-        }
-    )
-
-
-def _run_kora_route(config: dict[str, Any], request_id: str, request: dict[str, Any]) -> dict[str, Any]:
-    text = _message_text(request)
-    graph = normalize_graph(_classification_graph(config, request_id, text))
-    validate_graph(graph)
-    result = run_graph(graph)
-    if not result.get("ok"):
-        raise RuntimeError(str(result.get("error")))
-    final = result.get("final")
-    if not isinstance(final, dict):
-        raise RuntimeError("proxy graph did not return an object")
-    routed = dict(final)
-    routed.update(
-        {
-            "kora_graph_id": result["graph_id"],
-            "kora_event_count": len(result.get("events", [])),
-        }
-    )
-    return routed
-
-
-def _openai_style_response(request_id: str, route: dict[str, Any], source: str) -> dict[str, Any]:
-    return {
-        "id": f"chatcmpl-kora-{request_id}",
-        "object": "chat.completion",
-        "choices": [
-            {
-                "index": 0,
-                "finish_reason": "stop",
-                "message": {
-                    "role": "assistant",
-                    "content": json.dumps(
-                        {
-                            "source": source,
-                            "route_kind": route["route_kind"],
-                            "selected_route": route["selected_route"],
-                            "classification_output": route.get("classification_output"),
-                            "provider_needed_reason": route.get("provider_needed_reason"),
-                        },
-                        sort_keys=True,
-                    ),
-                },
-            }
-        ],
-        "usage": {"prompt_tokens": 0, "completion_tokens": 0, "total_tokens": 0},
-        "provider_calls": 0,
-    }
 
 
 def build_proxy_summary(
     *,
     requests_path: Path = REQUESTS_PATH,
     json_out: Path | None = None,
-) -> dict[str, Any]:
-    config = load_requests(requests_path)
-    cache: dict[str, dict[str, Any]] = {}
-    results: list[dict[str, Any]] = []
-
-    for item in config["requests"]:
-        request_id = str(item["id"])
-        request = item["request"]
-        cache_key = _request_cache_key(request)
-
-        if cache_key in cache:
-            cached = cache[cache_key]
-            route = dict(cached["route"])
-            route.update(
-                {
-                    "route_kind": "cache_hit",
-                    "selected_route": "proxy.cache.reuse",
-                    "provider_needed_reason": None,
-                }
-            )
-            handler = "cache_reuse"
-            source = "cache"
-            graph_id = cached["route"].get("kora_graph_id")
-            event_count = 0
-        else:
-            route = _run_kora_route(config, request_id, request)
-            handler = "classify_by_rules" if route["route_kind"] == "deterministic" else "provider_needed_fallback"
-            source = "kora_task_graph"
-            graph_id = route.get("kora_graph_id")
-            event_count = route.get("kora_event_count", 0)
-            if route["route_kind"] == "deterministic":
-                cache[cache_key] = {"route": route}
-
-        proxy_response = _openai_style_response(request_id, route, source)
-        results.append(
-            {
-                "id": request_id,
-                "openai_style_request": request,
-                "request_text": _message_text(request),
-                "route_kind": route["route_kind"],
-                "selected_route": route["selected_route"],
-                "handler": handler,
-                "classification_output": route.get("classification_output"),
-                "provider_needed_reason": route.get("provider_needed_reason"),
-                "provider_calls": 0,
-                "cache_key": cache_key,
-                "source": source,
-                "kora_graph_id": graph_id,
-                "kora_event_count": event_count,
-                "openai_style_response": proxy_response,
-                "expected_route_kind": item["expected_route_kind"],
-                "expected_handler": item["expected_handler"],
-            }
-        )
-
-    total_requests = len(results)
-    deterministic_handled = sum(1 for item in results if item["route_kind"] == "deterministic")
-    cache_hits = sum(1 for item in results if item["route_kind"] == "cache_hit")
-    provider_needed = sum(1 for item in results if item["route_kind"] == "provider_required")
-    provider_calls = sum(int(item["provider_calls"]) for item in results)
-    expected_match_count = sum(
-        1
-        for item in results
-        if item["route_kind"] == item["expected_route_kind"]
-        and item["handler"] == item["expected_handler"]
+) -> dict:
+    return build_reusable_proxy_summary(
+        requests_path=requests_path,
+        expected_counters_path=EXPECTED_COUNTERS_PATH,
+        json_out=json_out,
+        mode="openai_compatible_proxy_example",
     )
-    avoided_provider_invocations = deterministic_handled + cache_hits
-    counters = {
-        "total_requests": total_requests,
-        "deterministic_handled": deterministic_handled,
-        "cache_hits": cache_hits,
-        "provider_needed": provider_needed,
-        "avoided_provider_invocations": avoided_provider_invocations,
-        "provider_calls_actually_made": provider_calls,
-    }
-    expected_counters = json.loads(EXPECTED_COUNTERS_PATH.read_text(encoding="utf-8"))
-    summary: dict[str, Any] = {
-        "ok": counters == expected_counters and expected_match_count == total_requests,
-        "mode": "openai_compatible_proxy_example",
-        **counters,
-        "expected_match_count": expected_match_count,
-        "results": results,
-        "example_request": results[0],
-        "safe_example_claim": (
-            "In this offline OpenAI-style proxy example, KORA routes deterministic or "
-            "cacheable sample requests without making provider calls and marks "
-            "ambiguous/open-ended requests as provider-needed."
-        ),
-        "claim_boundary": CLAIM_BOUNDARY,
-    }
-    if json_out is not None:
-        json_out.parent.mkdir(parents=True, exist_ok=True)
-        json_out.write_text(json.dumps(summary, indent=2, sort_keys=True) + "\n", encoding="utf-8")
-    return summary
 
 
-def render_report(summary: dict[str, Any]) -> str:
-    example = summary["example_request"]
-    lines = [
-        "KORA OpenAI-Compatible Proxy Example",
-        "",
-        f"Total requests: {summary['total_requests']}",
-        f"Deterministic handled: {summary['deterministic_handled']}",
-        f"Cache hits: {summary['cache_hits']}",
-        f"Provider-needed: {summary['provider_needed']}",
-        f"Avoided simulated provider/model invocations: {summary['avoided_provider_invocations']}",
-        f"Provider calls actually made: {summary['provider_calls_actually_made']}",
-        "",
-        "Example request:",
-        f"- OpenAI-style chat request: \"{example['request_text'].split(':', 1)[-1].strip()}\"",
-        f"- Route: {example['route_kind']}",
-        f"- Handler: {example['handler']}",
-        f"- Provider calls: {example['provider_calls']}",
-        "",
-        "Comparison surface:",
-    ]
-    for item in summary["results"]:
-        lines.append(
-            "- {id}: route={route}, handler={handler}, provider_calls={calls}, source={source}".format(
-                id=item["id"],
-                route=item["route_kind"],
-                handler=item["handler"],
-                calls=item["provider_calls"],
-                source=item["source"],
-            )
-        )
-    lines.extend(["", "Claim boundary:", summary["claim_boundary"]])
-    return "\n".join(lines) + "\n"
+def render_report(summary: dict) -> str:
+    return render_reusable_report(summary, title="KORA OpenAI-Compatible Proxy Example")
 
 
 def main() -> int:
@@ -281,10 +50,7 @@ def main() -> int:
         json_out=Path(args.json_out) if args.json_out else None,
     )
     report = render_report(summary)
-    if args.report_md:
-        report_path = Path(args.report_md)
-        report_path.parent.mkdir(parents=True, exist_ok=True)
-        report_path.write_text(report, encoding="utf-8")
+    write_report(report, Path(args.report_md) if args.report_md else None)
     print(report, end="")
     return 0 if summary["ok"] else 1
 

--- a/kora/cli.py
+++ b/kora/cli.py
@@ -16,6 +16,12 @@ from kora.five_minute_first_value import (
     render_markdown_summary as render_first_value_markdown,
     write_outputs as write_first_value_outputs,
 )
+from kora.openai_proxy_demo import (
+    DEFAULT_EXPECTED_COUNTERS_PATH,
+    build_proxy_summary,
+    render_report as render_proxy_report,
+    write_report as write_proxy_report,
+)
 from kora.studio_server import (
     DEFAULT_STUDIO_HOST,
     DEFAULT_STUDIO_PORT,
@@ -145,6 +151,34 @@ def _run_doctor_command(
         report_path = Path(report_md)
         report_path.parent.mkdir(parents=True, exist_ok=True)
         report_path.write_text(report, encoding="utf-8")
+    print(report, end="")
+    return 0 if summary["ok"] else 1
+
+
+def _run_proxy_demo_command(
+    requests_path: str,
+    *,
+    json_out: str | None,
+    report_md: str | None,
+) -> int:
+    path = Path(requests_path)
+    if not path.exists() or not path.is_file():
+        print(f"KORA proxy demo request JSON not found: {path}", file=sys.stderr)
+        return 2
+
+    try:
+        summary = build_proxy_summary(
+            requests_path=path,
+            expected_counters_path=DEFAULT_EXPECTED_COUNTERS_PATH,
+            json_out=Path(json_out) if json_out else None,
+            mode="openai_proxy_demo_cli",
+        )
+    except (json.JSONDecodeError, KeyError, RuntimeError, ValueError) as e:
+        print(f"KORA proxy demo failed: {e}", file=sys.stderr)
+        return 1
+
+    report = render_proxy_report(summary)
+    write_proxy_report(report, Path(report_md) if report_md else None)
     print(report, end="")
     return 0 if summary["ok"] else 1
 
@@ -325,6 +359,19 @@ def main(argv: list[str] | None = None) -> int:
     doctor_parser.add_argument("--json-out", help="optional path for structured JSON output")
     doctor_parser.add_argument("--report-md", help="optional path for the rendered text report")
 
+    proxy_demo_parser = subparsers.add_parser(
+        "proxy-demo",
+        help="run the offline OpenAI-style proxy demo",
+        description=(
+            "Run the offline KORA proxy demo for OpenAI-style sample request JSON. "
+            "The demo routes deterministic or cacheable sample requests without provider calls "
+            "and marks ambiguous/open-ended requests as provider-needed."
+        ),
+    )
+    proxy_demo_parser.add_argument("requests_path", help="OpenAI-style request fixture JSON")
+    proxy_demo_parser.add_argument("--json-out", help="optional path for structured JSON output")
+    proxy_demo_parser.add_argument("--report-md", help="optional path for the rendered text report")
+
     run_parser = subparsers.add_parser(
         "run",
         help="run the public-safe first-value fixture path or a named example",
@@ -386,6 +433,13 @@ def main(argv: list[str] | None = None) -> int:
         return _run_doctor_command(
             args.workload_path,
             all_workloads=args.all,
+            json_out=args.json_out,
+            report_md=args.report_md,
+        )
+
+    if args.command == "proxy-demo":
+        return _run_proxy_demo_command(
+            args.requests_path,
             json_out=args.json_out,
             report_md=args.report_md,
         )

--- a/kora/openai_proxy_demo.py
+++ b/kora/openai_proxy_demo.py
@@ -1,0 +1,292 @@
+"""Reusable offline OpenAI-style proxy demo routing utilities."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+from typing import Any
+
+from kora.executor import run_graph
+from kora.task_ir import TaskGraph, normalize_graph, validate_graph
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+DEFAULT_REQUESTS_PATH = REPO_ROOT / "examples" / "openai_compatible_proxy" / "requests.json"
+DEFAULT_EXPECTED_COUNTERS_PATH = (
+    REPO_ROOT / "examples" / "openai_compatible_proxy" / "expected_counters.json"
+)
+CLAIM_BOUNDARY = (
+    "In this offline proxy demo, KORA routes deterministic or cacheable "
+    "OpenAI-style sample requests without making provider calls and marks "
+    "ambiguous/open-ended requests as provider-needed. It does not claim "
+    "production proxy readiness, full OpenAI API compatibility, automatic cost "
+    "reduction, real API-cost proof, benchmark superiority, or broad workload superiority."
+)
+SAFE_EXAMPLE_CLAIM = (
+    "In this offline proxy demo, KORA routes deterministic or cacheable "
+    "OpenAI-style sample requests without making provider calls and marks "
+    "ambiguous/open-ended requests as provider-needed."
+)
+
+
+def load_requests(path: Path = DEFAULT_REQUESTS_PATH) -> dict[str, Any]:
+    """Load an OpenAI-style request fixture."""
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def message_text(request: dict[str, Any]) -> str:
+    """Extract text from OpenAI-style chat message content."""
+    messages = request.get("messages", [])
+    if not isinstance(messages, list):
+        return ""
+    parts: list[str] = []
+    for message in messages:
+        if not isinstance(message, dict):
+            continue
+        content = message.get("content", "")
+        if isinstance(content, str):
+            parts.append(content)
+        elif isinstance(content, list):
+            for item in content:
+                if isinstance(item, dict) and isinstance(item.get("text"), str):
+                    parts.append(str(item["text"]))
+    return " ".join(parts)
+
+
+def request_cache_key(request: dict[str, Any]) -> str:
+    """Return a stable cache key for an OpenAI-style request object."""
+    canonical = json.dumps(request, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+def classification_graph(config: dict[str, Any], request_id: str, text: str) -> TaskGraph:
+    """Build the KORA TaskGraph used by the offline proxy demo."""
+    return TaskGraph.model_validate(
+        {
+            "graph_id": f"openai-compatible-proxy-{request_id}",
+            "version": "0.1",
+            "root": "classify",
+            "defaults": {"budget": {"max_time_ms": 1500, "max_tokens": 300, "max_retries": 0}},
+            "tasks": [
+                {
+                    "id": "classify",
+                    "type": "det.proxy.openai_compatible_classification",
+                    "deps": [],
+                    "in": {"text": text},
+                    "run": {
+                        "kind": "det",
+                        "spec": {
+                            "handler": "classify_by_rules",
+                            "args": {
+                                "scenario_id": "openai_compatible_proxy",
+                                "routes": config["routes"],
+                                "provider_required_route": config["provider_required_route"],
+                            },
+                        },
+                    },
+                    "policy": {"on_fail": "fail"},
+                    "tags": ["openai-compatible-proxy", "offline-demo"],
+                }
+            ],
+        }
+    )
+
+
+def run_kora_route(config: dict[str, Any], request_id: str, request: dict[str, Any]) -> dict[str, Any]:
+    """Route one OpenAI-style request through KORA TaskGraph execution."""
+    text = message_text(request)
+    graph = normalize_graph(classification_graph(config, request_id, text))
+    validate_graph(graph)
+    result = run_graph(graph)
+    if not result.get("ok"):
+        raise RuntimeError(str(result.get("error")))
+    final = result.get("final")
+    if not isinstance(final, dict):
+        raise RuntimeError("proxy graph did not return an object")
+    routed = dict(final)
+    routed.update(
+        {
+            "kora_graph_id": result["graph_id"],
+            "kora_event_count": len(result.get("events", [])),
+        }
+    )
+    return routed
+
+
+def openai_style_response(request_id: str, route: dict[str, Any], source: str) -> dict[str, Any]:
+    """Build a small OpenAI-style response envelope for demo output."""
+    return {
+        "id": f"chatcmpl-kora-{request_id}",
+        "object": "chat.completion",
+        "choices": [
+            {
+                "index": 0,
+                "finish_reason": "stop",
+                "message": {
+                    "role": "assistant",
+                    "content": json.dumps(
+                        {
+                            "source": source,
+                            "route_kind": route["route_kind"],
+                            "selected_route": route["selected_route"],
+                            "classification_output": route.get("classification_output"),
+                            "provider_needed_reason": route.get("provider_needed_reason"),
+                        },
+                        sort_keys=True,
+                    ),
+                },
+            }
+        ],
+        "usage": {"prompt_tokens": 0, "completion_tokens": 0, "total_tokens": 0},
+        "provider_calls": 0,
+    }
+
+
+def build_proxy_summary(
+    *,
+    requests_path: Path = DEFAULT_REQUESTS_PATH,
+    expected_counters_path: Path | None = DEFAULT_EXPECTED_COUNTERS_PATH,
+    json_out: Path | None = None,
+    mode: str = "openai_proxy_demo",
+) -> dict[str, Any]:
+    """Run the offline proxy demo and return structured evidence."""
+    config = load_requests(requests_path)
+    cache: dict[str, dict[str, Any]] = {}
+    results: list[dict[str, Any]] = []
+
+    for item in config["requests"]:
+        request_id = str(item["id"])
+        request = item["request"]
+        cache_key = request_cache_key(request)
+
+        if cache_key in cache:
+            cached = cache[cache_key]
+            route = dict(cached["route"])
+            route.update(
+                {
+                    "route_kind": "cache_hit",
+                    "selected_route": "proxy.cache.reuse",
+                    "provider_needed_reason": None,
+                }
+            )
+            handler = "cache_reuse"
+            source = "cache"
+            graph_id = cached["route"].get("kora_graph_id")
+            event_count = 0
+        else:
+            route = run_kora_route(config, request_id, request)
+            handler = (
+                "classify_by_rules"
+                if route["route_kind"] == "deterministic"
+                else "provider_needed_fallback"
+            )
+            source = "kora_task_graph"
+            graph_id = route.get("kora_graph_id")
+            event_count = route.get("kora_event_count", 0)
+            if route["route_kind"] == "deterministic":
+                cache[cache_key] = {"route": route}
+
+        proxy_response = openai_style_response(request_id, route, source)
+        results.append(
+            {
+                "id": request_id,
+                "openai_style_request": request,
+                "request_text": message_text(request),
+                "route_kind": route["route_kind"],
+                "selected_route": route["selected_route"],
+                "handler": handler,
+                "classification_output": route.get("classification_output"),
+                "provider_needed_reason": route.get("provider_needed_reason"),
+                "provider_calls": 0,
+                "cache_key": cache_key,
+                "source": source,
+                "kora_graph_id": graph_id,
+                "kora_event_count": event_count,
+                "openai_style_response": proxy_response,
+                "expected_route_kind": item["expected_route_kind"],
+                "expected_handler": item["expected_handler"],
+            }
+        )
+
+    total_requests = len(results)
+    deterministic_handled = sum(1 for item in results if item["route_kind"] == "deterministic")
+    cache_hits = sum(1 for item in results if item["route_kind"] == "cache_hit")
+    provider_needed = sum(1 for item in results if item["route_kind"] == "provider_required")
+    provider_calls = sum(int(item["provider_calls"]) for item in results)
+    expected_match_count = sum(
+        1
+        for item in results
+        if item["route_kind"] == item["expected_route_kind"]
+        and item["handler"] == item["expected_handler"]
+    )
+    avoided_provider_invocations = deterministic_handled + cache_hits
+    counters = {
+        "total_requests": total_requests,
+        "deterministic_handled": deterministic_handled,
+        "cache_hits": cache_hits,
+        "provider_needed": provider_needed,
+        "avoided_provider_invocations": avoided_provider_invocations,
+        "provider_calls_actually_made": provider_calls,
+    }
+    expected_counters = (
+        json.loads(expected_counters_path.read_text(encoding="utf-8"))
+        if expected_counters_path is not None and expected_counters_path.exists()
+        else counters
+    )
+    summary: dict[str, Any] = {
+        "ok": counters == expected_counters and expected_match_count == total_requests,
+        "mode": mode,
+        **counters,
+        "expected_match_count": expected_match_count,
+        "results": results,
+        "example_request": results[0],
+        "safe_example_claim": SAFE_EXAMPLE_CLAIM,
+        "claim_boundary": CLAIM_BOUNDARY,
+    }
+    if json_out is not None:
+        json_out.parent.mkdir(parents=True, exist_ok=True)
+        json_out.write_text(json.dumps(summary, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return summary
+
+
+def render_report(summary: dict[str, Any], *, title: str = "KORA OpenAI Proxy Demo") -> str:
+    """Render the proxy summary as a concise CLI/example report."""
+    example = summary["example_request"]
+    lines = [
+        title,
+        "",
+        f"Total requests: {summary['total_requests']}",
+        f"Deterministic handled: {summary['deterministic_handled']}",
+        f"Cache hits: {summary['cache_hits']}",
+        f"Provider-needed: {summary['provider_needed']}",
+        f"Avoided simulated provider/model invocations: {summary['avoided_provider_invocations']}",
+        f"Provider calls actually made: {summary['provider_calls_actually_made']}",
+        "",
+        "Example request:",
+        f"- OpenAI-style chat request: \"{example['request_text'].split(':', 1)[-1].strip()}\"",
+        f"- Route: {example['route_kind']}",
+        f"- Handler: {example['handler']}",
+        f"- Provider calls: {example['provider_calls']}",
+        "",
+        "Comparison surface:",
+    ]
+    for item in summary["results"]:
+        lines.append(
+            "- {id}: route={route}, handler={handler}, provider_calls={calls}, source={source}".format(
+                id=item["id"],
+                route=item["route_kind"],
+                handler=item["handler"],
+                calls=item["provider_calls"],
+                source=item["source"],
+            )
+        )
+    lines.extend(["", "Claim boundary:", summary["claim_boundary"]])
+    return "\n".join(lines) + "\n"
+
+
+def write_report(report: str, report_md: Path | None) -> None:
+    """Write a rendered report when an output path is provided."""
+    if report_md is None:
+        return
+    report_md.parent.mkdir(parents=True, exist_ok=True)
+    report_md.write_text(report, encoding="utf-8")

--- a/tests/test_first_value_cli.py
+++ b/tests/test_first_value_cli.py
@@ -36,12 +36,13 @@ def test_top_level_help_lists_first_value_commands() -> None:
     assert "inspect" in completed.stdout
     assert "compare" in completed.stdout
     assert "doctor" in completed.stdout
+    assert "proxy-demo" in completed.stdout
     assert "run" in completed.stdout
     assert "report" in completed.stdout
 
 
 def test_first_value_command_help_works() -> None:
-    for command in ("inspect", "compare", "doctor", "run", "report"):
+    for command in ("inspect", "compare", "doctor", "proxy-demo", "run", "report"):
         completed = _run_kora(command, "--help")
         assert completed.returncode == 0
         assert command in completed.stdout

--- a/tests/test_openai_proxy_demo_cli.py
+++ b/tests/test_openai_proxy_demo_cli.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+from kora.openai_proxy_demo import (
+    DEFAULT_REQUESTS_PATH,
+    build_proxy_summary,
+    message_text,
+    request_cache_key,
+)
+
+
+def _run_kora(*args: str) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    env.pop("OPENAI_API_KEY", None)
+    env.pop("ANTHROPIC_API_KEY", None)
+    return subprocess.run(
+        [sys.executable, "-m", "kora", *args],
+        check=False,
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+
+def test_proxy_demo_module_matches_expected_counters() -> None:
+    expected = json.loads(
+        Path("examples/openai_compatible_proxy/expected_counters.json").read_text(encoding="utf-8")
+    )
+
+    summary = build_proxy_summary(requests_path=DEFAULT_REQUESTS_PATH)
+
+    assert summary["ok"] is True
+    for key, value in expected.items():
+        assert summary[key] == value
+    assert summary["mode"] == "openai_proxy_demo"
+    assert summary["expected_match_count"] == summary["total_requests"]
+    assert summary["provider_calls_actually_made"] == 0
+
+
+def test_proxy_demo_module_uses_kora_graph_and_cache_paths() -> None:
+    summary = build_proxy_summary(requests_path=DEFAULT_REQUESTS_PATH)
+
+    deterministic = [item for item in summary["results"] if item["route_kind"] == "deterministic"]
+    cache_hits = [item for item in summary["results"] if item["route_kind"] == "cache_hit"]
+    provider_needed = [item for item in summary["results"] if item["route_kind"] == "provider_required"]
+
+    assert len(deterministic) == 3
+    assert len(cache_hits) == 1
+    assert len(provider_needed) == 2
+    assert all(item["source"] == "kora_task_graph" for item in deterministic)
+    assert all(str(item["kora_graph_id"]).startswith("openai-compatible-proxy-") for item in deterministic)
+    assert cache_hits[0]["source"] == "cache"
+    assert cache_hits[0]["selected_route"] == "proxy.cache.reuse"
+    assert all(item["handler"] == "provider_needed_fallback" for item in provider_needed)
+
+
+def test_proxy_demo_module_extracts_chat_message_text_and_cache_key() -> None:
+    request = {
+        "model": "gpt-4o-mini",
+        "messages": [
+            {"role": "system", "content": "Classify only."},
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "Classify this ticket:"},
+                    {"type": "text", "text": "Customer was charged twice"},
+                ],
+            },
+        ],
+    }
+
+    assert message_text(request) == "Classify only. Classify this ticket: Customer was charged twice"
+    assert request_cache_key(request) == request_cache_key(dict(reversed(list(request.items()))))
+
+
+def test_proxy_demo_cli_runs_and_writes_outputs(tmp_path: Path) -> None:
+    json_out = tmp_path / "proxy_demo.json"
+    report_md = tmp_path / "proxy_demo.md"
+
+    completed = _run_kora(
+        "proxy-demo",
+        "examples/openai_compatible_proxy/requests.json",
+        "--json-out",
+        str(json_out),
+        "--report-md",
+        str(report_md),
+    )
+
+    assert completed.returncode == 0
+    assert "KORA OpenAI Proxy Demo" in completed.stdout
+    assert "Total requests: 6" in completed.stdout
+    assert "Cache hits: 1" in completed.stdout
+    assert "Provider calls actually made: 0" in completed.stdout
+    saved = json.loads(json_out.read_text(encoding="utf-8"))
+    assert saved["mode"] == "openai_proxy_demo_cli"
+    assert saved["avoided_provider_invocations"] == 4
+    assert saved["provider_calls_actually_made"] == 0
+    assert report_md.read_text(encoding="utf-8") == completed.stdout
+
+
+def test_proxy_demo_cli_missing_file_fails_cleanly() -> None:
+    completed = _run_kora("proxy-demo", "/tmp/not-a-kora-proxy-fixture.json")
+
+    assert completed.returncode == 2
+    assert "KORA proxy demo request JSON not found" in completed.stderr


### PR DESCRIPTION
## Summary
- extract the OpenAI-style proxy demo routing logic into `kora.openai_proxy_demo`
- add first-class `python3 -m kora proxy-demo examples/openai_compatible_proxy/requests.json`
- keep `examples/openai_compatible_proxy/run.py` working as a compatibility wrapper
- add module/CLI tests and update docs, breadcrumbs, and Goal 085 report

## Validation
- `python3 examples/openai_compatible_proxy/run.py`
- `python3 -m kora proxy-demo examples/openai_compatible_proxy/requests.json`
- `python3 -m kora examples list`
- `python3 -m pytest tests/test_openai_proxy_demo_cli.py tests/test_openai_compatible_proxy_example.py tests/test_kora_doctor_cli.py tests/test_first_value_cli.py tests/test_deterministic_classification_expansion_pack.py` -> 36 passed
- `python3 scripts/check_markdown_links_goal082b.py`
- `git diff --check`

## Claim Boundary
In this offline proxy demo, KORA routes deterministic or cacheable OpenAI-style sample requests without making provider calls and marks ambiguous/open-ended requests as provider-needed. This does not claim production proxy readiness, full OpenAI API compatibility, automatic cost reduction, real API-cost proof, benchmark superiority, or broad workload superiority.
