### PR TITLE
Goal 093C Metadata update post-change verification

### DIFF
--- a/OPEN_THIS_FIRST.md
+++ b/OPEN_THIS_FIRST.md
@@ -2,7 +2,7 @@
 
 Status: current public project breadcrumb.
 
-Last updated by: Goal 093A.
+Last updated by: Goal 093C.
 
 ## Current Status
 
@@ -28,6 +28,7 @@ Current state:
 - Goal 091 compressed the public README into a focused KORA landing page: [Goal 091 README compression](docs/reports/goal091_readme_compression.md).
 - Goal 092 audited the public repository surface after the README replacement and proposed metadata, root, examples, and docs alignment steps without changing repository settings or moving files: [Goal 092 repository public surface alignment audit](docs/reports/goal092_repository_public_surface_alignment_audit.md).
 - Goal 093A prepared a metadata change approval packet for the repository description and topics without changing repository settings: [Goal 093A metadata change approval packet](docs/reports/goal093a_metadata_change_approval_packet.md).
+- Goal 093B applied the approved GitHub repository description and topics metadata update; Goal 093C verified and documented the readback: [Goal 093C metadata update post-change verification](docs/reports/goal093c_metadata_update_postchange_verification.md).
 - a deterministic classification example pack exists under `examples/deterministic_classification/`, using KORA `TaskGraph` execution across support-ticket routing, issue triage, incident severity routing, document type routing, and log/event classification.
 - a KORA Doctor example exists under `examples/kora_doctor/`, using KORA `TaskGraph` execution to inspect a synthetic workload and explain deterministic candidates, provider-needed candidates, route rationale, counters, and next steps.
 - the KORA Doctor example now includes a report pack mode across four bundled offline workloads and a README refresh proposal for examples-driven positioning.
@@ -38,26 +39,37 @@ Current state:
 
 ## Current Branch
 
-- branch: `codex/goal093a-metadata-approval-packet`
+- branch: `codex/goal093c-metadata-postchange-verification`
 - public truth: `origin/main`
 - branch pushed to: not pushed in this worktree
-- open PR: none for Goal 093A
-- base commit: `7e568a0d8ea7056796bfd8a67bfc7c7cd19f8f9c`
+- open PR: none for Goal 093C
+- base commit: `05f01fcff7a12a90945d9d69a5c18221ea8519c6`
 
 ## Last Completed Goal
 
-Goal 093A - Metadata Change Approval Packet.
+Goal 093C - Metadata Update Post-Change Verification.
+
+Goal 093C verified and documented the Goal 093B GitHub repository metadata update. The public README and GitHub About metadata are now aligned around AI Workload Control Layer positioning.
+
+Primary report:
+
+- [Goal 093C metadata update post-change verification](docs/reports/goal093c_metadata_update_postchange_verification.md)
+
+Metadata readback:
+
+- description: `AI Workload Control Layer for routing deterministic, reusable, retrieval-needed, tool-needed, and provider-needed work before model invocation.`
+- topics: `ai-infrastructure`, `ai-workload-control`, `deterministic-routing`, `llm-infrastructure`, `open-source`, `python`, `retrieval-routing`, `task-graph`, `tool-routing`, `workload-routing`
+- homepage remains empty; visibility remains public; default branch remains `main`.
+
+Claim boundary: Goal 093C is verification and documentation sync only. It did not change repository settings, move files, create a release, create a tag, create a publication, or add product claims.
+
+Previous completed Goal: Goal 093A - Metadata Change Approval Packet.
 
 Goal 093A prepared an approval packet for updating the public repository description and topics to match the AI Workload Control Layer positioning. It made no repository-setting changes.
 
 Primary report:
 
 - [Goal 093A metadata change approval packet](docs/reports/goal093a_metadata_change_approval_packet.md)
-
-Approval boundary:
-
-- Goal 093B may apply the metadata update only after explicit owner approval.
-- Goal 093A did not change repository description, topics, homepage, releases, tags, package state, or files outside the approval packet and breadcrumbs.
 
 Previous completed Goal: Goal 092 - Repository Public Surface Alignment Audit.
 
@@ -403,13 +415,13 @@ KORA makes AI workloads routable. The current KRK public alpha shows how workloa
 
 ## Recommended Next Goal
 
-Goal 093B - Apply metadata update after explicit owner approval.
+Goal 094 - Root orientation stubs for older root strategic documents, without moving files.
 
 Recommended scope:
 
-- apply the repository description and topics exactly as approved in the Goal 093A packet.
-- verify the public About panel after the settings change.
-- do not move files, rewrite docs, create releases, create tags, or publish packages.
+- add or refresh short root stubs for older strategic documents.
+- keep file paths stable; do not move files in Goal 094 unless explicitly approved.
+- preserve README and GitHub About alignment around AI Workload Control Layer positioning.
 
 ## How To Continue
 

