### PR TITLE
Add offline RAG routing example

### DIFF
--- a/OPEN_THIS_FIRST.md
+++ b/OPEN_THIS_FIRST.md
@@ -2,7 +2,7 @@
 
 Status: current public project breadcrumb.
 
-Last updated by: Goal 085.
+Last updated by: Goal 086.
 
 ## Current Status
 
@@ -20,6 +20,7 @@ Current state:
 - public first-run acceptance testing has been run against the README/source-install path, KORA Doctor, deterministic classification, and PyPI collision wording.
 - an offline OpenAI-compatible proxy example exists under `examples/openai_compatible_proxy/`, showing KORA routing OpenAI-style chat request objects through deterministic handlers, local cache reuse, or provider-needed fallback without provider calls.
 - the OpenAI-style proxy demo routing logic is now reusable from `kora.openai_proxy_demo`, and `python3 -m kora proxy-demo examples/openai_compatible_proxy/requests.json` runs the same offline no-provider-call path from the first-class CLI.
+- an offline RAG routing example exists under `examples/rag_routing/`, showing KORA routing sample queries across deterministic answers, cache hits, retrieval-needed handling, and provider-needed fallback without provider calls.
 - a deterministic classification example pack exists under `examples/deterministic_classification/`, using KORA `TaskGraph` execution across support-ticket routing, issue triage, incident severity routing, document type routing, and log/event classification.
 - a KORA Doctor example exists under `examples/kora_doctor/`, using KORA `TaskGraph` execution to inspect a synthetic workload and explain deterministic candidates, provider-needed candidates, route rationale, counters, and next steps.
 - the KORA Doctor example now includes a report pack mode across four bundled offline workloads and a README refresh proposal for examples-driven positioning.
@@ -31,15 +32,33 @@ Current state:
 
 ## Current Branch
 
-- branch: `goal085_openai_proxy_module_cli`
+- branch: `goal086_rag_routing_example`
 - public truth: `origin/main`
 - branch pushed to: not pushed in this worktree
-- open PR: none for Goal 085
-- base commit: `651ab79e037d334339463efb1df61e9e8812371c`
+- open PR: none for Goal 086
+- base commit: `d104d87345afd4d860a8872d2eccbe2b5e0eb063`
 
 ## Last Completed Goal
 
-Goal 085 - Implement OpenAI Proxy Reusable Module and CLI.
+Goal 086 - Implement RAG Routing Example.
+
+Goal 086 added an offline RAG routing example under `examples/rag_routing/`. The example uses KORA `TaskGraph` execution with the deterministic `rag_route_query` handler for non-cache sample queries, local cache reuse for repeated sample queries, retrieval-needed labels for document-grounded queries over an offline corpus, and provider-needed fallback labels for ambiguous/open-ended sample queries. It makes `0` provider calls.
+
+Primary report:
+
+- [Goal 086 RAG routing example](docs/reports/goal086_rag_routing_example.md)
+
+Example artifacts:
+
+- [RAG routing example README](examples/rag_routing/README.md)
+- [RAG routing runnable script](examples/rag_routing/run.py)
+- [RAG routing corpus fixture](examples/rag_routing/corpus.json)
+- [RAG routing query fixture](examples/rag_routing/queries.json)
+- [RAG routing expected counters](examples/rag_routing/expected_counters.json)
+
+Claim boundary: In this offline RAG-routing example, KORA routes sample queries across deterministic, cache, retrieval-needed, and provider-needed paths without making provider calls. It does not claim production RAG readiness, retrieval accuracy, automatic cost reduction, real API-cost proof, benchmark superiority, or broad workload superiority.
+
+Previous completed Goal: Goal 085 - Implement OpenAI Proxy Reusable Module and CLI.
 
 Goal 085 promoted the Goal 084 proxy example's routing logic into `kora.openai_proxy_demo` and added the first-class offline CLI command `python3 -m kora proxy-demo examples/openai_compatible_proxy/requests.json`. The existing `examples/openai_compatible_proxy/run.py` script remains a compatibility wrapper over the reusable module. Both paths make `0` provider calls.
 
@@ -262,6 +281,9 @@ Primary report:
 ## Primary Reports
 
 - [Review hub](REVIEW_HUB.md)
+- [Goal 086 RAG routing example](docs/reports/goal086_rag_routing_example.md)
+- [RAG routing example README](examples/rag_routing/README.md)
+- [Goal 085 OpenAI proxy reusable module and CLI](docs/reports/goal085_openai_proxy_reusable_module_cli.md)
 - [Goal 084 OpenAI-compatible proxy example](docs/reports/goal084_openai_compatible_proxy_example.md)
 - [OpenAI-compatible proxy example README](examples/openai_compatible_proxy/README.md)
 - [Goal 083B getkora distribution strategy](docs/reports/goal083b_getkora_distribution_strategy.md)
@@ -303,7 +325,7 @@ KORA makes AI workloads routable. The current KRK public alpha shows how workloa
 
 ## Recommended Next Goal
 
-Goal 086 - Public reviewer walkthrough and example catalog refresh.
+Goal 087 - Public reviewer walkthrough and example catalog refresh.
 
 Recommended scope:
 

--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ Current implemented surfaces in this GitHub repository include:
 - Run offline examples through the KORA example runner: `python3 -m kora run <example>`
 - Run KORA Doctor sample workload inspection from the first-class CLI: `python3 -m kora doctor examples/kora_doctor/customer_support_workload.json`
 - Run the reusable offline OpenAI-style proxy demo from the first-class CLI: `python3 -m kora proxy-demo examples/openai_compatible_proxy/requests.json`
+- Run the offline RAG routing example.
 - Run the deterministic classification expansion pack.
 - Run the offline OpenAI-compatible proxy example.
 - Run first-value CLI paths: `kora inspect`, `kora compare`, `kora run`, `kora doctor`, `kora proxy-demo`, and `kora report`
