### PR TITLE
Goal 093A Metadata change approval packet

### DIFF
--- a/OPEN_THIS_FIRST.md
+++ b/OPEN_THIS_FIRST.md
@@ -2,7 +2,7 @@
 
 Status: current public project breadcrumb.
 
-Last updated by: Goal 092.
+Last updated by: Goal 093A.
 
 ## Current Status
 
@@ -27,6 +27,7 @@ Current state:
 - Goal 089A embeds that architecture diagram near the top of the public README and vision doc: [Goal 089A README architecture diagram placement](docs/reports/goal089a_readme_architecture_diagram_placement.md).
 - Goal 091 compressed the public README into a focused KORA landing page: [Goal 091 README compression](docs/reports/goal091_readme_compression.md).
 - Goal 092 audited the public repository surface after the README replacement and proposed metadata, root, examples, and docs alignment steps without changing repository settings or moving files: [Goal 092 repository public surface alignment audit](docs/reports/goal092_repository_public_surface_alignment_audit.md).
+- Goal 093A prepared a metadata change approval packet for the repository description and topics without changing repository settings: [Goal 093A metadata change approval packet](docs/reports/goal093a_metadata_change_approval_packet.md).
 - a deterministic classification example pack exists under `examples/deterministic_classification/`, using KORA `TaskGraph` execution across support-ticket routing, issue triage, incident severity routing, document type routing, and log/event classification.
 - a KORA Doctor example exists under `examples/kora_doctor/`, using KORA `TaskGraph` execution to inspect a synthetic workload and explain deterministic candidates, provider-needed candidates, route rationale, counters, and next steps.
 - the KORA Doctor example now includes a report pack mode across four bundled offline workloads and a README refresh proposal for examples-driven positioning.
@@ -37,28 +38,34 @@ Current state:
 
 ## Current Branch
 
-- branch: `codex/goal092-public-surface-audit`
+- branch: `codex/goal093a-metadata-approval-packet`
 - public truth: `origin/main`
 - branch pushed to: not pushed in this worktree
-- open PR: none for Goal 092
-- base commit: `2972973d732624353bd722d648886eed4d6d9e6c`
+- open PR: none for Goal 093A
+- base commit: `7e568a0d8ea7056796bfd8a67bfc7c7cd19f8f9c`
 
 ## Last Completed Goal
 
-Goal 092 - Repository Public Surface Alignment Audit.
+Goal 093A - Metadata Change Approval Packet.
+
+Goal 093A prepared an approval packet for updating the public repository description and topics to match the AI Workload Control Layer positioning. It made no repository-setting changes.
+
+Primary report:
+
+- [Goal 093A metadata change approval packet](docs/reports/goal093a_metadata_change_approval_packet.md)
+
+Approval boundary:
+
+- Goal 093B may apply the metadata update only after explicit owner approval.
+- Goal 093A did not change repository description, topics, homepage, releases, tags, package state, or files outside the approval packet and breadcrumbs.
+
+Previous completed Goal: Goal 092 - Repository Public Surface Alignment Audit.
 
 Goal 092 audited the public GitHub surface after the exact public documentation replacement. It identified remaining alignment work for repository metadata, root files, example organization, and docs navigation while making no repository-setting changes and moving no files.
 
 Primary report:
 
 - [Goal 092 repository public surface alignment audit](docs/reports/goal092_repository_public_surface_alignment_audit.md)
-
-Primary findings:
-
-- GitHub About metadata still uses older Inference Operating System positioning.
-- The root directory still exposes older architecture, executive summary, vision, roadmap, artifact, experiment, and Studio surfaces at similar prominence to the current README.
-- `examples/` mixes current flagship examples with older first-run, validation, and benchmark examples.
-- `docs/` needs clearer current, evidence, historical, and archive navigation.
 
 Claim boundary: Goal 092 is an audit/proposal only. It does not add product claims, production-readiness claims, package-publication claims, release claims, metadata changes, or file moves.
 
@@ -396,11 +403,11 @@ KORA makes AI workloads routable. The current KRK public alpha shows how workloa
 
 ## Recommended Next Goal
 
