### PR TITLE
Goal 088 cache reuse example

### DIFF
--- a/OPEN_THIS_FIRST.md
+++ b/OPEN_THIS_FIRST.md
@@ -2,7 +2,7 @@
 
 Status: current public project breadcrumb.
 
-Last updated by: Goal 087.
+Last updated by: Goal 088.
 
 ## Current Status
 
@@ -22,6 +22,7 @@ Current state:
 - the OpenAI-style proxy demo routing logic is now reusable from `kora.openai_proxy_demo`, and `python3 -m kora proxy-demo examples/openai_compatible_proxy/requests.json` runs the same offline no-provider-call path from the first-class CLI.
 - an offline RAG routing example exists under `examples/rag_routing/`, showing KORA routing sample queries across deterministic answers, cache hits, retrieval-needed handling, and provider-needed fallback without provider calls.
 - an offline agent workflow optimization example exists under `examples/agent_workflow_optimization/`, showing KORA routing sample workflow steps across deterministic, cache, tool-needed, and provider-needed paths without provider calls.
+- an offline cache reuse example exists under `examples/cache_reuse/`, showing KORA routing repeated sample requests to cache hits while preserving provider-needed fallback for ambiguous/open-ended requests without provider calls.
 - a deterministic classification example pack exists under `examples/deterministic_classification/`, using KORA `TaskGraph` execution across support-ticket routing, issue triage, incident severity routing, document type routing, and log/event classification.
 - a KORA Doctor example exists under `examples/kora_doctor/`, using KORA `TaskGraph` execution to inspect a synthetic workload and explain deterministic candidates, provider-needed candidates, route rationale, counters, and next steps.
 - the KORA Doctor example now includes a report pack mode across four bundled offline workloads and a README refresh proposal for examples-driven positioning.
@@ -33,15 +34,32 @@ Current state:
 
 ## Current Branch
 
-- branch: `goal087_agent_workflow_optimization`
+- branch: `goal088_cache_reuse_example`
 - public truth: `origin/main`
 - branch pushed to: not pushed in this worktree
-- open PR: none for Goal 087
-- base commit: `2a197f57cca2dc6bfcd0c7c322432da587b88ded`
+- open PR: none for Goal 088
+- base commit: `ca7d7de4ecded1bdf4a550c7a58700dd5a9c704b`
 
 ## Last Completed Goal
 
-Goal 087 - Implement Agent Workflow Optimization Example.
+Goal 088 - Implement Cache Reuse Example.
+
+Goal 088 added an offline cache reuse example under `examples/cache_reuse/`. The example uses KORA `TaskGraph` execution with the deterministic `classify_by_rules` handler for first-time deterministic sample requests, local cache reuse for repeated exact or semantically equivalent sample requests, and provider-needed fallback labels for ambiguous/open-ended sample requests. It makes `0` provider calls.
+
+Primary report:
+
+- [Goal 088 cache reuse example](docs/reports/goal088_cache_reuse_example.md)
+
+Example artifacts:
+
+- [Cache reuse example README](examples/cache_reuse/README.md)
+- [Cache reuse runnable script](examples/cache_reuse/run.py)
+- [Cache reuse request fixture](examples/cache_reuse/requests.json)
+- [Cache reuse expected counters](examples/cache_reuse/expected_counters.json)
+
+Claim boundary: In this offline cache-reuse example, KORA routes repeated sample requests to cache hits without making provider calls and marks ambiguous/open-ended requests as provider-needed. It does not claim production cache correctness, automatic cost reduction, real API-cost proof, benchmark superiority, or broad workload superiority.
+
+Previous completed Goal: Goal 087 - Implement Agent Workflow Optimization Example.
 
 Goal 087 added an offline agent workflow optimization example under `examples/agent_workflow_optimization/`. The example uses KORA `TaskGraph` execution with the deterministic `agent_route_step` handler for non-cache sample workflow steps, local cache reuse for repeated deterministic steps, tool-needed labels for explicit local action steps, and provider-needed fallback labels for ambiguous planning/open-ended generation steps. It makes `0` provider calls.
 
@@ -299,6 +317,8 @@ Primary report:
 ## Primary Reports
 
 - [Review hub](REVIEW_HUB.md)
+- [Goal 088 cache reuse example](docs/reports/goal088_cache_reuse_example.md)
+- [Cache reuse example README](examples/cache_reuse/README.md)
 - [Goal 087 agent workflow optimization example](docs/reports/goal087_agent_workflow_optimization_example.md)
 - [Agent workflow optimization example README](examples/agent_workflow_optimization/README.md)
 - [Goal 086 RAG routing example](docs/reports/goal086_rag_routing_example.md)
@@ -345,7 +365,7 @@ KORA makes AI workloads routable. The current KRK public alpha shows how workloa
 
 ## Recommended Next Goal
 
-Goal 088 - Public reviewer walkthrough and example catalog refresh.
+Goal 089 - Public reviewer walkthrough and example catalog refresh.
 
 Recommended scope:
 

