### PR TITLE
Goal 089A show architecture diagram in README

### DIFF
--- a/OPEN_THIS_FIRST.md
+++ b/OPEN_THIS_FIRST.md
@@ -24,6 +24,7 @@ Current state:
 - an offline agent workflow optimization example exists under `examples/agent_workflow_optimization/`, showing KORA routing sample workflow steps across deterministic, cache, tool-needed, and provider-needed paths without provider calls.
 - an offline cache reuse example exists under `examples/cache_reuse/`, showing KORA routing repeated sample requests to cache hits while preserving provider-needed fallback for ambiguous/open-ended requests without provider calls.
 - Goal 089 replaced the public workload-control architecture diagram with `docs/assets/kora_workload_control_layer_architecture.svg` and completed a public repository hygiene audit: [Goal 089 repository hygiene and architecture diagram](docs/reports/goal089_repository_hygiene_and_architecture_diagram.md).
+- Goal 089A embeds that architecture diagram near the top of the public README and vision doc: [Goal 089A README architecture diagram placement](docs/reports/goal089a_readme_architecture_diagram_placement.md).
 - a deterministic classification example pack exists under `examples/deterministic_classification/`, using KORA `TaskGraph` execution across support-ticket routing, issue triage, incident severity routing, document type routing, and log/event classification.
 - a KORA Doctor example exists under `examples/kora_doctor/`, using KORA `TaskGraph` execution to inspect a synthetic workload and explain deterministic candidates, provider-needed candidates, route rationale, counters, and next steps.
 - the KORA Doctor example now includes a report pack mode across four bundled offline workloads and a README refresh proposal for examples-driven positioning.
@@ -35,11 +36,11 @@ Current state:
 
 ## Current Branch
 
-- branch: `goal089_repository_hygiene_architecture_diagram`
+- branch: `goal089a_readme_architecture_diagram_placement`
 - public truth: `origin/main`
 - branch pushed to: not pushed in this worktree
-- open PR: none for Goal 089
-- base commit: `2fdc260fb0b4b174ad15e41e081df3703dd209c7`
+- open PR: none for Goal 089A
+- base commit: `5157832af5dcdf6df8baf8ff9f3ab6df35c8ffbb`
 
 ## Last Completed Goal
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@ Many AI systems treat every task as a model problem. Many tasks are actually cla
 
 Current examples are offline and synthetic. They demonstrate KORA's routing/control surfaces, not production readiness, production cost reduction, benchmark superiority, or model replacement.
 
+![KORA Workload Control Layer Architecture](docs/assets/kora_workload_control_layer_architecture.svg)
+
+View the architecture diagram: [docs/assets/kora_workload_control_layer_architecture.svg](docs/assets/kora_workload_control_layer_architecture.svg)
+
 ## Current Availability
 
 Use the current GitHub repository for the latest examples and CLI commands.

--- a/REVIEW_HUB.md
+++ b/REVIEW_HUB.md
@@ -14,11 +14,11 @@ KRK means KORA Routing Kernel. KRK is the deterministic-first execution routing 
 
 - repository: `https://github.com/Krako-Labs/KORA`
 - public truth branch: `origin/main`
-- active evidence branch: `goal089_repository_hygiene_architecture_diagram`
-- worktree label: `goal089_repository_hygiene_architecture_diagram`
+- active evidence branch: `goal089a_readme_architecture_diagram_placement`
+- worktree label: `goal089a_readme_architecture_diagram_placement`
 - branch pushed to: not pushed in this worktree
-- open PR: none for Goal 089
-- base commit: `2fdc260fb0b4b174ad15e41e081df3703dd209c7`
+- open PR: none for Goal 089A
+- base commit: `5157832af5dcdf6df8baf8ff9f3ab6df35c8ffbb`
 
 ## Current State Summary
 
@@ -113,6 +113,7 @@ Generated summaries:
 
 Current reviewer path:
 
+- [Goal 089A README architecture diagram placement](docs/reports/goal089a_readme_architecture_diagram_placement.md)
 - [Goal 089 repository hygiene and architecture diagram](docs/reports/goal089_repository_hygiene_and_architecture_diagram.md)
 - [Goal 082B narrative repositioning](docs/reports/goal082b_narrative_repositioning.md)
 - [Goal 088 cache reuse example](docs/reports/goal088_cache_reuse_example.md)

--- a/docs/reports/goal089a_readme_architecture_diagram_placement.md
+++ b/docs/reports/goal089a_readme_architecture_diagram_placement.md
@@ -1,0 +1,39 @@
+# Goal 089A README Architecture Diagram Placement
+
+Status: implemented.
+
+Base: `origin/main` at `5157832af5dcdf6df8baf8ff9f3ab6df35c8ffbb`.
+
+Branch: `goal089a_readme_architecture_diagram_placement`.
+
+## Summary
+
+Goal 089A makes the clean KORA Workload Control Layer architecture diagram visible from the public README. Goal 089 had copied the clean SVG into `docs/assets/`, but README did not embed that asset, so the GitHub repository landing page still appeared text-only near the top.
+
+## Changes
+
+- Verified the clean SVG exists at `docs/assets/kora_workload_control_layer_architecture.svg`.
+- Embedded the SVG near the top of `README.md` after the opening KORA positioning section.
+- Added a direct fallback link under the README image.
+- Confirmed `docs/README.md` already referenced the same SVG path.
+- Added the same diagram reference and fallback link to `docs/vision/kora_workload_control_layer.md`.
+
+## SVG Handling
+
+The SVG file was not modified in this task.
+
+## Validation
+
+Validation run:
+
+- `test -f docs/assets/kora_workload_control_layer_architecture.svg`
+- `grep -n "docs/assets/kora_workload_control_layer_architecture.svg" README.md`
+- markdown link validation for changed files
+- `python3 scripts/check_markdown_links_goal082b.py`
+- `git diff --check`
+
+Result: passed.
+
+## Claim Boundary
+
+This task did not add new technical claims, production-readiness claims, release artifacts, tags, GitHub Releases, or package publication claims.

--- a/docs/vision/kora_workload_control_layer.md
+++ b/docs/vision/kora_workload_control_layer.md
@@ -8,6 +8,10 @@ KORA is an AI Workload Control Layer. It helps developers inspect work before se
 
 This vision is grounded in the current offline examples and evidence already present in the repository. It does not claim production readiness, model replacement, automatic savings, benchmark superiority, or broad workload superiority.
 
+![KORA Workload Control Layer Architecture](../assets/kora_workload_control_layer_architecture.svg)
+
+View the architecture diagram: [docs/assets/kora_workload_control_layer_architecture.svg](../assets/kora_workload_control_layer_architecture.svg)
+
 ## Current AI Stack
 
 Many AI applications are built around a model-centric path:


### PR DESCRIPTION
## Summary

- embeds the clean KORA Workload Control Layer architecture SVG near the top of `README.md`
- adds a direct fallback link under the README image
- adds the same diagram reference to the workload-control vision doc
- adds the Goal 089A placement report and updates breadcrumbs

## Validation

- `test -f docs/assets/kora_workload_control_layer_architecture.svg`
- `grep -n "docs/assets/kora_workload_control_layer_architecture.svg" README.md`
- `python3 scripts/check_markdown_links_goal082b.py`
- changed markdown link sanity check
- `git diff --check`

## Audits

- SVG file is not modified in this branch
- README embeds the SVG near the top and includes fallback link
- docs/README and docs/vision reference the same diagram path
- no new technical claims, release artifacts, tags, GitHub Releases, or package publication