--- a/OPEN_THIS_FIRST.md
+++ b/OPEN_THIS_FIRST.md
@@ -41,8 +41,8 @@ Current state:
 
 - branch: `codex/goal093c-metadata-postchange-verification`
 - public truth: `origin/main`
-- branch pushed to: not pushed in this worktree
-- open PR: none for Goal 093C
+- branch pushed to: `origin/codex/goal093c-metadata-postchange-verification`
+- open PR: #244
 - base commit: `05f01fcff7a12a90945d9d69a5c18221ea8519c6`
 
 ## Last Completed Goal

--- a/REVIEW_HUB.md
+++ b/REVIEW_HUB.md
@@ -16,8 +16,8 @@ KRK means KORA Routing Kernel. KRK is the deterministic-first execution routing 
 - public truth branch: `origin/main`
 - active verification branch: `codex/goal093c-metadata-postchange-verification`
 - worktree label: `goal093c_metadata_postchange_verification`
-- branch pushed to: not pushed in this worktree
-- open PR: none for Goal 093C
+- branch pushed to: `origin/codex/goal093c-metadata-postchange-verification`
+- open PR: #244
 - base commit: `05f01fcff7a12a90945d9d69a5c18221ea8519c6`
 
 ## Current State Summary

--- a/REVIEW_HUB.md
+++ b/REVIEW_HUB.md
@@ -2,7 +2,7 @@
 
 Status: current public review and continuation hub.
 
-Last updated by: Goal 093A.
+Last updated by: Goal 093C.
 
 ## Project Identity
 
@@ -14,11 +14,11 @@ KRK means KORA Routing Kernel. KRK is the deterministic-first execution routing 
 
 - repository: `https://github.com/Krako-Labs/KORA`
 - public truth branch: `origin/main`
-- active approval branch: `codex/goal093a-metadata-approval-packet`
-- worktree label: `goal093a_metadata_approval_packet`
+- active verification branch: `codex/goal093c-metadata-postchange-verification`
+- worktree label: `goal093c_metadata_postchange_verification`
 - branch pushed to: not pushed in this worktree
-- open PR: none for Goal 093A
-- base commit: `7e568a0d8ea7056796bfd8a67bfc7c7cd19f8f9c`
+- open PR: none for Goal 093C
+- base commit: `05f01fcff7a12a90945d9d69a5c18221ea8519c6`
 
 ## Current State Summary
 
@@ -49,9 +49,11 @@ KORA now has a public-safe first-value path and an evidence package that covers:
 - Goal 091B replaced selected public landing and index documents exactly and was merged into `origin/main` at `2972973d732624353bd722d648886eed4d6d9e6c`.
 - Goal 092 audited the public repository surface and identified remaining alignment work for GitHub metadata, root files, examples grouping, and docs navigation without changing settings or moving files.
 - Goal 093A prepared a metadata change approval packet for repository description and topics without changing repository settings.
+- Goal 093B applied the approved GitHub repository description and topics metadata update; Goal 093C verified and documented that repository metadata is now aligned with the README around AI Workload Control Layer positioning.
 - reusable Project Operating System templates, prompts, and adoption standard.
 - validated Project Operating System continuation path for KORA.
-- current recommended next step is applying the approved metadata update only after explicit owner approval.
+- no repository settings should be changed further without explicit owner approval.
+- current recommended next step is Goal 094 root orientation stubs for older root strategic documents, without moving files.
 
 Current status is evidence-centered and local-first. It is not production-readiness evidence.
 
@@ -94,6 +96,7 @@ This is a sufficient recent history backfill, not a complete reconstruction.
 | Goal 091 | Compressed README into a focused public landing page while preserving source-install guidance, flagship examples, architecture diagram, and claim boundaries. | [Goal 091 README compression](docs/reports/goal091_readme_compression.md) |
 | Goal 092 | Audited the post-replacement public repository surface and proposed staged alignment work for metadata, root structure, examples, and docs navigation. | [Goal 092 repository public surface alignment audit](docs/reports/goal092_repository_public_surface_alignment_audit.md) |
 | Goal 093A | Prepared the metadata change approval packet for repository description and topics without applying settings changes. | [Goal 093A metadata change approval packet](docs/reports/goal093a_metadata_change_approval_packet.md) |
+| Goal 093C | Verified the post-change GitHub metadata readback after Goal 093B and documented that repository metadata now matches the README positioning. | [Goal 093C metadata update post-change verification](docs/reports/goal093c_metadata_update_postchange_verification.md) |
 
 ## Evidence Index
 
@@ -119,6 +122,7 @@ Generated summaries:
 
 Current reviewer path:
 
+- [Goal 093C metadata update post-change verification](docs/reports/goal093c_metadata_update_postchange_verification.md)
 - [Goal 093A metadata change approval packet](docs/reports/goal093a_metadata_change_approval_packet.md)
 - [Goal 092 repository public surface alignment audit](docs/reports/goal092_repository_public_surface_alignment_audit.md)
 - [Goal 091 README compression](docs/reports/goal091_readme_compression.md)