--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ Current implemented surfaces in this GitHub repository include:
 - Run offline examples through the KORA example runner: `python3 -m kora run <example>`
 - Run KORA Doctor sample workload inspection from the first-class CLI: `python3 -m kora doctor examples/kora_doctor/customer_support_workload.json`
 - Run the reusable offline OpenAI-style proxy demo from the first-class CLI: `python3 -m kora proxy-demo examples/openai_compatible_proxy/requests.json`
+- Run the offline cache reuse example.
 - Run the offline agent workflow optimization example.
 - Run the offline RAG routing example.
 - Run the deterministic classification expansion pack.
@@ -114,6 +115,7 @@ python3 -m kora examples list
 python3 -m kora doctor examples/kora_doctor/customer_support_workload.json
 python3 -m kora doctor --all examples/kora_doctor/
 python3 -m kora proxy-demo examples/openai_compatible_proxy/requests.json
+python3 examples/cache_reuse/run.py
 python3 examples/agent_workflow_optimization/run.py
 python3 examples/rag_routing/run.py
 python3 examples/openai_compatible_proxy/run.py
@@ -123,6 +125,30 @@ python3 examples/deterministic_classification/run.py
 ```
 
 The examples require no provider credentials and make no provider calls.
+
+### Cache Reuse
+
+The cache reuse example shows KORA identifying repeated or reusable work as a first-class workflow-control surface. It routes first-time deterministic sample requests through KORA `TaskGraph` execution, repeated exact or semantically equivalent sample requests to cache hits, and ambiguous or open-ended sample requests to provider-needed fallback.
+
+Run the example:
+
+```bash
+python3 examples/cache_reuse/run.py
+```
+
+Expected counters:
+
+- total requests: `7`
+- first-time deterministic handled: `3`
+- cache hits: `2`
+- provider-needed: `2`
+- avoided simulated provider/model invocations: `5`
+- provider calls actually made: `0`
+
+Docs:
+
+- [Cache reuse example README](examples/cache_reuse/README.md)
+- [Goal 088 cache reuse example](docs/reports/goal088_cache_reuse_example.md)
 
 ### Agent Workflow Optimization
 

--- a/REVIEW_HUB.md
+++ b/REVIEW_HUB.md
@@ -2,7 +2,7 @@
 
 Status: current public review and continuation hub.
 
-Last updated by: Goal 087.
+Last updated by: Goal 088.
 
 ## Project Identity
 
@@ -14,11 +14,11 @@ KRK means KORA Routing Kernel. KRK is the deterministic-first execution routing 
 
 - repository: `https://github.com/Krako-Labs/KORA`
 - public truth branch: `origin/main`
-- active evidence branch: `goal087_agent_workflow_optimization`
-- worktree label: `goal087_agent_workflow_optimization`
+- active evidence branch: `goal088_cache_reuse_example`
+- worktree label: `goal088_cache_reuse_example`
 - branch pushed to: not pushed in this worktree
-- open PR: none for Goal 087
-- base commit: `2a197f57cca2dc6bfcd0c7c322432da587b88ded`
+- open PR: none for Goal 088
+- base commit: `ca7d7de4ecded1bdf4a550c7a58700dd5a9c704b`
 
 ## Current State Summary
 
@@ -39,6 +39,7 @@ KORA now has a public-safe first-value path and an evidence package that covers:
 - reusable OpenAI-style proxy demo module and first-class `kora proxy-demo` CLI command for running the offline proxy/control path over sample request JSON.
 - offline RAG routing example with exact deterministic answers, local cache reuse, retrieval-needed labels over a small offline corpus, provider-needed fallback labels, and `0` provider calls.
 - offline agent workflow optimization example with deterministic steps, cache reuse, tool-needed local actions, provider-needed fallback labels, and `0` provider calls.
+- offline cache reuse example with first-time deterministic handling, repeated exact and semantic cache hits, provider-needed fallback labels, and `0` provider calls.
 - deterministic classification example pack with KORA `TaskGraph` execution across support-ticket routing, issue triage, incident severity routing, document type routing, and log/event classification.
 - KORA Doctor first-value developer example with KORA `TaskGraph` execution, deterministic candidate/provider-needed candidate inspection, route rationale, counters, and next-step recommendations.
 - KORA Doctor report pack with four bundled offline workloads, aggregate report mode, and a README refresh proposal for examples-driven routing/control positioning.
@@ -86,6 +87,7 @@ This is a sufficient recent history backfill, not a complete reconstruction.
 | Goal 085 | Promoted the OpenAI-style proxy demo into reusable module logic and a first-class offline `kora proxy-demo` CLI command. | [Goal 085 OpenAI proxy reusable module and CLI](docs/reports/goal085_openai_proxy_reusable_module_cli.md) |
 | Goal 086 | Added an offline RAG routing example that routes sample queries across deterministic, cache, retrieval-needed, and provider-needed paths without provider calls. | [Goal 086 RAG routing example](docs/reports/goal086_rag_routing_example.md) |
 | Goal 087 | Added an offline agent workflow optimization example that routes sample workflow steps across deterministic, cache, tool-needed, and provider-needed paths without provider calls. | [Goal 087 agent workflow optimization example](docs/reports/goal087_agent_workflow_optimization_example.md) |