-Goal 093 - Metadata-only public surface alignment.
+Goal 093B - Apply metadata update after explicit owner approval.
 
 Recommended scope:
 
-- update GitHub repository description and topics after explicit owner approval.
+- apply the repository description and topics exactly as approved in the Goal 093A packet.
 - verify the public About panel after the settings change.
 - do not move files, rewrite docs, create releases, create tags, or publish packages.
 

--- a/REVIEW_HUB.md
+++ b/REVIEW_HUB.md
@@ -2,7 +2,7 @@
 
 Status: current public review and continuation hub.
 
-Last updated by: Goal 092.
+Last updated by: Goal 093A.
 
 ## Project Identity
 
@@ -14,11 +14,11 @@ KRK means KORA Routing Kernel. KRK is the deterministic-first execution routing 
 
 - repository: `https://github.com/Krako-Labs/KORA`
 - public truth branch: `origin/main`
-- active audit branch: `codex/goal092-public-surface-audit`
-- worktree label: `goal092_public_surface_audit`
+- active approval branch: `codex/goal093a-metadata-approval-packet`
+- worktree label: `goal093a_metadata_approval_packet`
 - branch pushed to: not pushed in this worktree
-- open PR: none for Goal 092
-- base commit: `2972973d732624353bd722d648886eed4d6d9e6c`
+- open PR: none for Goal 093A
+- base commit: `7e568a0d8ea7056796bfd8a67bfc7c7cd19f8f9c`
 
 ## Current State Summary
 
@@ -48,9 +48,10 @@ KORA now has a public-safe first-value path and an evidence package that covers:
 - Goal 091 compressed README into a focused landing page with a source quick start, flagship examples table, and short claim boundaries.
 - Goal 091B replaced selected public landing and index documents exactly and was merged into `origin/main` at `2972973d732624353bd722d648886eed4d6d9e6c`.
 - Goal 092 audited the public repository surface and identified remaining alignment work for GitHub metadata, root files, examples grouping, and docs navigation without changing settings or moving files.
+- Goal 093A prepared a metadata change approval packet for repository description and topics without changing repository settings.
 - reusable Project Operating System templates, prompts, and adoption standard.
 - validated Project Operating System continuation path for KORA.
-- current recommended next step is metadata-only alignment after explicit owner approval.
+- current recommended next step is applying the approved metadata update only after explicit owner approval.
 
 Current status is evidence-centered and local-first. It is not production-readiness evidence.
 
@@ -92,6 +93,7 @@ This is a sufficient recent history backfill, not a complete reconstruction.
 | Goal 088 | Added an offline cache reuse example that routes repeated sample requests to cache hits and marks ambiguous/open-ended requests as provider-needed without provider calls. | [Goal 088 cache reuse example](docs/reports/goal088_cache_reuse_example.md) |
 | Goal 091 | Compressed README into a focused public landing page while preserving source-install guidance, flagship examples, architecture diagram, and claim boundaries. | [Goal 091 README compression](docs/reports/goal091_readme_compression.md) |
 | Goal 092 | Audited the post-replacement public repository surface and proposed staged alignment work for metadata, root structure, examples, and docs navigation. | [Goal 092 repository public surface alignment audit](docs/reports/goal092_repository_public_surface_alignment_audit.md) |
+| Goal 093A | Prepared the metadata change approval packet for repository description and topics without applying settings changes. | [Goal 093A metadata change approval packet](docs/reports/goal093a_metadata_change_approval_packet.md) |
 
 ## Evidence Index
 
@@ -117,6 +119,7 @@ Generated summaries:
 
 Current reviewer path:
 
+- [Goal 093A metadata change approval packet](docs/reports/goal093a_metadata_change_approval_packet.md)
 - [Goal 092 repository public surface alignment audit](docs/reports/goal092_repository_public_surface_alignment_audit.md)
 - [Goal 091 README compression](docs/reports/goal091_readme_compression.md)
 - [Goal 089A README architecture diagram placement](docs/reports/goal089a_readme_architecture_diagram_placement.md)