@@ -112,6 +113,7 @@ python3 -m kora examples list
 python3 -m kora doctor examples/kora_doctor/customer_support_workload.json
 python3 -m kora doctor --all examples/kora_doctor/
 python3 -m kora proxy-demo examples/openai_compatible_proxy/requests.json
+python3 examples/rag_routing/run.py
 python3 examples/openai_compatible_proxy/run.py
 python3 examples/kora_doctor/run.py
 python3 examples/kora_doctor/run.py --all
@@ -119,6 +121,31 @@ python3 examples/deterministic_classification/run.py
 ```
 
 The examples require no provider credentials and make no provider calls.
+
+### RAG Routing
+
+The RAG routing example shows KORA controlling a retrieval-style workflow. It routes exact FAQ/policy queries to deterministic answers, repeated queries to cache reuse, document-grounded queries to retrieval-needed handling over an offline corpus, and ambiguous or open-ended generation queries to provider-needed fallback.
+
+Run the example:
+
+```bash
+python3 examples/rag_routing/run.py
+```
+
+Expected counters:
+
+- total queries: `7`
+- deterministic answered: `2`
+- cache hits: `1`
+- retrieval-needed: `2`
+- provider-needed: `2`
+- avoided simulated provider/model invocations: `3`
+- provider calls actually made: `0`
+
+Docs:
+
+- [RAG routing example README](examples/rag_routing/README.md)
+- [Goal 086 RAG routing example](docs/reports/goal086_rag_routing_example.md)
 
 ### OpenAI-Compatible Proxy
 

--- a/REVIEW_HUB.md
+++ b/REVIEW_HUB.md
@@ -2,7 +2,7 @@
 
 Status: current public review and continuation hub.
 
-Last updated by: Goal 085.
+Last updated by: Goal 086.
 
 ## Project Identity
 
@@ -14,11 +14,11 @@ KRK means KORA Routing Kernel. KRK is the deterministic-first execution routing 
 
 - repository: `https://github.com/Krako-Labs/KORA`
 - public truth branch: `origin/main`
-- active evidence branch: `goal085_openai_proxy_module_cli`
-- worktree label: `goal085_openai_proxy_module_cli`
+- active evidence branch: `goal086_rag_routing_example`
+- worktree label: `goal086_rag_routing_example`
 - branch pushed to: not pushed in this worktree
-- open PR: none for Goal 085
-- base commit: `651ab79e037d334339463efb1df61e9e8812371c`
+- open PR: none for Goal 086
+- base commit: `d104d87345afd4d860a8872d2eccbe2b5e0eb063`
 
 ## Current State Summary
 
@@ -37,6 +37,7 @@ KORA now has a public-safe first-value path and an evidence package that covers:
 - public first-run acceptance testing covers README-only onboarding, fresh source install, KORA Doctor, deterministic classification, and PyPI collision wording.
 - OpenAI-compatible proxy example with offline OpenAI-style chat request fixtures, KORA deterministic routing, local cache reuse, provider-needed fallback labels, and `0` provider calls.
 - reusable OpenAI-style proxy demo module and first-class `kora proxy-demo` CLI command for running the offline proxy/control path over sample request JSON.
+- offline RAG routing example with exact deterministic answers, local cache reuse, retrieval-needed labels over a small offline corpus, provider-needed fallback labels, and `0` provider calls.
 - deterministic classification example pack with KORA `TaskGraph` execution across support-ticket routing, issue triage, incident severity routing, document type routing, and log/event classification.
 - KORA Doctor first-value developer example with KORA `TaskGraph` execution, deterministic candidate/provider-needed candidate inspection, route rationale, counters, and next-step recommendations.
 - KORA Doctor report pack with four bundled offline workloads, aggregate report mode, and a README refresh proposal for examples-driven routing/control positioning.
@@ -82,6 +83,7 @@ This is a sufficient recent history backfill, not a complete reconstruction.
 | Goal 083C | Ran public first-run acceptance testing over README onboarding, fresh source install, KORA Doctor, deterministic classification, and PyPI collision wording. | [Goal 083C public first-run acceptance test](docs/reports/goal083c_public_first_run_acceptance_test.md) |
 | Goal 084 | Added an offline OpenAI-compatible proxy example that routes OpenAI-style sample requests through KORA deterministic handling, cache reuse, or provider-needed fallback. | [Goal 084 OpenAI-compatible proxy example](docs/reports/goal084_openai_compatible_proxy_example.md) |
 | Goal 085 | Promoted the OpenAI-style proxy demo into reusable module logic and a first-class offline `kora proxy-demo` CLI command. | [Goal 085 OpenAI proxy reusable module and CLI](docs/reports/goal085_openai_proxy_reusable_module_cli.md) |
+| Goal 086 | Added an offline RAG routing example that routes sample queries across deterministic, cache, retrieval-needed, and provider-needed paths without provider calls. | [Goal 086 RAG routing example](docs/reports/goal086_rag_routing_example.md) |
 
 ## Evidence Index
 
@@ -108,6 +110,8 @@ Generated summaries:
 Current reviewer path:
 
 - [Goal 082B narrative repositioning](docs/reports/goal082b_narrative_repositioning.md)
+- [Goal 086 RAG routing example](docs/reports/goal086_rag_routing_example.md)
+- [RAG routing example README](examples/rag_routing/README.md)
 - [Goal 085 OpenAI proxy reusable module and CLI](docs/reports/goal085_openai_proxy_reusable_module_cli.md)
 - [Goal 084 OpenAI-compatible proxy example](docs/reports/goal084_openai_compatible_proxy_example.md)
 - [OpenAI-compatible proxy example README](examples/openai_compatible_proxy/README.md)
@@ -160,6 +164,7 @@ Supported:
 - KORA's planned future PyPI distribution package name is `getkora`; current latest-feature testing requires source install from the repository.
 - KORA has an offline OpenAI-style proxy example where sample chat requests are routed through deterministic handling, local cache reuse, or provider-needed fallback without provider calls.
 - KORA has a reusable offline proxy demo module and first-class `kora proxy-demo` CLI command for routing OpenAI-style sample request JSON without provider calls.