+| Goal 088 | Added an offline cache reuse example that routes repeated sample requests to cache hits and marks ambiguous/open-ended requests as provider-needed without provider calls. | [Goal 088 cache reuse example](docs/reports/goal088_cache_reuse_example.md) |
 
 ## Evidence Index
 
@@ -112,6 +114,8 @@ Generated summaries:
 Current reviewer path:
 
 - [Goal 082B narrative repositioning](docs/reports/goal082b_narrative_repositioning.md)
+- [Goal 088 cache reuse example](docs/reports/goal088_cache_reuse_example.md)
+- [Cache reuse example README](examples/cache_reuse/README.md)
 - [Goal 087 agent workflow optimization example](docs/reports/goal087_agent_workflow_optimization_example.md)
 - [Agent workflow optimization example README](examples/agent_workflow_optimization/README.md)
 - [Goal 086 RAG routing example](docs/reports/goal086_rag_routing_example.md)
@@ -170,6 +174,7 @@ Supported:
 - KORA has a reusable offline proxy demo module and first-class `kora proxy-demo` CLI command for routing OpenAI-style sample request JSON without provider calls.
 - KORA has an offline RAG routing example where sample queries are routed across deterministic, cache, retrieval-needed, and provider-needed paths without provider calls.
 - KORA has an offline agent workflow optimization example where sample workflow steps are routed across deterministic, cache, tool-needed, and provider-needed paths without provider calls.
+- KORA has an offline cache reuse example where repeated sample requests are routed to cache hits without provider calls and ambiguous/open-ended requests are marked provider-needed.
 - Current evidence supports bounded statements about route selectivity, dry-run runtime integration, provider-path validation, bounded H100 execution, expanded H100 representativeness, and fixture-derived output fidelity.
 - KORA has reusable public-safe Project Operating System templates for breadcrumbs, review hubs, ADRs, reports, evidence, claim registries, bootstrap checklists, and project prompts.
 
@@ -186,6 +191,7 @@ Not supported:
 - retrieval accuracy from the RAG routing example.
 - production agent readiness from the agent workflow example.
 - autonomous agent reliability from the agent workflow example.
+- production cache correctness from the cache reuse example.
 - customer savings.
 - energy reduction.
 - broad workload superiority.
@@ -380,8 +386,8 @@ Boundary: this is positioning grounded in current examples and evidence. It does
 
 ## Recommended Next Goals
 
-1. Goal 088 - Public reviewer walkthrough and example catalog refresh.
-2. Goal 089 - Contributor issue seed for examples-first onboarding.
+1. Goal 089 - Public reviewer walkthrough and example catalog refresh.
+2. Goal 090 - Contributor issue seed for examples-first onboarding.
 3. Goal 087 - Contributor issue seed for first-value examples.
 4. Goal 088 - Wheel and source distribution smoke validation.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -32,6 +32,7 @@ python3 -m kora doctor examples/kora_doctor/customer_support_workload.json
 - [Open this first](../OPEN_THIS_FIRST.md)
 - [Review hub](../REVIEW_HUB.md)
 - [Goal 083C public first-run acceptance test](reports/goal083c_public_first_run_acceptance_test.md)
+- [Goal 088 cache reuse example](reports/goal088_cache_reuse_example.md)
 - [Goal 087 agent workflow optimization example](reports/goal087_agent_workflow_optimization_example.md)
 - [Goal 086 RAG routing example](reports/goal086_rag_routing_example.md)
 - [Goal 085 OpenAI proxy reusable module and CLI](reports/goal085_openai_proxy_reusable_module_cli.md)
@@ -40,6 +41,7 @@ python3 -m kora doctor examples/kora_doctor/customer_support_workload.json
 - [getkora distribution strategy](packaging/getkora_distribution_strategy.md)
 - [KORA Workload Control Layer vision](vision/kora_workload_control_layer.md)
 - [KORA Doctor README](../examples/kora_doctor/README.md)
+- [Cache reuse example README](../examples/cache_reuse/README.md)
 - [Agent workflow optimization example README](../examples/agent_workflow_optimization/README.md)
 - [RAG routing example README](../examples/rag_routing/README.md)
 - [OpenAI-compatible proxy example README](../examples/openai_compatible_proxy/README.md)
@@ -166,6 +168,7 @@ KORA control layer architecture.
 ## Reports
 
 - [Goal 082B narrative repositioning](reports/goal082b_narrative_repositioning.md)
+- [Goal 088 cache reuse example](reports/goal088_cache_reuse_example.md)
 - [Goal 087 agent workflow optimization example](reports/goal087_agent_workflow_optimization_example.md)
 - [Goal 086 RAG routing example](reports/goal086_rag_routing_example.md)
 - [Goal 085 OpenAI proxy reusable module and CLI](reports/goal085_openai_proxy_reusable_module_cli.md)