@@ -395,10 +399,9 @@ Boundary: this is positioning grounded in current examples and evidence. It does
 
 ## Recommended Next Goals
 
-1. Goal 093B - Apply metadata update after explicit owner approval.
-2. Goal 094 - Root orientation stubs for older root strategic documents, without moving files.
-3. Goal 095 - Examples grouping proposal with link-preserving plan.
-4. Goal 096 - Documentation navigation and archive-bucket proposal.
+1. Goal 094 - Root orientation stubs for older root strategic documents, without moving files.
+2. Goal 095 - Examples grouping proposal with link-preserving plan.
+3. Goal 096 - Documentation navigation and archive-bucket proposal.
 
 ## How To Resume Review
 
@@ -406,7 +409,7 @@ Paste a new Goal with this instruction:
 
 ```text
 Start by reading OPEN_THIS_FIRST.md and REVIEW_HUB.md.
-Use the active branch codex/goal093a-metadata-approval-packet for the current approval packet, or create a new scoped branch from origin/main for a new Goal.
+Use the active branch codex/goal093c-metadata-postchange-verification for the current verification packet, or create a new scoped branch from origin/main for a new Goal.
 Keep public/private and claim boundaries from REVIEW_HUB.md.
 Update OPEN_THIS_FIRST.md and REVIEW_HUB.md before committing unless explicitly exempted.
 ```

--- a/docs/reports/goal093c_metadata_update_postchange_verification.md
+++ b/docs/reports/goal093c_metadata_update_postchange_verification.md
@@ -1,0 +1,51 @@
+# Goal 093C Metadata Update Post-Change Verification
+
+Public HEAD: `05f01fcff7a12a90945d9d69a5c18221ea8519c6`
+
+Status: verification and documentation sync only. This goal did not change repository settings, update description, update topics, update homepage, move files, merge a pull request, create a release, create a tag, create a publication, or change product claims.
+
+## Purpose
+
+Goal 093B updated the GitHub repository metadata outside Git after owner approval. This report records the post-change readback in tracked documentation.
+
+## Pre-Change Metadata From Goal 093A
+
+| Field | Pre-change value |
+| --- | --- |
+| Description | `An Inference Operating System that reduces unnecessary LLM calls by structuring intelligence before scaling it.` |
+| Homepage | empty |
+| Topics | `agent-framework`, `ai-infrastructure`, `cost-optimization`, `inference`, `json-schema`, `large-language-models`, `llm`, `open-source`, `orchestration`, `task-graph` |
+| Visibility | `public` |
+| Default branch | `main` |
+
+## Post-Change Metadata Readback
+
+| Field | Post-change value |
+| --- | --- |
+| Description | `AI Workload Control Layer for routing deterministic, reusable, retrieval-needed, tool-needed, and provider-needed work before model invocation.` |
+| Homepage | empty |
+| Topics | `ai-infrastructure`, `ai-workload-control`, `deterministic-routing`, `llm-infrastructure`, `open-source`, `python`, `retrieval-routing`, `task-graph`, `tool-routing`, `workload-routing` |
+| Visibility | `public` |
+| Default branch | `main` |
+
+## Verification Result
+
+- Exact description now set: `AI Workload Control Layer for routing deterministic, reusable, retrieval-needed, tool-needed, and provider-needed work before model invocation.`
+- Exact topics now set: `ai-infrastructure`, `ai-workload-control`, `deterministic-routing`, `llm-infrastructure`, `open-source`, `python`, `retrieval-routing`, `task-graph`, `tool-routing`, `workload-routing`
+- Homepage remains empty.
+- Visibility remains `public`.
+- Default branch remains `main`.
+- The README and GitHub About metadata now align around AI Workload Control Layer positioning.
+
+## Boundary Confirmation
+
+- No files were moved.
+- No release was created.
+- No tag was created.
+- No GitHub Release was created.
+- No package publication was performed.
+- No repository settings were changed in Goal 093C.
+
+## Recommended Next Goal
+
+Goal 094 - Root orientation stubs for older root strategic documents, without moving files.


### PR DESCRIPTION
## Summary

- adds Goal 093C post-change verification report for the GitHub metadata update applied in Goal 093B
- records current repository description, topics, homepage, visibility, and default branch readback
- updates `OPEN_THIS_FIRST.md` and `REVIEW_HUB.md` with short Goal 093B/093C status and next Goal 094 guidance

## Boundary

This PR does not change repository settings.
This PR does not update description, topics, or homepage.
This PR only documents readback after the approved Goal 093B metadata update.

## Validation

- `python3 -m kora examples list`
- `python3 scripts/check_markdown_links_goal082b.py`
- `git diff --check`
- high-risk private/internal scan over changed files

## Not performed

- no repository settings changes
- no file moves
- no release, tag, GitHub Release, or PyPI publication
- no merge requested in this gate