+- KORA has an offline RAG routing example where sample queries are routed across deterministic, cache, retrieval-needed, and provider-needed paths without provider calls.
 - Current evidence supports bounded statements about route selectivity, dry-run runtime integration, provider-path validation, bounded H100 execution, expanded H100 representativeness, and fixture-derived output fidelity.
 - KORA has reusable public-safe Project Operating System templates for breadcrumbs, review hubs, ADRs, reports, evidence, claim registries, bootstrap checklists, and project prompts.
 
@@ -172,6 +177,8 @@ Not supported:
 - production cost reduction.
 - automatic cost reduction from the KORA Doctor example.
 - production proxy readiness from the KORA Doctor report pack.
+- production RAG readiness from the RAG routing example.
+- retrieval accuracy from the RAG routing example.
 - customer savings.
 - energy reduction.
 - broad workload superiority.
@@ -366,7 +373,7 @@ Boundary: this is positioning grounded in current examples and evidence. It does
 
 ## Recommended Next Goals
 
-1. Goal 086 - Public reviewer walkthrough and example catalog refresh.
+1. Goal 087 - Public reviewer walkthrough and example catalog refresh.
 2. Goal 086 - Contributor issue seed for examples-first onboarding.
 3. Goal 087 - Contributor issue seed for first-value examples.
 4. Goal 088 - Wheel and source distribution smoke validation.

--- a/docs/README.md
+++ b/docs/README.md
@@ -32,12 +32,14 @@ python3 -m kora doctor examples/kora_doctor/customer_support_workload.json
 - [Open this first](../OPEN_THIS_FIRST.md)
 - [Review hub](../REVIEW_HUB.md)
 - [Goal 083C public first-run acceptance test](reports/goal083c_public_first_run_acceptance_test.md)
+- [Goal 086 RAG routing example](reports/goal086_rag_routing_example.md)
 - [Goal 085 OpenAI proxy reusable module and CLI](reports/goal085_openai_proxy_reusable_module_cli.md)
 - [Goal 084 OpenAI-compatible proxy example](reports/goal084_openai_compatible_proxy_example.md)
 - [Goal 083B getkora distribution strategy](reports/goal083b_getkora_distribution_strategy.md)
 - [getkora distribution strategy](packaging/getkora_distribution_strategy.md)
 - [KORA Workload Control Layer vision](vision/kora_workload_control_layer.md)
 - [KORA Doctor README](../examples/kora_doctor/README.md)
+- [RAG routing example README](../examples/rag_routing/README.md)
 - [OpenAI-compatible proxy example README](../examples/openai_compatible_proxy/README.md)
 - [Goal 083 KORA Doctor CLI](reports/goal083_kora_doctor_cli.md)
 - [Deterministic classification example pack README](../examples/deterministic_classification/README.md)
@@ -162,6 +164,7 @@ KORA control layer architecture.
 ## Reports
 
 - [Goal 082B narrative repositioning](reports/goal082b_narrative_repositioning.md)
+- [Goal 086 RAG routing example](reports/goal086_rag_routing_example.md)
 - [Goal 085 OpenAI proxy reusable module and CLI](reports/goal085_openai_proxy_reusable_module_cli.md)
 - [Goal 084 OpenAI-compatible proxy example](reports/goal084_openai_compatible_proxy_example.md)
 - [Goal 083C public first-run acceptance test](reports/goal083c_public_first_run_acceptance_test.md)
@@ -245,6 +248,7 @@ python3 -m kora examples list
 python3 -m kora doctor examples/kora_doctor/customer_support_workload.json
 python3 -m kora doctor --all examples/kora_doctor/
 python3 -m kora proxy-demo examples/openai_compatible_proxy/requests.json
+python3 examples/rag_routing/run.py
 python3 examples/openai_compatible_proxy/run.py
 python3 examples/kora_doctor/run.py
 python3 examples/kora_doctor/run.py --all