@@ -251,6 +254,7 @@ python3 -m kora examples list
 python3 -m kora doctor examples/kora_doctor/customer_support_workload.json
 python3 -m kora doctor --all examples/kora_doctor/
 python3 -m kora proxy-demo examples/openai_compatible_proxy/requests.json
+python3 examples/cache_reuse/run.py
 python3 examples/agent_workflow_optimization/run.py
 python3 examples/rag_routing/run.py
 python3 examples/openai_compatible_proxy/run.py

--- a/docs/reports/goal088_cache_reuse_example.md
+++ b/docs/reports/goal088_cache_reuse_example.md
@@ -1,0 +1,165 @@
+# Goal 088 Cache Reuse Example
+
+## Motivation
+
+Goal 088 makes cache reuse a first-class KORA example. Earlier examples used cache reuse as a supporting route inside proxy, RAG, and agent workflows. This example isolates the concept so a new user can see repeated or reusable work routed to cache hits without provider calls.
+
+This is a first-value OSS example. It is not a production cache correctness or production cost reduction claim.
+
+## User-Facing Walkthrough
+
+Run the example from a current source checkout:
+
+```bash
+python3 examples/cache_reuse/run.py
+```
+
+Expected high-level output:
+
+```text
+KORA Cache Reuse Example
+
+Total requests: 7
+First-time deterministic handled: 3
+Cache hits: 2
+Provider-needed: 2
+Avoided simulated provider/model invocations: 5
+Provider calls actually made: 0
+```
+
+Write structured outputs:
+
+```bash
+python3 examples/cache_reuse/run.py \
+  --json-out /tmp/kora_goal088_cache_reuse.json \
+  --report-md /tmp/kora_goal088_cache_reuse.md
+```
+
+Run through the KORA example runner:
+
+```bash
+python3 -m kora run cache_reuse
+```
+
+## Implementation Summary
+
+- Added `examples/cache_reuse/`.
+- Added request fixtures in `requests.json`.
+- Added expected counters in `expected_counters.json`.
+- Added `examples/cache_reuse/run.py`.
+- Reused KORA `TaskGraph` execution with the deterministic `classify_by_rules` handler for first-time deterministic requests.
+- Added tests in `tests/test_cache_reuse_example.py`.
+- Added the `cache_reuse` entry to `python3 -m kora examples list`.
+- Updated README/docs and continuation breadcrumbs.
+
+The example uses KORA `TaskGraph` execution for every non-cache request. Cache hits reuse prior deterministic results inside the same offline example run. No external APIs are called.
+
+## Route Examples
+
+First-time deterministic request:
+
+- input: `Classify ticket: customer was charged twice for order 4815`
+- route: `deterministic`
+- handler: `classify_by_rules`
+- provider calls: `0`
+
+Exact repeated request:
+
+- input: repeated `Classify ticket: customer was charged twice for order 4815`
+- route: `cache_hit`
+- handler: `cache_reuse`
+- provider calls: `0`
+
+Semantically equivalent repeated request:
+
+- input: `Please classify: duplicate charge on order 4815`
+- route: `cache_hit`
+- handler: `cache_reuse`
+- provider calls: `0`
+
+Provider-needed request:
+
+- input: `Draft a warm retention email for this account`
+- route: `provider_required`
+- handler: `provider_needed_fallback`
+- provider calls actually made: `0`
+
+## Evidence Counters
+
+Using `examples/cache_reuse/requests.json`:
+
+- total requests: `7`
+- first-time deterministic handled: `3`
+- cache hits: `2`
+- provider-needed: `2`
+- avoided simulated provider/model invocations: `5`
+- provider calls actually made: `0`
+
+The counters are sample-fixture counters only.
+
+## Validation Results
+
+Final validation was run from the Goal 088 worktree:
+
+```bash
+python3 examples/cache_reuse/run.py
+```
+
+Result: passed. The command reported `Total requests: 7`, `First-time deterministic handled: 3`, `Cache hits: 2`, `Provider-needed: 2`, and `Provider calls actually made: 0`.
+
+```bash
+python3 examples/cache_reuse/run.py --json-out /tmp/kora_goal088_cache_reuse.json --report-md /tmp/kora_goal088_cache_reuse.md
+```
+
+Result: passed. The command wrote JSON and Markdown outputs and reported the same counters.
+
+```bash
+python3 -m kora examples list
+```
+
+Result: passed. The output includes `cache_reuse: offline cache reuse routing example`.
+
+```bash
+python3 -m pytest tests/test_cache_reuse_example.py tests/test_agent_workflow_optimization_example.py tests/test_rag_routing_example.py tests/test_openai_proxy_demo_cli.py tests/test_first_value_cli.py tests/test_executor.py
+```
+
+Result: passed with `46 passed in 15.78s`.
+
+```bash
+python3 scripts/check_markdown_links_goal082b.py
+```
+
+Result: passed with `Goal 082B markdown links OK`.
+
+```bash
+git diff --check
+```
+
+Result: passed with no output.
+
+## Limitations
+
+- The request fixture is small and synthetic.
+- Semantic reuse is represented by an explicit fixture-owned `semantic_cache_key`.
+- Cache reuse is local to one example run.
+- Provider-needed means a real system would likely need provider/model handling; no provider/model call is made here.
+- The example does not implement a production cache service, cache invalidation, distributed cache, or HTTP endpoint.
+
+## Claim Boundaries
+
+Supported narrow wording:
+
+> In this offline cache-reuse example, KORA routes repeated sample requests to cache hits without making provider calls and marks ambiguous/open-ended requests as provider-needed.
+
+Not claimed:
+
+- production cache correctness.
+- automatic cost reduction.
+- real API-cost proof.
+- benchmark superiority.
+- broad workload superiority.
+- production validation.
+
+## Recommended Next Goal
+
+Goal 089 should refresh the public reviewer walkthrough and example catalog now that cache reuse is a first-class example alongside deterministic classification, KORA Doctor, OpenAI-style proxy control, RAG routing, and agent workflow optimization.