@@ -392,7 +395,7 @@ Boundary: this is positioning grounded in current examples and evidence. It does
 
 ## Recommended Next Goals
 
-1. Goal 093 - Metadata-only public surface alignment after explicit owner approval.
+1. Goal 093B - Apply metadata update after explicit owner approval.
 2. Goal 094 - Root orientation stubs for older root strategic documents, without moving files.
 3. Goal 095 - Examples grouping proposal with link-preserving plan.
 4. Goal 096 - Documentation navigation and archive-bucket proposal.
@@ -403,7 +406,7 @@ Paste a new Goal with this instruction:
 
 ```text
 Start by reading OPEN_THIS_FIRST.md and REVIEW_HUB.md.
-Use the active branch codex/goal092-public-surface-audit for the current audit repair, or create a new scoped branch from origin/main for a new Goal.
+Use the active branch codex/goal093a-metadata-approval-packet for the current approval packet, or create a new scoped branch from origin/main for a new Goal.
 Keep public/private and claim boundaries from REVIEW_HUB.md.
 Update OPEN_THIS_FIRST.md and REVIEW_HUB.md before committing unless explicitly exempted.
 ```

--- a/docs/reports/goal093a_metadata_change_approval_packet.md
+++ b/docs/reports/goal093a_metadata_change_approval_packet.md
@@ -1,0 +1,127 @@
+# Goal 093A Metadata Change Approval Packet
+
+Current public HEAD: `7e568a0d8ea7056796bfd8a67bfc7c7cd19f8f9c`
+
+Status: approval packet only. This goal did not change repository settings, update repository description, update topics, update homepage, move files, merge a pull request, create a release, create a tag, create a publication, or change product claims.
+
+## Purpose
+
+KORA's README and documentation now position the project as an AI Workload Control Layer. The public repository metadata still uses older Inference Operating System wording. This packet prepares the exact metadata update for owner approval before any settings are changed.
+
+## Current Repository Metadata
+
+| Field | Current value |
+| --- | --- |
+| Visibility | `public` |
+| Default branch | `main` |
+| Description | `An Inference Operating System that reduces unnecessary LLM calls by structuring intelligence before scaling it.` |
+| Homepage | empty |
+| Topics | `agent-framework`, `ai-infrastructure`, `cost-optimization`, `inference`, `json-schema`, `large-language-models`, `llm`, `open-source`, `orchestration`, `task-graph` |
+
+## Proposed Repository Metadata
+
+| Field | Proposed value |
+| --- | --- |
+| Description | `AI Workload Control Layer for routing deterministic, reusable, retrieval-needed, tool-needed, and provider-needed work before model invocation.` |
+| Homepage | no change |
+| Topics | `ai-infrastructure`, `workload-routing`, `ai-workload-control`, `task-graph`, `deterministic-routing`, `llm-infrastructure`, `retrieval-routing`, `tool-routing`, `python`, `open-source` |
+
+## Before And After
+
+| Field | Before | After |
+| --- | --- | --- |
+| Description | `An Inference Operating System that reduces unnecessary LLM calls by structuring intelligence before scaling it.` | `AI Workload Control Layer for routing deterministic, reusable, retrieval-needed, tool-needed, and provider-needed work before model invocation.` |
+| Homepage | empty | no change |
+| Topics | `agent-framework`, `ai-infrastructure`, `cost-optimization`, `inference`, `json-schema`, `large-language-models`, `llm`, `open-source`, `orchestration`, `task-graph` | `ai-infrastructure`, `workload-routing`, `ai-workload-control`, `task-graph`, `deterministic-routing`, `llm-infrastructure`, `retrieval-routing`, `tool-routing`, `python`, `open-source` |
+
+## Apply Commands For Later Approval
+
+Do not run these commands until Goal 093B receives explicit owner approval.
+
+Description update:
+
+```bash
+GH_CONFIG_DIR="$HOME/.config/gh-hkalbertkim" gh api \
+  -X PATCH repos/Krako-Labs/KORA \
+  -f description='AI Workload Control Layer for routing deterministic, reusable, retrieval-needed, tool-needed, and provider-needed work before model invocation.'
+```
+
+Topics update:
+
+```bash
+GH_CONFIG_DIR="$HOME/.config/gh-hkalbertkim" gh api \
+  -X PUT repos/Krako-Labs/KORA/topics \
+  -H 'Accept: application/vnd.github+json' \
+  -f names[]=ai-infrastructure \
+  -f names[]=workload-routing \
+  -f names[]=ai-workload-control \
+  -f names[]=task-graph \
+  -f names[]=deterministic-routing \
+  -f names[]=llm-infrastructure \
+  -f names[]=retrieval-routing \
+  -f names[]=tool-routing \
+  -f names[]=python \
+  -f names[]=open-source
+```
+
+Read-back verification after a later approved update:
+
+```bash
+GH_CONFIG_DIR="$HOME/.config/gh-hkalbertkim" gh api repos/Krako-Labs/KORA \
+  -q '{description:.description,homepage:.homepage,topics:.topics,visibility:.visibility,default_branch:.default_branch}'
+```
+
+## Rollback Plan
+
+If the approved metadata update needs to be reverted, restore the current description and topics with these values:
+
+- description: `An Inference Operating System that reduces unnecessary LLM calls by structuring intelligence before scaling it.`
+- homepage: empty
+- topics: `agent-framework`, `ai-infrastructure`, `cost-optimization`, `inference`, `json-schema`, `large-language-models`, `llm`, `open-source`, `orchestration`, `task-graph`
+
+Rollback commands:
+
+```bash
+GH_CONFIG_DIR="$HOME/.config/gh-hkalbertkim" gh api \
+  -X PATCH repos/Krako-Labs/KORA \
+  -f description='An Inference Operating System that reduces unnecessary LLM calls by structuring intelligence before scaling it.'
+
+GH_CONFIG_DIR="$HOME/.config/gh-hkalbertkim" gh api \
+  -X PUT repos/Krako-Labs/KORA/topics \
+  -H 'Accept: application/vnd.github+json' \
+  -f names[]=agent-framework \
+  -f names[]=ai-infrastructure \
+  -f names[]=cost-optimization \
+  -f names[]=inference \
+  -f names[]=json-schema \
+  -f names[]=large-language-models \
+  -f names[]=llm \
+  -f names[]=open-source \
+  -f names[]=orchestration \
+  -f names[]=task-graph
+```
+
+## Risks
+
+- Metadata changes are immediately public in the repository About panel.
+- Topic changes may affect discovery and external expectations.
+- The proposed wording is clearer but less cost-optimization-centered than the current description.
+- The description still mentions model invocation, so future public copy should keep claim boundaries clear.
+- Topics should not imply production readiness, package publication, or broad benchmark superiority.
+
+## Confirmation
+
+- No repository settings were changed in Goal 093A.
+- No description update was applied.
+- No topics update was applied.
+- No homepage update was applied.
+- No file moves were made.
+- No release, tag, publication, or merge was created.
+
+## Recommended Next Goal
+
+Goal 093B - Apply metadata update after explicit owner approval.
+
+Required owner approval sentence:
+
+`Approved: Goal 093B may update the KORA GitHub repository description and topics exactly as specified in docs/reports/goal093a_metadata_change_approval_packet.md.`


### PR DESCRIPTION
## Summary

- adds the Goal 093A metadata change approval packet
- updates `OPEN_THIS_FIRST.md` and `REVIEW_HUB.md` with a short Goal 093A breadcrumb
- documents current repository metadata, proposed description/topics, apply commands for a later approved goal, rollback plan, and risks

## Approval boundary

This PR does not change repository settings.
This PR only prepares the metadata update approval packet.
Actual description/topics update requires explicit owner approval in Goal 093B.

## Validation

- `python3 -m kora examples list`
- `python3 scripts/check_markdown_links_goal082b.py`
- `git diff --check`
- high-risk private/internal scan over changed files

## Not performed

- no repository description update
- no topic update
- no homepage update
- no file moves
- no merge
- no release, tag, GitHub Release, or PyPI publication