--- a/docs/reports/goal086_rag_routing_example.md
+++ b/docs/reports/goal086_rag_routing_example.md
@@ -1,0 +1,170 @@
+# Goal 086 RAG Routing Example
+
+## Motivation
+
+Goal 086 adds a concrete offline RAG routing example to show KORA inside a retrieval-style workflow. The example demonstrates workload control before provider/model generation by separating exact deterministic answers, cache hits, retrieval-needed cases, and provider-needed fallback cases.
+
+This is a first-value OSS example. It is not a production RAG claim.
+
+## User-Facing Walkthrough
+
+Run the example from a current source checkout:
+
+```bash
+python3 examples/rag_routing/run.py
+```
+
+Expected high-level output:
+
+```text
+KORA RAG Routing Example
+
+Total queries: 7
+Deterministic answered: 2
+Cache hits: 1
+Retrieval-needed: 2
+Provider-needed: 2
+Avoided simulated provider/model invocations: 3
+Provider calls actually made: 0
+```
+
+Write structured outputs:
+
+```bash
+python3 examples/rag_routing/run.py \
+  --json-out /tmp/kora_goal086_rag_routing.json \
+  --report-md /tmp/kora_goal086_rag_routing.md
+```
+
+Run through the KORA example runner:
+
+```bash
+python3 -m kora run rag_routing
+```
+
+## Implementation Summary
+
+- Added `examples/rag_routing/`.
+- Added a small offline corpus fixture in `corpus.json`.
+- Added query fixtures and route expectations in `queries.json`.
+- Added expected counters in `expected_counters.json`.
+- Added `examples/rag_routing/run.py`.
+- Added the deterministic `rag_route_query` executor handler.
+- Added tests in `tests/test_rag_routing_example.py`.
+- Added the `rag_routing` entry to `python3 -m kora examples list`.
+- Updated README/docs and continuation breadcrumbs.
+
+The example uses KORA `TaskGraph` execution for every non-cache query. Cache hits reuse a prior routed result inside the same offline example run. No external APIs are called.
+
+## Route Examples
+
+Deterministic answer:
+
+- query: `What is the refund window?`
+- route: `deterministic_answer`
+- handler: `exact_faq_answer`
+- provider calls: `0`
+
+Cache hit:
+
+- query: repeated `What is the refund window?`
+- route: `cache_hit`
+- handler: `cache_reuse`
+- provider calls: `0`
+
+Retrieval-needed:
+
+- query: `How long are audit logs retained?`
+- route: `retrieval_needed`
+- handler: `retrieve_from_corpus`
+- retrieved document: `doc-security-retention`
+- provider calls: `0`
+
+Provider-needed:
+
+- query: `Write a persuasive apology email about a delayed renewal.`
+- route: `provider_needed`
+- handler: `provider_needed_fallback`
+- provider calls actually made: `0`
+
+## Evidence Counters
+
+Using `examples/rag_routing/queries.json` and `examples/rag_routing/corpus.json`:
+
+- total queries: `7`
+- deterministic answered: `2`
+- cache hits: `1`
+- retrieval-needed: `2`
+- provider-needed: `2`
+- avoided simulated provider/model invocations: `3`
+- provider calls actually made: `0`
+
+The counters are sample-fixture counters only.
+
+## Validation Results
+
+Final validation was run from the Goal 086 worktree:
+
+```bash
+python3 examples/rag_routing/run.py
+```
+
+Result: passed. The command reported `Total queries: 7`, `Deterministic answered: 2`, `Cache hits: 1`, `Retrieval-needed: 2`, `Provider-needed: 2`, and `Provider calls actually made: 0`.
+
+```bash
+python3 examples/rag_routing/run.py --json-out /tmp/kora_goal086_rag_routing.json --report-md /tmp/kora_goal086_rag_routing.md
+```
+
+Result: passed. The command wrote JSON and Markdown outputs and reported the same counters.
+
+```bash
+python3 -m kora examples list
+```
+
+Result: passed. The output includes `rag_routing: offline RAG routing control example`.
+
+```bash
+python3 -m pytest tests/test_rag_routing_example.py tests/test_openai_proxy_demo_cli.py tests/test_first_value_cli.py tests/test_executor.py
+```
+
+Result: passed with `36 passed in 11.33s`.
+
+```bash
+python3 scripts/check_markdown_links_goal082b.py
+```
+
+Result: passed with `Goal 082B markdown links OK`.
+
+```bash
+git diff --check
+```
+
+Result: passed with no output.
+
+## Limitations
+
+- The corpus is small and synthetic.
+- Retrieval-needed means the example found a document-grounded route; it does not claim retrieval accuracy.
+- Provider-needed means a real system would likely need provider/model handling; no provider/model call is made here.
+- Cache reuse is local to one example run.
+- The example does not implement a production RAG service, vector database, embedding model, or HTTP endpoint.
+
+## Claim Boundaries
+
+Supported narrow wording:
+
+> In this offline RAG-routing example, KORA routes sample queries across deterministic, cache, retrieval-needed, and provider-needed paths without making provider calls.
+
+Not claimed:
+
+- production RAG readiness.
+- retrieval accuracy.
+- automatic cost reduction.
+- real API-cost proof.
+- benchmark superiority.
+- broad workload superiority.
+- production validation.
+
+## Recommended Next Goal
+
+Goal 087 should refresh the public reviewer walkthrough and example catalog now that KORA has first-class examples for deterministic classification, KORA Doctor, OpenAI-style proxy control, and RAG routing.

--- a/examples/rag_routing/README.md
+++ b/examples/rag_routing/README.md
@@ -1,0 +1,59 @@
+# RAG Routing Example
+
+This offline example shows KORA controlling a retrieval-style workflow. It routes exact FAQ/policy queries to deterministic answers, repeated queries to a local cache path, document-grounded queries to retrieval-needed handling over a small corpus, and ambiguous or open-ended generation queries to provider-needed fallback.
+
+It does not call external APIs and does not require provider credentials.
+
+Current availability: run this example from a current `Krako-Labs/KORA` checkout installed from source. Plain `python3 -m pip install kora` installs a different PyPI project and should not be used for these examples. Future package distribution is planned as `getkora`, but this README does not claim that package is published.
+
+## Quick Run
+
+```bash
+python3 examples/rag_routing/run.py
+```
+
+Write structured JSON and a report:
+
+```bash
+python3 examples/rag_routing/run.py \
+  --json-out /tmp/kora_goal086_rag_routing.json \
+  --report-md /tmp/kora_goal086_rag_routing.md
+```
+
+Run through the KORA example runner:
+
+```bash
+python3 -m kora run rag_routing
+```
+
+## Expected Output
+
+```text
+KORA RAG Routing Example
+
+Total queries: 7
+Deterministic answered: 2
+Cache hits: 1
+Retrieval-needed: 2
+Provider-needed: 2
+Avoided simulated provider/model invocations: 3
+Provider calls actually made: 0
+```
+
+## Expected Counters
+
+- total queries: `7`
+- deterministic answered: `2`
+- cache hits: `1`
+- retrieval-needed: `2`
+- provider-needed: `2`
+- avoided simulated provider/model invocations: `3`
+- provider calls actually made: `0`
+
+Expected counters are in [expected_counters.json](expected_counters.json). Query fixtures are in [queries.json](queries.json). The offline corpus fixture is in [corpus.json](corpus.json).
+
+## Claim Boundary
+
+In this offline RAG-routing example, KORA routes sample queries across deterministic, cache, retrieval-needed, and provider-needed paths without making provider calls.
+
+This example does not claim production RAG readiness, retrieval accuracy, automatic cost reduction, real API-cost proof, benchmark superiority, or broad workload superiority.