--- a/examples/cache_reuse/README.md
+++ b/examples/cache_reuse/README.md
@@ -1,0 +1,57 @@
+# Cache Reuse Example
+
+This offline example shows KORA identifying repeated or reusable work. It routes first-time deterministic sample requests through KORA `TaskGraph` execution, repeated exact or semantically equivalent sample requests to cache hits, and ambiguous/open-ended sample requests to provider-needed fallback.
+
+It does not call external APIs and does not require provider credentials.
+
+Current availability: run this example from a current `Krako-Labs/KORA` checkout installed from source. Plain `python3 -m pip install kora` installs a different PyPI project and should not be used for these examples. Future package distribution is planned as `getkora`, but this README does not claim that package is published.
+
+## Quick Run
+
+```bash
+python3 examples/cache_reuse/run.py
+```
+
+Write structured JSON and a report:
+
+```bash
+python3 examples/cache_reuse/run.py \
+  --json-out /tmp/kora_goal088_cache_reuse.json \
+  --report-md /tmp/kora_goal088_cache_reuse.md
+```
+
+Run through the KORA example runner:
+
+```bash
+python3 -m kora run cache_reuse
+```
+
+## Expected Output
+
+```text
+KORA Cache Reuse Example
+
+Total requests: 7
+First-time deterministic handled: 3
+Cache hits: 2
+Provider-needed: 2
+Avoided simulated provider/model invocations: 5
+Provider calls actually made: 0
+```
+
+## Expected Counters
+
+- total requests: `7`
+- first-time deterministic handled: `3`
+- cache hits: `2`
+- provider-needed: `2`
+- avoided simulated provider/model invocations: `5`
+- provider calls actually made: `0`
+
+Expected counters are in [expected_counters.json](expected_counters.json). Request fixtures are in [requests.json](requests.json).
+
+## Claim Boundary
+
+In this offline cache-reuse example, KORA routes repeated sample requests to cache hits without making provider calls and marks ambiguous/open-ended requests as provider-needed.
+
+This example does not claim production cache correctness, automatic cost reduction, real API-cost proof, benchmark superiority, or broad workload superiority.

--- a/examples/cache_reuse/expected_counters.json
+++ b/examples/cache_reuse/expected_counters.json
@@ -1,0 +1,8 @@
+{
+  "total_requests": 7,
+  "first_time_deterministic_handled": 3,
+  "cache_hits": 2,
+  "provider_needed": 2,
+  "avoided_provider_invocations": 5,
+  "provider_calls_actually_made": 0
+}

--- a/examples/cache_reuse/requests.json
+++ b/examples/cache_reuse/requests.json
@@ -1,0 +1,84 @@
+{
+  "request_set_id": "kora_cache_reuse_sample_requests_v0",
+  "routes": [
+    {
+      "route_id": "cache.det.billing_duplicate_charge",
+      "keywords": ["charged twice", "duplicate charge", "double charged"],
+      "output": {
+        "category": "billing_duplicate_charge",
+        "priority": "normal",
+        "owner": "billing_ops"
+      }
+    },
+    {
+      "route_id": "cache.det.password_reset",
+      "keywords": ["password reset", "cannot sign in", "login reset"],
+      "output": {
+        "category": "account_access",
+        "priority": "normal",
+        "owner": "account_support"
+      }
+    },
+    {
+      "route_id": "cache.det.invoice_copy",
+      "keywords": ["invoice copy", "copy of invoice", "download invoice"],
+      "output": {
+        "category": "billing_document",
+        "priority": "low",
+        "owner": "billing_ops"
+      }
+    }
+  ],
+  "provider_required_route": "cache.provider_needed.ambiguous_or_open_ended",
+  "requests": [
+    {
+      "id": "cache-001",
+      "text": "Classify ticket: customer was charged twice for order 4815",
+      "semantic_cache_key": "billing_duplicate_charge_order_4815",
+      "expected_route_kind": "deterministic",
+      "expected_handler": "classify_by_rules"
+    },
+    {
+      "id": "cache-002",
+      "text": "Classify ticket: customer was charged twice for order 4815",
+      "semantic_cache_key": "billing_duplicate_charge_order_4815",
+      "expected_route_kind": "cache_hit",
+      "expected_handler": "cache_reuse"
+    },
+    {
+      "id": "cache-003",
+      "text": "Please classify: duplicate charge on order 4815",
+      "semantic_cache_key": "billing_duplicate_charge_order_4815",
+      "expected_route_kind": "cache_hit",
+      "expected_handler": "cache_reuse"
+    },
+    {
+      "id": "cache-004",
+      "text": "Classify ticket: user needs password reset",
+      "semantic_cache_key": "account_password_reset",
+      "expected_route_kind": "deterministic",
+      "expected_handler": "classify_by_rules"
+    },
+    {
+      "id": "cache-005",
+      "text": "Classify ticket: send copy of invoice INV-1007",
+      "semantic_cache_key": "invoice_copy_inv_1007",
+      "expected_route_kind": "deterministic",
+      "expected_handler": "classify_by_rules"
+    },
+    {
+      "id": "cache-006",
+      "text": "Draft a warm retention email for this account",
+      "semantic_cache_key": "open_ended_retention_email",
+      "expected_route_kind": "provider_required",
+      "expected_handler": "provider_needed_fallback"
+    },
+    {
+      "id": "cache-007",
+      "text": "Recommend a strategy for this customer's renewal negotiation",
+      "semantic_cache_key": "open_ended_renewal_strategy",
+      "expected_route_kind": "provider_required",
+      "expected_handler": "provider_needed_fallback"
+    }
+  ]
+}