--- a/examples/rag_routing/corpus.json
+++ b/examples/rag_routing/corpus.json
@@ -1,0 +1,25 @@
+{
+  "corpus_id": "kora_rag_routing_sample_corpus_v0",
+  "documents": [
+    {
+      "id": "doc-return-policy",
+      "title": "Return Policy",
+      "body": "Customers may request a refund within 30 days of purchase when the order record is available."
+    },
+    {
+      "id": "doc-support-hours",
+      "title": "Support Hours",
+      "body": "Standard support hours are Monday through Friday, 9 AM to 5 PM local business time."
+    },
+    {
+      "id": "doc-security-retention",
+      "title": "Security Retention Policy",
+      "body": "Audit logs are retained for 90 days. Access review records are retained for one year."
+    },
+    {
+      "id": "doc-billing-exports",
+      "title": "Billing Export Guide",
+      "body": "Billing exports include invoice id, account id, billing period, amount, status, and currency."
+    }
+  ]
+}

--- a/examples/rag_routing/expected_counters.json
+++ b/examples/rag_routing/expected_counters.json
@@ -1,0 +1,9 @@
+{
+  "total_queries": 7,
+  "deterministic_answered": 2,
+  "cache_hits": 1,
+  "retrieval_needed": 2,
+  "provider_needed": 2,
+  "avoided_provider_invocations": 3,
+  "provider_calls_actually_made": 0
+}

--- a/examples/rag_routing/queries.json
+++ b/examples/rag_routing/queries.json
@@ -1,0 +1,80 @@
+{
+  "query_set_id": "kora_rag_routing_sample_queries_v0",
+  "exact_answers": [
+    {
+      "route_id": "rag.det.return_policy",
+      "question": "What is the refund window?",
+      "aliases": ["How long do customers have to request a refund?"],
+      "answer": "Customers may request a refund within 30 days of purchase."
+    },
+    {
+      "route_id": "rag.det.support_hours",
+      "question": "What are support hours?",
+      "aliases": ["When is support available?"],
+      "answer": "Standard support hours are Monday through Friday, 9 AM to 5 PM local business time."
+    }
+  ],
+  "retrieval_rules": [
+    {
+      "route_id": "rag.retrieve.security_retention",
+      "keywords": ["audit logs", "access review", "retention"],
+      "document_ids": ["doc-security-retention"]
+    },
+    {
+      "route_id": "rag.retrieve.billing_exports",
+      "keywords": ["billing export", "invoice fields", "export fields"],
+      "document_ids": ["doc-billing-exports"]
+    }
+  ],
+  "provider_needed_rules": [
+    {
+      "route_id": "rag.provider.open_ended_generation",
+      "keywords": ["write", "draft", "persuasive", "strategy", "recommend a plan"],
+      "reason": "open-ended generation or strategic judgment"
+    }
+  ],
+  "queries": [
+    {
+      "id": "rag-001",
+      "query": "What is the refund window?",
+      "expected_route_kind": "deterministic_answer",
+      "expected_handler": "exact_faq_answer"
+    },
+    {
+      "id": "rag-002",
+      "query": "What is the refund window?",
+      "expected_route_kind": "cache_hit",
+      "expected_handler": "cache_reuse"
+    },
+    {
+      "id": "rag-003",
+      "query": "What are support hours?",
+      "expected_route_kind": "deterministic_answer",
+      "expected_handler": "exact_faq_answer"
+    },
+    {
+      "id": "rag-004",
+      "query": "How long are audit logs retained?",
+      "expected_route_kind": "retrieval_needed",
+      "expected_handler": "retrieve_from_corpus"
+    },
+    {
+      "id": "rag-005",
+      "query": "Which invoice fields are available in the billing export?",
+      "expected_route_kind": "retrieval_needed",
+      "expected_handler": "retrieve_from_corpus"
+    },
+    {
+      "id": "rag-006",
+      "query": "Write a persuasive apology email about a delayed renewal.",
+      "expected_route_kind": "provider_needed",
+      "expected_handler": "provider_needed_fallback"
+    },
+    {
+      "id": "rag-007",
+      "query": "Recommend a plan for our pricing strategy next quarter.",
+      "expected_route_kind": "provider_needed",
+      "expected_handler": "provider_needed_fallback"
+    }
+  ]
+}

--- a/examples/rag_routing/run.py
+++ b/examples/rag_routing/run.py
@@ -1,0 +1,256 @@
+"""Offline RAG routing example using KORA task execution."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from kora.executor import run_graph
+from kora.task_ir import TaskGraph, normalize_graph, validate_graph
+
+EXAMPLE_DIR = Path(__file__).resolve().parent
+CORPUS_PATH = EXAMPLE_DIR / "corpus.json"
+QUERIES_PATH = EXAMPLE_DIR / "queries.json"
+EXPECTED_COUNTERS_PATH = EXAMPLE_DIR / "expected_counters.json"
+CLAIM_BOUNDARY = (
+    "In this offline RAG-routing example, KORA routes sample queries across "
+    "deterministic, cache, retrieval-needed, and provider-needed paths without "
+    "making provider calls. It does not claim production RAG readiness, retrieval "
+    "accuracy, automatic cost reduction, real API-cost proof, or benchmark superiority."
+)
+
+
+def load_corpus(path: Path = CORPUS_PATH) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def load_queries(path: Path = QUERIES_PATH) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _query_cache_key(query: str) -> str:
+    normalized = " ".join(query.lower().strip().split())
+    return hashlib.sha256(normalized.encode("utf-8")).hexdigest()
+
+
+def _rag_graph(config: dict[str, Any], corpus: dict[str, Any], query_id: str, query: str) -> TaskGraph:
+    return TaskGraph.model_validate(
+        {
+            "graph_id": f"rag-routing-{query_id}",
+            "version": "0.1",
+            "root": "route_query",
+            "defaults": {"budget": {"max_time_ms": 1500, "max_tokens": 300, "max_retries": 0}},
+            "tasks": [
+                {
+                    "id": "route_query",
+                    "type": "det.rag.route_query",
+                    "deps": [],
+                    "in": {"query": query},
+                    "run": {
+                        "kind": "det",
+                        "spec": {
+                            "handler": "rag_route_query",
+                            "args": {
+                                "exact_answers": config["exact_answers"],
+                                "retrieval_rules": config["retrieval_rules"],
+                                "provider_needed_rules": config["provider_needed_rules"],
+                                "corpus": corpus["documents"],
+                            },
+                        },
+                    },
+                    "policy": {"on_fail": "fail"},
+                    "tags": ["rag-routing", "offline-example"],
+                }
+            ],
+        }
+    )
+
+
+def _run_kora_rag_route(config: dict[str, Any], corpus: dict[str, Any], query_id: str, query: str) -> dict[str, Any]:
+    graph = normalize_graph(_rag_graph(config, corpus, query_id, query))
+    validate_graph(graph)
+    result = run_graph(graph)
+    if not result.get("ok"):
+        raise RuntimeError(str(result.get("error")))
+    final = result.get("final")
+    if not isinstance(final, dict):
+        raise RuntimeError("RAG routing graph did not return an object")
+    routed = dict(final)
+    routed.update(
+        {
+            "kora_graph_id": result["graph_id"],
+            "kora_event_count": len(result.get("events", [])),
+        }
+    )
+    return routed
+
+
+def build_rag_summary(
+    *,
+    corpus_path: Path = CORPUS_PATH,
+    queries_path: Path = QUERIES_PATH,
+    json_out: Path | None = None,
+) -> dict[str, Any]:
+    corpus = load_corpus(corpus_path)
+    config = load_queries(queries_path)
+    cache: dict[str, dict[str, Any]] = {}
+    results: list[dict[str, Any]] = []
+
+    for item in config["queries"]:
+        query_id = str(item["id"])
+        query = str(item["query"])
+        cache_key = _query_cache_key(query)
+
+        if cache_key in cache:
+            cached = cache[cache_key]
+            route = dict(cached["route"])
+            route.update(
+                {
+                    "route_kind": "cache_hit",
+                    "selected_route": "rag.cache.reuse",
+                    "handler": "cache_reuse",
+                    "provider_needed_reason": None,
+                }
+            )
+            source = "cache"
+            graph_id = cached["route"].get("kora_graph_id")
+            event_count = 0
+        else:
+            route = _run_kora_rag_route(config, corpus, query_id, query)
+            source = "kora_task_graph"
+            graph_id = route.get("kora_graph_id")
+            event_count = int(route.get("kora_event_count", 0))
+            if route["route_kind"] in {"deterministic_answer", "retrieval_needed"}:
+                cache[cache_key] = {"route": route}
+
+        results.append(
+            {
+                "id": query_id,
+                "query": query,
+                "route_kind": route["route_kind"],
+                "selected_route": route["selected_route"],
+                "handler": route["handler"],
+                "answer": route.get("answer"),
+                "retrieved_documents": route.get("retrieved_documents", []),
+                "provider_needed_reason": route.get("provider_needed_reason"),
+                "provider_calls": int(route.get("provider_calls", 0)),
+                "cache_key": cache_key,
+                "source": source,
+                "kora_graph_id": graph_id,
+                "kora_event_count": event_count,
+                "expected_route_kind": item["expected_route_kind"],
+                "expected_handler": item["expected_handler"],
+            }
+        )
+
+    total_queries = len(results)
+    deterministic_answered = sum(1 for item in results if item["route_kind"] == "deterministic_answer")
+    cache_hits = sum(1 for item in results if item["route_kind"] == "cache_hit")
+    retrieval_needed = sum(1 for item in results if item["route_kind"] == "retrieval_needed")
+    provider_needed = sum(1 for item in results if item["route_kind"] == "provider_needed")
+    provider_calls = sum(int(item["provider_calls"]) for item in results)
+    expected_match_count = sum(
+        1
+        for item in results
+        if item["route_kind"] == item["expected_route_kind"]
+        and item["handler"] == item["expected_handler"]
+    )
+    counters = {
+        "total_queries": total_queries,
+        "deterministic_answered": deterministic_answered,
+        "cache_hits": cache_hits,
+        "retrieval_needed": retrieval_needed,
+        "provider_needed": provider_needed,
+        "avoided_provider_invocations": deterministic_answered + cache_hits,
+        "provider_calls_actually_made": provider_calls,
+    }
+    expected_counters = json.loads(EXPECTED_COUNTERS_PATH.read_text(encoding="utf-8"))
+    summary: dict[str, Any] = {
+        "ok": counters == expected_counters and expected_match_count == total_queries,
+        "mode": "rag_routing_example",
+        **counters,
+        "expected_match_count": expected_match_count,
+        "corpus_id": corpus["corpus_id"],
+        "query_set_id": config["query_set_id"],
+        "results": results,
+        "example_query": results[0],
+        "safe_example_claim": (
+            "In this offline RAG-routing example, KORA routes sample queries across "
+            "deterministic, cache, retrieval-needed, and provider-needed paths without "
+            "making provider calls."
+        ),
+        "claim_boundary": CLAIM_BOUNDARY,
+    }
+    if json_out is not None:
+        json_out.parent.mkdir(parents=True, exist_ok=True)
+        json_out.write_text(json.dumps(summary, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return summary
+
+
+def render_report(summary: dict[str, Any]) -> str:
+    example = summary["example_query"]
+    lines = [
+        "KORA RAG Routing Example",
+        "",
+        f"Total queries: {summary['total_queries']}",
+        f"Deterministic answered: {summary['deterministic_answered']}",
+        f"Cache hits: {summary['cache_hits']}",
+        f"Retrieval-needed: {summary['retrieval_needed']}",
+        f"Provider-needed: {summary['provider_needed']}",
+        f"Avoided simulated provider/model invocations: {summary['avoided_provider_invocations']}",
+        f"Provider calls actually made: {summary['provider_calls_actually_made']}",
+        "",
+        "Example query:",
+        f"- Input: \"{example['query']}\"",
+        f"- Route: {example['route_kind']}",
+        f"- Handler: {example['handler']}",
+        f"- Provider calls: {example['provider_calls']}",
+        "",
+        "Comparison surface:",
+    ]
+    for item in summary["results"]:
+        lines.append(
+            "- {id}: route={route}, handler={handler}, provider_calls={calls}, source={source}".format(
+                id=item["id"],
+                route=item["route_kind"],
+                handler=item["handler"],
+                calls=item["provider_calls"],
+                source=item["source"],
+            )
+        )
+    lines.extend(["", "Claim boundary:", summary["claim_boundary"]])
+    return "\n".join(lines) + "\n"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--corpus", default=str(CORPUS_PATH), help="offline document corpus JSON")
+    parser.add_argument("--queries", default=str(QUERIES_PATH), help="RAG query fixture JSON")
+    parser.add_argument("--json-out", help="optional path for structured JSON output")
+    parser.add_argument("--report-md", help="optional path for rendered report output")
+    args = parser.parse_args()
+
+    summary = build_rag_summary(
+        corpus_path=Path(args.corpus),
+        queries_path=Path(args.queries),
+        json_out=Path(args.json_out) if args.json_out else None,
+    )
+    report = render_report(summary)
+    if args.report_md:
+        report_path = Path(args.report_md)
+        report_path.parent.mkdir(parents=True, exist_ok=True)
+        report_path.write_text(report, encoding="utf-8")
+    print(report, end="")
+    return 0 if summary["ok"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/kora/cli.py
+++ b/kora/cli.py
@@ -57,6 +57,7 @@ def _example_descriptions() -> dict[str, str]:
         "direct_vs_kora": "direct call vs KORA-controlled path",
         "kora_doctor": "offline doctor-style workload inspection example",
         "openai_compatible_proxy": "offline OpenAI-style proxy routing example",
+        "rag_routing": "offline RAG routing control example",
         "real_workload_harness": "benchmark/report flow example",
         "real_model_call_validation_fake": "local no-network model-call validation example",
         "runtime_integrated_benchmark": "initial runtime-path benchmark harness",

--- a/kora/executor.py
+++ b/kora/executor.py
@@ -208,6 +208,115 @@ def _handle_doctor_inspect_task(task: Task, state: dict[str, Any]) -> dict[str, 
     }
 
 
+def _handle_rag_route_query(task: Task, state: dict[str, Any]) -> dict[str, Any]:
+    del state
+    if task.run.kind != "det":
+        raise ValueError("rag_route_query requires deterministic task input")
+
+    args = task.run.spec.args
+    query = task.in_.get("query", args.get("query", ""))
+    if not isinstance(query, str):
+        query = str(query)
+    normalized_query = " ".join(query.lower().strip().split())
+    lowered = query.lower()
+
+    exact_answers = args.get("exact_answers", [])
+    if not isinstance(exact_answers, list):
+        exact_answers = []
+    for item in exact_answers:
+        if not isinstance(item, dict):
+            continue
+        question = str(item.get("question", "")).strip().lower()
+        aliases = item.get("aliases", [])
+        if not isinstance(aliases, list):
+            aliases = []
+        candidates = [question, *[str(alias).strip().lower() for alias in aliases]]
+        if normalized_query in {" ".join(candidate.split()) for candidate in candidates if candidate}:
+            return {
+                "status": "ok",
+                "task_id": task.id,
+                "route_kind": "deterministic_answer",
+                "selected_route": str(item.get("route_id", "rag.det.exact_answer")),
+                "handler": "exact_faq_answer",
+                "answer": str(item.get("answer", "")),
+                "retrieved_documents": [],
+                "provider_calls": 0,
+                "provider_needed_reason": None,
+            }
+
+    provider_needed_rules = args.get("provider_needed_rules", [])
+    if not isinstance(provider_needed_rules, list):
+        provider_needed_rules = []
+    for rule in provider_needed_rules:
+        if not isinstance(rule, dict):
+            continue
+        keywords = rule.get("keywords", [])
+        if not isinstance(keywords, list):
+            continue
+        if any(str(keyword).lower() in lowered for keyword in keywords):
+            return {
+                "status": "ok",
+                "task_id": task.id,
+                "route_kind": "provider_needed",
+                "selected_route": str(rule.get("route_id", "rag.provider_needed")),
+                "handler": "provider_needed_fallback",
+                "answer": None,
+                "retrieved_documents": [],
+                "provider_calls": 0,
+                "provider_needed_reason": str(rule.get("reason", "open-ended generation")),
+            }
+
+    corpus = args.get("corpus", [])
+    if not isinstance(corpus, list):
+        corpus = []
+    retrieval_rules = args.get("retrieval_rules", [])
+    if not isinstance(retrieval_rules, list):
+        retrieval_rules = []
+    corpus_by_id = {
+        str(document.get("id", "")): document
+        for document in corpus
+        if isinstance(document, dict)
+    }
+    for rule in retrieval_rules:
+        if not isinstance(rule, dict):
+            continue
+        keywords = rule.get("keywords", [])
+        if not isinstance(keywords, list):
+            continue
+        if any(str(keyword).lower() in lowered for keyword in keywords):
+            document_ids = rule.get("document_ids", [])
+            if not isinstance(document_ids, list):
+                document_ids = []
+            documents = [
+                corpus_by_id[str(document_id)]
+                for document_id in document_ids
+                if str(document_id) in corpus_by_id
+            ]
+            return {
+                "status": "ok",
+                "task_id": task.id,
+                "route_kind": "retrieval_needed",
+                "selected_route": str(rule.get("route_id", "rag.retrieve")),
+                "handler": "retrieve_from_corpus",
+                "answer": None,
+                "retrieved_documents": documents,
+                "provider_calls": 0,
+                "provider_needed_reason": None,
+            }
+
+    return {
+        "status": "ok",
+        "task_id": task.id,
+        "route_kind": "provider_needed",
+        "selected_route": "rag.provider_needed.unmatched",
+        "handler": "provider_needed_fallback",
+        "answer": None,
+        "retrieved_documents": [],
+        "provider_calls": 0,
+        "provider_needed_reason": "no deterministic or retrieval rule matched",
+    }
+
+
 def _handle_flaky_once(task: Task, state: dict[str, Any]) -> dict[str, Any]:
     attempts = state.setdefault("flaky_once_attempts", {})
     count = int(attempts.get(task.id, 0)) + 1
@@ -379,6 +488,7 @@ DETERMINISTIC_HANDLERS: dict[str, Handler] = {
     "classify_by_rules": _handle_classify_by_rules,
     "classify_simple": _handle_classify_simple,
     "doctor_inspect_task": _handle_doctor_inspect_task,
+    "rag_route_query": _handle_rag_route_query,
     "flaky_once": _handle_flaky_once,
     "parse_request_constraints": _handle_parse_request_constraints,
     "quality_gate": _handle_quality_gate,

--- a/tests/test_rag_routing_example.py
+++ b/tests/test_rag_routing_example.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+def _load_module():
+    script_path = Path("examples/rag_routing/run.py")
+    spec = importlib.util.spec_from_file_location("rag_routing_run", script_path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError("failed to load RAG routing module")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_rag_routing_summary_matches_expected_counters() -> None:
+    module = _load_module()
+    expected = json.loads(
+        Path("examples/rag_routing/expected_counters.json").read_text(encoding="utf-8")
+    )
+
+    summary = module.build_rag_summary()
+
+    assert summary["ok"] is True
+    for key, value in expected.items():
+        assert summary[key] == value
+    assert summary["expected_match_count"] == summary["total_queries"]
+    assert summary["provider_calls_actually_made"] == 0
+
+
+def test_rag_routing_uses_kora_task_graph_and_cache_paths() -> None:
+    module = _load_module()
+
+    summary = module.build_rag_summary()
+
+    deterministic = [item for item in summary["results"] if item["route_kind"] == "deterministic_answer"]
+    retrieval = [item for item in summary["results"] if item["route_kind"] == "retrieval_needed"]
+    cache_hits = [item for item in summary["results"] if item["route_kind"] == "cache_hit"]
+    provider_needed = [item for item in summary["results"] if item["route_kind"] == "provider_needed"]
+    assert len(deterministic) == 2
+    assert len(retrieval) == 2
+    assert len(cache_hits) == 1
+    assert len(provider_needed) == 2
+    assert all(str(item["kora_graph_id"]).startswith("rag-routing-") for item in deterministic)
+    assert all(item["source"] == "kora_task_graph" for item in retrieval)
+    assert retrieval[0]["retrieved_documents"][0]["id"] == "doc-security-retention"
+    assert cache_hits[0]["handler"] == "cache_reuse"
+    assert all(item["provider_calls"] == 0 for item in summary["results"])
+
+
+def test_rag_routing_report_contains_required_sections() -> None:
+    module = _load_module()
+
+    report = module.render_report(module.build_rag_summary())
+
+    assert "KORA RAG Routing Example" in report
+    assert "Total queries: 7" in report
+    assert "Deterministic answered: 2" in report
+    assert "Cache hits: 1" in report
+    assert "Retrieval-needed: 2" in report
+    assert "Provider-needed: 2" in report
+    assert "Provider calls actually made: 0" in report
+    assert "Claim boundary:" in report
+
+
+def test_rag_routing_cli_writes_outputs(tmp_path: Path) -> None:
+    json_out = tmp_path / "rag.json"
+    report_md = tmp_path / "rag.md"
+
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "examples/rag_routing/run.py",
+            "--json-out",
+            str(json_out),
+            "--report-md",
+            str(report_md),
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert completed.returncode == 0
+    assert "KORA RAG Routing Example" in completed.stdout
+    saved = json.loads(json_out.read_text(encoding="utf-8"))
+    assert saved["mode"] == "rag_routing_example"
+    assert saved["total_queries"] == 7
+    assert saved["retrieval_needed"] == 2
+    assert saved["provider_calls_actually_made"] == 0
+    assert report_md.read_text(encoding="utf-8") == completed.stdout
+
+
+def test_rag_routing_appears_in_example_listing() -> None:
+    completed = subprocess.run(
+        [sys.executable, "-m", "kora", "examples", "list"],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert completed.returncode == 0
+    assert "rag_routing: offline RAG routing control example" in completed.stdout


### PR DESCRIPTION
## Summary
- add `examples/rag_routing/` offline RAG routing example with corpus/query fixtures and expected counters
- add deterministic `rag_route_query` handler for exact answers, retrieval-needed routing, and provider-needed fallback
- add tests, example listing entry, README/docs updates, breadcrumbs, and Goal 086 report

## Validation
- `python3 examples/rag_routing/run.py`
- `python3 examples/rag_routing/run.py --json-out /tmp/kora_goal086_rag_routing.json --report-md /tmp/kora_goal086_rag_routing.md`
- `python3 -m kora examples list`
- `python3 -m pytest tests/test_rag_routing_example.py tests/test_openai_proxy_demo_cli.py tests/test_first_value_cli.py tests/test_executor.py` -> 36 passed
- `python3 scripts/check_markdown_links_goal082b.py`
- `git diff --check`

## Claim Boundary
In this offline RAG-routing example, KORA routes sample queries across deterministic, cache, retrieval-needed, and provider-needed paths without making provider calls. This does not claim production RAG readiness, retrieval accuracy, automatic cost reduction, real API-cost proof, benchmark superiority, or broad workload superiority.