--- a/examples/cache_reuse/run.py
+++ b/examples/cache_reuse/run.py
@@ -1,0 +1,253 @@
+"""Offline cache reuse example using KORA task execution."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from kora.executor import run_graph
+from kora.task_ir import TaskGraph, normalize_graph, validate_graph
+
+EXAMPLE_DIR = Path(__file__).resolve().parent
+REQUESTS_PATH = EXAMPLE_DIR / "requests.json"
+EXPECTED_COUNTERS_PATH = EXAMPLE_DIR / "expected_counters.json"
+CLAIM_BOUNDARY = (
+    "In this offline cache-reuse example, KORA routes repeated sample requests "
+    "to cache hits without making provider calls and marks ambiguous/open-ended "
+    "requests as provider-needed. It does not claim production cache correctness, "
+    "automatic cost reduction, real API-cost proof, or benchmark superiority."
+)
+
+
+def load_requests(path: Path = REQUESTS_PATH) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _cache_key(item: dict[str, Any]) -> str:
+    semantic_key = item.get("semantic_cache_key")
+    if isinstance(semantic_key, str) and semantic_key.strip():
+        normalized = " ".join(semantic_key.lower().strip().split())
+    else:
+        normalized = " ".join(str(item.get("text", "")).lower().strip().split())
+    return hashlib.sha256(normalized.encode("utf-8")).hexdigest()
+
+
+def _classification_graph(config: dict[str, Any], request_id: str, text: str) -> TaskGraph:
+    return TaskGraph.model_validate(
+        {
+            "graph_id": f"cache-reuse-{request_id}",
+            "version": "0.1",
+            "root": "classify",
+            "defaults": {"budget": {"max_time_ms": 1500, "max_tokens": 300, "max_retries": 0}},
+            "tasks": [
+                {
+                    "id": "classify",
+                    "type": "det.cache_reuse.classification",
+                    "deps": [],
+                    "in": {"text": text},
+                    "run": {
+                        "kind": "det",
+                        "spec": {
+                            "handler": "classify_by_rules",
+                            "args": {
+                                "scenario_id": "cache_reuse",
+                                "routes": config["routes"],
+                                "provider_required_route": config["provider_required_route"],
+                            },
+                        },
+                    },
+                    "policy": {"on_fail": "fail"},
+                    "tags": ["cache-reuse", "offline-example"],
+                }
+            ],
+        }
+    )
+
+
+def _run_kora_classification(config: dict[str, Any], request_id: str, text: str) -> dict[str, Any]:
+    graph = normalize_graph(_classification_graph(config, request_id, text))
+    validate_graph(graph)
+    result = run_graph(graph)
+    if not result.get("ok"):
+        raise RuntimeError(str(result.get("error")))
+    final = result.get("final")
+    if not isinstance(final, dict):
+        raise RuntimeError("cache reuse graph did not return an object")
+    routed = dict(final)
+    routed.update(
+        {
+            "kora_graph_id": result["graph_id"],
+            "kora_event_count": len(result.get("events", [])),
+        }
+    )
+    return routed
+
+
+def build_cache_reuse_summary(
+    *,
+    requests_path: Path = REQUESTS_PATH,
+    json_out: Path | None = None,
+) -> dict[str, Any]:
+    config = load_requests(requests_path)
+    cache: dict[str, dict[str, Any]] = {}
+    results: list[dict[str, Any]] = []
+
+    for item in config["requests"]:
+        request_id = str(item["id"])
+        text = str(item["text"])
+        cache_key = _cache_key(item)
+
+        if cache_key in cache:
+            cached = cache[cache_key]
+            route = dict(cached["route"])
+            route.update(
+                {
+                    "route_kind": "cache_hit",
+                    "selected_route": "cache.reuse.hit",
+                    "provider_needed_reason": None,
+                }
+            )
+            handler = "cache_reuse"
+            source = "cache"
+            graph_id = cached["route"].get("kora_graph_id")
+            event_count = 0
+        else:
+            route = _run_kora_classification(config, request_id, text)
+            handler = (
+                "classify_by_rules"
+                if route["route_kind"] == "deterministic"
+                else "provider_needed_fallback"
+            )
+            source = "kora_task_graph"
+            graph_id = route.get("kora_graph_id")
+            event_count = int(route.get("kora_event_count", 0))
+            if route["route_kind"] == "deterministic":
+                cache[cache_key] = {"route": route}
+
+        results.append(
+            {
+                "id": request_id,
+                "input": text,
+                "semantic_cache_key": item.get("semantic_cache_key"),
+                "cache_key": cache_key,
+                "route_kind": route["route_kind"],
+                "selected_route": route["selected_route"],
+                "handler": handler,
+                "classification_output": route.get("classification_output"),
+                "provider_needed_reason": route.get("provider_needed_reason"),
+                "provider_calls": int(route.get("provider_calls", 0)),
+                "source": source,
+                "kora_graph_id": graph_id,
+                "kora_event_count": event_count,
+                "expected_route_kind": item["expected_route_kind"],
+                "expected_handler": item["expected_handler"],
+            }
+        )
+
+    total_requests = len(results)
+    first_time_deterministic_handled = sum(
+        1 for item in results if item["route_kind"] == "deterministic"
+    )
+    cache_hits = sum(1 for item in results if item["route_kind"] == "cache_hit")
+    provider_needed = sum(1 for item in results if item["route_kind"] == "provider_required")
+    provider_calls = sum(int(item["provider_calls"]) for item in results)
+    expected_match_count = sum(
+        1
+        for item in results
+        if item["route_kind"] == item["expected_route_kind"]
+        and item["handler"] == item["expected_handler"]
+    )
+    counters = {
+        "total_requests": total_requests,
+        "first_time_deterministic_handled": first_time_deterministic_handled,
+        "cache_hits": cache_hits,
+        "provider_needed": provider_needed,
+        "avoided_provider_invocations": first_time_deterministic_handled + cache_hits,
+        "provider_calls_actually_made": provider_calls,
+    }
+    expected_counters = json.loads(EXPECTED_COUNTERS_PATH.read_text(encoding="utf-8"))
+    summary: dict[str, Any] = {
+        "ok": counters == expected_counters and expected_match_count == total_requests,
+        "mode": "cache_reuse_example",
+        **counters,
+        "expected_match_count": expected_match_count,
+        "request_set_id": config["request_set_id"],
+        "results": results,
+        "example_request": results[0],
+        "safe_example_claim": (
+            "In this offline cache-reuse example, KORA routes repeated sample requests "
+            "to cache hits without making provider calls and marks ambiguous/open-ended "
+            "requests as provider-needed."
+        ),
+        "claim_boundary": CLAIM_BOUNDARY,
+    }
+    if json_out is not None:
+        json_out.parent.mkdir(parents=True, exist_ok=True)
+        json_out.write_text(json.dumps(summary, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return summary
+
+
+def render_report(summary: dict[str, Any]) -> str:
+    example = summary["example_request"]
+    lines = [
+        "KORA Cache Reuse Example",
+        "",
+        f"Total requests: {summary['total_requests']}",
+        f"First-time deterministic handled: {summary['first_time_deterministic_handled']}",
+        f"Cache hits: {summary['cache_hits']}",
+        f"Provider-needed: {summary['provider_needed']}",
+        f"Avoided simulated provider/model invocations: {summary['avoided_provider_invocations']}",
+        f"Provider calls actually made: {summary['provider_calls_actually_made']}",
+        "",
+        "Example request:",
+        f"- Input: \"{example['input']}\"",
+        f"- Route: {example['route_kind']}",
+        f"- Handler: {example['handler']}",
+        f"- Provider calls: {example['provider_calls']}",
+        "",
+        "Comparison surface:",
+    ]
+    for item in summary["results"]:
+        lines.append(
+            "- {id}: route={route}, handler={handler}, provider_calls={calls}, source={source}".format(
+                id=item["id"],
+                route=item["route_kind"],
+                handler=item["handler"],
+                calls=item["provider_calls"],
+                source=item["source"],
+            )
+        )
+    lines.extend(["", "Claim boundary:", summary["claim_boundary"]])
+    return "\n".join(lines) + "\n"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--requests", default=str(REQUESTS_PATH), help="offline cache request fixture JSON")
+    parser.add_argument("--json-out", help="optional path for structured JSON output")
+    parser.add_argument("--report-md", help="optional path for rendered report output")
+    args = parser.parse_args()
+
+    summary = build_cache_reuse_summary(
+        requests_path=Path(args.requests),
+        json_out=Path(args.json_out) if args.json_out else None,
+    )
+    report = render_report(summary)
+    if args.report_md:
+        report_path = Path(args.report_md)
+        report_path.parent.mkdir(parents=True, exist_ok=True)
+        report_path.write_text(report, encoding="utf-8")
+    print(report, end="")
+    return 0 if summary["ok"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/kora/cli.py
+++ b/kora/cli.py
@@ -51,6 +51,7 @@ def _repo_root() -> Path:
 def _example_descriptions() -> dict[str, str]:
     return {
         "agent_workflow_optimization": "offline agent workflow control example",
+        "cache_reuse": "offline cache reuse routing example",
         "hello_kora": "basic deterministic hello-world graph",
         "retry_demo": "retry/recovery flow example",
         "customer_support_triage_fake_validation": "customer-support triage local no-network validation example",

--- a/tests/test_cache_reuse_example.py
+++ b/tests/test_cache_reuse_example.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+def _load_module():
+    script_path = Path("examples/cache_reuse/run.py")
+    spec = importlib.util.spec_from_file_location("cache_reuse_run", script_path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError("failed to load cache reuse module")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_cache_reuse_summary_matches_expected_counters() -> None:
+    module = _load_module()
+    expected = json.loads(
+        Path("examples/cache_reuse/expected_counters.json").read_text(encoding="utf-8")
+    )
+
+    summary = module.build_cache_reuse_summary()
+
+    assert summary["ok"] is True
+    for key, value in expected.items():
+        assert summary[key] == value
+    assert summary["expected_match_count"] == summary["total_requests"]
+    assert summary["provider_calls_actually_made"] == 0
+
+
+def test_cache_reuse_uses_kora_task_graph_and_cache_paths() -> None:
+    module = _load_module()
+
+    summary = module.build_cache_reuse_summary()
+
+    deterministic = [item for item in summary["results"] if item["route_kind"] == "deterministic"]
+    cache_hits = [item for item in summary["results"] if item["route_kind"] == "cache_hit"]
+    provider_needed = [item for item in summary["results"] if item["route_kind"] == "provider_required"]
+    assert len(deterministic) == 3
+    assert len(cache_hits) == 2
+    assert len(provider_needed) == 2
+    assert all(str(item["kora_graph_id"]).startswith("cache-reuse-") for item in deterministic)
+    assert all(item["source"] == "cache" for item in cache_hits)
+    assert cache_hits[0]["handler"] == "cache_reuse"
+    assert cache_hits[0]["cache_key"] == cache_hits[1]["cache_key"]
+    assert all(item["provider_calls"] == 0 for item in summary["results"])
+
+
+def test_cache_reuse_report_contains_required_sections() -> None:
+    module = _load_module()
+
+    report = module.render_report(module.build_cache_reuse_summary())
+
+    assert "KORA Cache Reuse Example" in report
+    assert "Total requests: 7" in report
+    assert "First-time deterministic handled: 3" in report
+    assert "Cache hits: 2" in report
+    assert "Provider-needed: 2" in report
+    assert "Provider calls actually made: 0" in report
+    assert "Claim boundary:" in report
+
+
+def test_cache_reuse_cli_writes_outputs(tmp_path: Path) -> None:
+    json_out = tmp_path / "cache_reuse.json"
+    report_md = tmp_path / "cache_reuse.md"
+
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "examples/cache_reuse/run.py",
+            "--json-out",
+            str(json_out),
+            "--report-md",
+            str(report_md),
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert completed.returncode == 0
+    assert "KORA Cache Reuse Example" in completed.stdout
+    saved = json.loads(json_out.read_text(encoding="utf-8"))
+    assert saved["mode"] == "cache_reuse_example"
+    assert saved["total_requests"] == 7
+    assert saved["cache_hits"] == 2
+    assert saved["provider_calls_actually_made"] == 0
+    assert report_md.read_text(encoding="utf-8") == completed.stdout
+
+
+def test_cache_reuse_appears_in_example_listing() -> None:
+    completed = subprocess.run(
+        [sys.executable, "-m", "kora", "examples", "list"],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert completed.returncode == 0
+    assert "cache_reuse: offline cache reuse routing example" in completed.stdout


### PR DESCRIPTION
## Summary

- Adds the offline cache reuse example under examples/cache_reuse/.
- Adds fixtures, expected counters, tests, docs, and example listing entry.
- Keeps claim language scoped to offline sample-request evidence with provider calls actually made: 0.

## Validation

- python3 examples/cache_reuse/run.py
- python3 examples/cache_reuse/run.py --json-out /tmp/kora_goal088_cache_reuse.json --report-md /tmp/kora_goal088_cache_reuse.md
- python3 -m kora examples list
- python3 -m pytest tests/test_cache_reuse_example.py tests/test_agent_workflow_optimization_example.py tests/test_rag_routing_example.py tests/test_openai_proxy_demo_cli.py tests/test_first_value_cli.py tests/test_executor.py
- python3 scripts/check_markdown_links_goal082b.py
- git diff --check
