### PR TITLE
Goal 103 - Representativeness route-only evaluator

### DIFF
--- a/OPEN_THIS_FIRST.md
+++ b/OPEN_THIS_FIRST.md
@@ -510,18 +510,16 @@ KORA makes AI workloads routable. The current KRK public alpha shows how workloa
 
 ## Recommended Next Goal
 
-Goal 103 - Implement a route-only evaluator for the Goal 102 representativeness seed without provider calls or H100 execution.
+Goal 104 - Codex Bounded Loop Protocol and Claim-Boundary Automation.
 
 Recommended scope:
 
-- load `examples/workloads/kora-representativeness-seed-v0.json`.
-- evaluate route labels or route-only expectations without provider calls.
-- do not run H100 workloads.
-- do not claim production workload proof, output-quality proof, or broad workload superiority.
-- keep any future larger H100 samples bounded, public-safe, fixture-derived, and explicitly approved.
-- exclude raw logs and private infrastructure details.
-- keep claims bounded to fixture-design and route-only evaluation evidence.
-- do not claim both-GPU active use, multi-GPU scaling, H100 superiority, GPU superiority, CPU superiority, production benchmark proof, production readiness, output-quality proof, energy reduction, customer savings, production cost reduction proof, real API-cost proof, real GPU-cost proof, provider replacement, general GPU-serving replacement, or broad workload superiority.
+- add bounded-loop protocol guidance for future Codex goal execution and review cleanup.
+- add claim-boundary automation guidance that keeps provider/H100/output-quality claims explicit and gated.
+- keep the work documentation/protocol focused unless a later goal explicitly approves code automation.
+- do not add provider calls, H100 execution, output-quality proof, production workload proof, or broad workload superiority claims.
+
+Alternative Goal 104 options remain public-safe output-quality methodology design or a second route-only fixture slice, but only after explicit approval.
 
 Optional docs-navigation movement remains a separate future track only if Albert explicitly approves movement.
 

--- a/OPEN_THIS_FIRST.md
+++ b/OPEN_THIS_FIRST.md
@@ -2,7 +2,7 @@
 
 Status: current public project breadcrumb.
 
-Last updated by: Goal 102.
+Last updated by: Goal 103.
 
 ## Current Status
 
@@ -41,21 +41,50 @@ Current state:
 - `kora doctor` is now a first-class CLI command for running the offline Doctor workload-control report against a workload JSON file or all bundled Doctor workloads.
 - the public README and docs index now position KORA as an AI Workload Control Layer, with examples-first onboarding and explicit claim boundaries.
 - the breadcrumb/review-hub pattern has been extracted into a reusable Project Operating System package and validated on KORA as a continuation surface.
-- current public continuation work is focused on Goal 102 broader workload representativeness planning and a public-safe fixture seed. Documentation movement remains optional only after later explicit Albert approval.
+- current public continuation work is focused on Goal 103 route-only evaluation of the Goal 102 public-safe representativeness seed. Documentation movement remains optional only after later explicit Albert approval.
 
 ## Current Branch
 
-- branch: `goal102-workload-representativeness-seed`
+- branch: `goal103-representativeness-route-only-evaluator`
 - public truth: `origin/main`
-- branch pushed to: `origin/goal102-workload-representativeness-seed`
-- open PR: Goal 102 PR for this branch
-- base commit: `5adb19044a697bdb6bfd57b342ba3699efc579c5`
+- branch pushed to: `origin/goal103-representativeness-route-only-evaluator`
+- open PR: [#253 Goal 103 - Representativeness route-only evaluator](https://github.com/Krako-Labs/KORA/pull/253)
+- base commit: `5e2a9cab9e5d3c8aca25fa2ec11cd6f06e060726`
 
 ## Active Goal
 
+Goal 103 - Representativeness Route-Only Evaluator.
+
+Goal 103 adds a route-only evaluator for the Goal 102 public-safe synthetic representativeness seed fixture. It reads the seed, reuses shape-only validation, and emits aggregate public-safe route counters only. It does not run H100 workloads, make provider calls, execute model inference, prove output quality, add production workload proof, or claim broad workload representativeness.
+
+Primary report:
+
+- [Goal 103 representativeness route-only evaluator](docs/reports/goal103_representativeness_route_only_evaluator.md)
+- [Goal 102 workload representativeness seed](docs/reports/goal102_workload_representativeness_seed.md)
+- [KORA representativeness seed fixture v0](examples/workloads/kora-representativeness-seed-v0.json)
+
+Evaluator command:
+
+```bash
+python3 scripts/evaluate_representativeness_seed_routes.py
+```
+
+Validation commands:
+
+```bash
+python3 scripts/validate_representativeness_seed.py
+python3 scripts/evaluate_representativeness_seed_routes.py
+python3 -m pytest tests/test_representativeness_seed.py
+python3 -m pytest tests/test_representativeness_route_only_evaluator.py
+```
+
+Current caveat: Goal 103 is route-only evidence over a synthetic seed fixture. It does not prove output quality, broad workload representativeness, production readiness, production workload handling, production cost reduction, H100/GPU/CPU superiority, both-GPU active use, multi-GPU scaling, broad workload superiority, customer savings, provider replacement, general GPU-serving replacement, or published `getkora`.
+
+## Last Completed Goal
+
 Goal 102 - Broader Workload Representativeness Plan and Fixture Expansion Seed.
 
-Goal 102 starts workload representativeness broadening by adding a public-safe synthetic seed fixture and a shape-only validator. It does not run H100 workloads, make provider calls, prove output quality, add production workload proof, or claim broad workload superiority.
+Goal 102 starts workload representativeness broadening by adding a public-safe synthetic seed fixture and a shape-only validator. PR #252 was squash-merged into `origin/main` at `5e2a9cab9e5d3c8aca25fa2ec11cd6f06e060726`.
 
 Primary report:
 
@@ -63,8 +92,6 @@ Primary report:
 - [KORA representativeness seed fixture v0](examples/workloads/kora-representativeness-seed-v0.json)
 
 Claim boundary: Goal 102 is fixture-design evidence and planning support only. It does not prove broader workload representativeness, output quality, production readiness, production workload handling, production cost reduction, H100/GPU/CPU superiority, both-GPU active use, multi-GPU scaling, broad workload superiority, customer savings, provider replacement, general GPU-serving replacement, or published `getkora`.
-
-## Last Completed Goal
 
 Goal 100 - Review Goal 099 Evidence Package and Evidence Index Decision.
 

--- a/REVIEW_HUB.md
+++ b/REVIEW_HUB.md
@@ -460,7 +460,7 @@ Paste a new Goal with this instruction:
 
 ```text
 Start by reading OPEN_THIS_FIRST.md and REVIEW_HUB.md.
-Use the active branch goal102-workload-representativeness-seed for the current verification packet, or create a new scoped branch from origin/main for a new Goal.
+Use the active branch goal103-representativeness-route-only-evaluator and PR #253 for the current Goal 103 review packet, or create a new scoped branch from origin/main for a new Goal after Goal 103 is merged.
 Keep public/private and claim boundaries from REVIEW_HUB.md.
 Update OPEN_THIS_FIRST.md and REVIEW_HUB.md before committing unless explicitly exempted.
 ```

--- a/REVIEW_HUB.md
+++ b/REVIEW_HUB.md
@@ -2,7 +2,7 @@
 
 Status: current public review and continuation hub.
 
-Last updated by: Goal 102.
+Last updated by: Goal 103.
 
 ## Project Identity
 
@@ -14,11 +14,11 @@ KRK means KORA Routing Kernel. KRK is the deterministic-first execution routing 
 
 - repository: `https://github.com/Krako-Labs/KORA`
 - public truth branch: `origin/main`
-- active verification branch: `goal102-workload-representativeness-seed`
-- worktree label: `goal102-workload-representativeness-seed`
-- branch pushed to: `origin/goal102-workload-representativeness-seed`
-- open PR: Goal 102 PR for this branch
-- base commit: `5adb19044a697bdb6bfd57b342ba3699efc579c5`
+- active verification branch: `goal103-representativeness-route-only-evaluator`
+- worktree label: `goal103-representativeness-route-only-evaluator`
+- branch pushed to: `origin/goal103-representativeness-route-only-evaluator`
+- open PR: [#253 Goal 103 - Representativeness route-only evaluator](https://github.com/Krako-Labs/KORA/pull/253)
+- base commit: `5e2a9cab9e5d3c8aca25fa2ec11cd6f06e060726`
 
 ## Current State Summary
 
@@ -57,10 +57,11 @@ KORA now has a public-safe first-value path and an evidence package that covers:
 - Goal 098 prepared controlled CPU/non-GPU and GPU/H100 evidence regeneration on the AI Champion H100 server, with local no-CUDA status recorded as `not_run`.
 - Goal 099 executed the Goal 098 server-run packet through SSH remote execution on the AI Champion H100 server, separating CPU/non-GPU and bounded GPU/H100 paths.
 - Goal 102 starts broader workload representativeness planning with a public-safe synthetic seed fixture and shape-only validator.
+- Goal 103 adds a route-only evaluator over the Goal 102 seed fixture, producing aggregate public-safe route and workload-category counters only.
 - reusable Project Operating System templates, prompts, and adoption standard.
 - validated Project Operating System continuation path for KORA.
 - no repository settings should be changed further without explicit owner approval.
-- current work is Goal 102: broaden workload category coverage for future route-only and output-quality evaluation design. Documentation movement remains optional only after later explicit Albert approval.
+- current work is Goal 103: route-only aggregate evaluation of the Goal 102 seed fixture. Documentation movement remains optional only after later explicit Albert approval.
 
 Current status is evidence-centered and local-first. It is not production-readiness evidence.
 
@@ -112,6 +113,7 @@ This is a sufficient recent history backfill, not a complete reconstruction.
 | Goal 099 | Executed the Goal 098 server-run packet through SSH remote execution on the AI Champion H100 server with aggregate CPU/non-GPU and bounded H100 summaries. | [Goal 099 AI Champion H100 server run](docs/reports/goal099_ai_champion_h100_server_run.md) |
 | Goal 100 | Reviewed the Goal 099 evidence package and recommended a narrow evidence-index refresh rather than a broad evidence package rewrite. | [Goal 100 Goal 099 evidence index review](docs/reports/goal100_goal099_evidence_index_review.md) |
 | Goal 102 | Added a public-safe synthetic representativeness seed fixture and shape-only validator for future route-only evaluation design. | [Goal 102 workload representativeness seed](docs/reports/goal102_workload_representativeness_seed.md) |
+| Goal 103 | Added a route-only evaluator that validates the Goal 102 seed fixture and emits aggregate public-safe route/category counters without provider calls or H100 execution. | [Goal 103 representativeness route-only evaluator](docs/reports/goal103_representativeness_route_only_evaluator.md) |
 
 ## Evidence Index
 
@@ -141,6 +143,9 @@ Generated summaries:
 
 Current reviewer path:
 
+- [Goal 103 representativeness route-only evaluator](docs/reports/goal103_representativeness_route_only_evaluator.md)
+- [Representativeness route-only evaluator script](scripts/evaluate_representativeness_seed_routes.py)
+- [Representativeness route-only evaluator tests](tests/test_representativeness_route_only_evaluator.py)
 - [Goal 102 workload representativeness seed](docs/reports/goal102_workload_representativeness_seed.md)
 - [KORA representativeness seed fixture v0](examples/workloads/kora-representativeness-seed-v0.json)
 - [Goal 099 AI Champion H100 server run](docs/reports/goal099_ai_champion_h100_server_run.md)
@@ -190,6 +195,7 @@ Current reviewer path:
 
 Current evidence path:
 
+- [Goal 103 representativeness route-only evaluator](docs/reports/goal103_representativeness_route_only_evaluator.md)
 - [Goal 102 workload representativeness seed](docs/reports/goal102_workload_representativeness_seed.md)
 - [KORA representativeness seed fixture v0](examples/workloads/kora-representativeness-seed-v0.json)
 - [Goal 100 Goal 099 evidence index review](docs/reports/goal100_goal099_evidence_index_review.md)
@@ -230,11 +236,14 @@ Supported:
 - KORA has an offline agent workflow optimization example where sample workflow steps are routed across deterministic, cache, tool-needed, and provider-needed paths without provider calls.
 - KORA has an offline cache reuse example where repeated sample requests are routed to cache hits without provider calls and ambiguous/open-ended requests are marked provider-needed.
 - Current evidence supports bounded statements about route selectivity, dry-run runtime integration, provider-path validation, bounded H100 execution, expanded H100 representativeness, and fixture-derived output fidelity.
+- Goal 103 supports aggregate route-only counters over the public-safe synthetic representativeness seed fixture after shape validation.
 - KORA has reusable public-safe Project Operating System templates for breadcrumbs, review hubs, ADRs, reports, evidence, claim registries, bootstrap checklists, and project prompts.
 
 Not supported:
 
 - production readiness.
+- broad workload representativeness from Goal 103 route-only counters.
+- output quality from Goal 103 route-only counters.
 - model replacement.
 - production diagnostic accuracy from the KORA Doctor example.
 - production validation from the deterministic classification example pack.
@@ -421,6 +430,7 @@ Boundary: this is positioning grounded in current examples and evidence. It does
 - H100 measurements are bounded and do not establish H100 superiority.
 - Goal 099 records that 2 H100-class devices were visible, but does not establish both-GPU active use or multi-GPU scaling.
 - Goal 102 is a fixture-design seed only; it does not prove broader workload representativeness, output quality, production workload handling, or broad workload superiority.
+- Goal 103 is route-only aggregate seed analysis only; it does not prove output quality, broad workload representativeness, production workload handling, or broad workload superiority.
 - Output fidelity is deterministic rule-based over public fixtures, not live semantic judging.
 - The deterministic classification example pack is intentionally synthetic and small; broader workload representativeness remains unproven.
 - The KORA Doctor example is synthetic and does not inspect arbitrary repositories or prove diagnostic accuracy.
@@ -440,8 +450,8 @@ Boundary: this is positioning grounded in current examples and evidence. It does
 
 ## Recommended Next Goals
 
-1. Goal 103 - Implement a route-only evaluator for the Goal 102 representativeness seed without provider calls or H100 execution.
-2. Goal 103 alternative - Design output-quality validation methodology for public-safe fixtures.
+1. Goal 104 - Design output-quality validation methodology for public-safe fixtures without semantic judging or provider calls.
+2. Goal 104 alternative - Add a second route-only fixture slice after explicit approval for category expansion.
 3. Optional documentation movement proposal for one small bucket only after later explicit Albert approval.
 
 ## How To Resume Review

--- a/docs/reports/goal103_representativeness_route_only_evaluator.md
+++ b/docs/reports/goal103_representativeness_route_only_evaluator.md
@@ -1,0 +1,122 @@
+# Goal 103 Representativeness Route-Only Evaluator
+
+Status: route-only evaluator added for the Goal 102 representativeness seed; no provider calls, H100 execution, model inference, or output-quality proof added.
+
+## Objective
+
+Goal 103 adds a narrow evaluator for the public-safe synthetic representativeness seed fixture introduced in Goal 102.
+
+The evaluator reads the fixture, reuses the shape-only validator, and reports aggregate route/counter evidence only. It does not inspect or publish raw benchmark outputs beyond the already public fixture content.
+
+## Input Fixture
+
+- [KORA representativeness seed fixture v0](../../examples/workloads/kora-representativeness-seed-v0.json)
+- schema: `kora_representativeness_seed_v0`
+- claim scope: `fixture_only`
+- public safe: `true`
+
+## Evaluator Command
+
+```bash
+python3 scripts/evaluate_representativeness_seed_routes.py
+```
+
+The evaluator emits deterministic JSON to stdout. It does not create raw benchmark artifacts.
+
+## Aggregate Counters Produced
+
+Total seed items: `40`
+
+Route counts:
+
+| Route | Count |
+| --- | ---: |
+| `cache` | 6 |
+| `cpu` | 5 |
+| `deterministic` | 7 |
+| `fallback` | 5 |
+| `gpu` | 3 |
+| `provider_needed` | 8 |
+| `retrieval_needed` | 1 |
+| `tool_needed` | 5 |
+
+Route group counts:
+
+| Group | Count |
+| --- | ---: |
+| `cache_reuse_candidates` | 6 |
+| `deterministic_local_route_candidates` | 18 |
+| `fallback_control_candidates` | 5 |
+| `provider_model_candidates` | 11 |
+
+Unsupported, unknown, or missing route metadata count: `0`
+
+Workload category counts:
+
+| Category | Count |
+| --- | ---: |
+| `agent_workflow_steps` | 3 |
+| `cache_reuse_repeated_work` | 2 |
+| `document_intake` | 3 |
+| `gpu_candidate_batch` | 3 |
+| `incident_alert_routing` | 3 |
+| `issue_triage` | 3 |
+| `mixed_operational_workflow` | 3 |
+| `output_quality_methodology_seed` | 2 |
+| `policy_safety_fallback` | 2 |
+| `provider_needed_ambiguous_tasks` | 2 |
+| `rag_query_routing` | 3 |
+| `report_generation_control` | 3 |
+| `support_ticket_classification` | 3 |
+| `tool_needed_local_actions` | 2 |
+| `validation_schema_check` | 3 |
+
+## Validation Performed
+
+The evaluator calls [the Goal 102 shape-only validator](../../scripts/validate_representativeness_seed.py) before computing route counters.
+
+Validation covers:
+
+- supported schema version.
+- fixture-level `public_safe: true`.
+- fixture-level `claim_scope: fixture_only`.
+- item count range.
+- required item fields.
+- duplicate ids.
+- allowed route-label vocabulary.
+- item-level `public_safe: true`.
+- item-level `claim_scope: fixture_only`.
+
+## Relationship To Goal 102
+
+Goal 102 added the seed fixture and shape-only validation. Goal 103 is the next narrow step: it turns that same fixture into aggregate route/counter evidence for planning and reviewer inspection.
+
+This remains shape-validated seed analysis. It is not a benchmark, not an output-quality evaluator, and not production workload evidence.
+
+## Explicit Non-Claims
+
+Goal 103 does not:
+
+- call OpenAI, Anthropic, Gemini, local model servers, or any external inference provider.
+- execute H100, GPU, CUDA, server, or remote workloads.
+- run model inference.
+- evaluate output quality.
+- prove broader workload representativeness.
+- prove production readiness.
+- prove production workload handling.
+- prove production benchmark results.
+- prove production cost reduction, real API-cost reduction, or real GPU-cost reduction.
+- prove H100, GPU, CPU, or multi-GPU superiority.
+- prove customer savings.
+- replace providers, model serving, or GPU serving.
+- publish `getkora`.
+
+## Recommended Next Goal
+
+Recommended next goal:
+
+- Goal 104 - Design a public-safe output-quality methodology for the representativeness seed without semantic judging or live provider calls.
+
+Alternative next goal:
+
+- Goal 104 - Add a second route-only fixture slice after explicit approval for the category expansion boundary.

--- a/scripts/evaluate_representativeness_seed_routes.py
+++ b/scripts/evaluate_representativeness_seed_routes.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections import Counter
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from scripts.validate_representativeness_seed import ALLOWED_ROUTES, DEFAULT_FIXTURE, validate_seed
+
+
+LOCAL_ROUTE_CANDIDATES = ("cpu", "deterministic", "retrieval_needed", "tool_needed")
+PROVIDER_MODEL_CANDIDATES = ("gpu", "provider_needed")
+CACHE_REUSE_CANDIDATES = ("cache",)
+FALLBACK_CONTROL_CANDIDATES = ("fallback",)
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise ValueError("fixture root must be an object")
+    return data
+
+
+def evaluate_routes(path: Path = DEFAULT_FIXTURE) -> dict[str, Any]:
+    validation_summary = validate_seed(path)
+    data = _load_json(path)
+    items = data["items"]
+
+    route_counts = Counter(item.get("expected_route") for item in items)
+    category_counts = Counter(item.get("category") for item in items)
+    unsupported_or_missing = sum(
+        1 for item in items if item.get("expected_route") not in ALLOWED_ROUTES
+    )
+
+    def count_routes(routes: tuple[str, ...]) -> int:
+        return sum(route_counts[route] for route in routes)
+
+    return {
+        "ok": True,
+        "fixture": str(path),
+        "validation": {
+            "shape_validated": validation_summary["ok"],
+            "claim_scope": validation_summary["claim_scope"],
+            "public_safe": validation_summary["public_safe"],
+        },
+        "total_seed_items": len(items),
+        "route_counts": {
+            route: route_counts[route]
+            for route in sorted(ALLOWED_ROUTES)
+            if route_counts[route]
+        },
+        "route_group_counts": {
+            "cache_reuse_candidates": count_routes(CACHE_REUSE_CANDIDATES),
+            "deterministic_local_route_candidates": count_routes(LOCAL_ROUTE_CANDIDATES),
+            "fallback_control_candidates": count_routes(FALLBACK_CONTROL_CANDIDATES),
+            "provider_model_candidates": count_routes(PROVIDER_MODEL_CANDIDATES),
+        },
+        "workload_category_counts": {
+            category: category_counts[category] for category in sorted(category_counts)
+        },
+        "unsupported_unknown_missing_route_metadata_count": unsupported_or_missing,
+        "non_claims": [
+            "does_not_call_providers",
+            "does_not_execute_h100_or_gpu_workloads",
+            "does_not_run_model_inference",
+            "does_not_prove_output_quality",
+            "does_not_prove_broader_workload_representativeness",
+        ],
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Evaluate aggregate route counters for the KORA representativeness seed fixture."
+    )
+    parser.add_argument(
+        "--fixture",
+        type=Path,
+        default=DEFAULT_FIXTURE,
+        help="Path to the representativeness seed fixture.",
+    )
+    args = parser.parse_args(argv)
+
+    summary = evaluate_routes(args.fixture)
+    print(json.dumps(summary, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_representativeness_route_only_evaluator.py
+++ b/tests/test_representativeness_route_only_evaluator.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+
+from scripts.evaluate_representativeness_seed_routes import DEFAULT_FIXTURE, evaluate_routes
+
+
+def test_route_only_evaluator_counts_seed_routes() -> None:
+    summary = evaluate_routes(DEFAULT_FIXTURE)
+
+    assert summary["ok"] is True
+    assert summary["total_seed_items"] == 40
+    assert summary["route_counts"] == {
+        "cache": 6,
+        "cpu": 5,
+        "deterministic": 7,
+        "fallback": 5,
+        "gpu": 3,
+        "provider_needed": 8,
+        "retrieval_needed": 1,
+        "tool_needed": 5,
+    }
+    assert summary["route_group_counts"] == {
+        "cache_reuse_candidates": 6,
+        "deterministic_local_route_candidates": 18,
+        "fallback_control_candidates": 5,
+        "provider_model_candidates": 11,
+    }
+    assert summary["unsupported_unknown_missing_route_metadata_count"] == 0
+
+
+def test_route_only_evaluator_counts_workload_categories() -> None:
+    summary = evaluate_routes(DEFAULT_FIXTURE)
+
+    assert summary["workload_category_counts"] == {
+        "agent_workflow_steps": 3,
+        "cache_reuse_repeated_work": 2,
+        "document_intake": 3,
+        "gpu_candidate_batch": 3,
+        "incident_alert_routing": 3,
+        "issue_triage": 3,
+        "mixed_operational_workflow": 3,
+        "output_quality_methodology_seed": 2,
+        "policy_safety_fallback": 2,
+        "provider_needed_ambiguous_tasks": 2,
+        "rag_query_routing": 3,
+        "report_generation_control": 3,
+        "support_ticket_classification": 3,
+        "tool_needed_local_actions": 2,
+        "validation_schema_check": 3,
+    }
+
+
+def test_route_only_evaluator_cli_outputs_deterministic_json() -> None:
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "scripts/evaluate_representativeness_seed_routes.py",
+            "--fixture",
+            str(DEFAULT_FIXTURE),
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert completed.returncode == 0
+    summary = json.loads(completed.stdout)
+    assert summary["total_seed_items"] == 40
+    assert list(summary["route_counts"]) == [
+        "cache",
+        "cpu",
+        "deterministic",
+        "fallback",
+        "gpu",
+        "provider_needed",
+        "retrieval_needed",
+        "tool_needed",
+    ]
+    assert summary["validation"] == {
+        "claim_scope": "fixture_only",
+        "public_safe": True,
+        "shape_validated": True,
+    }
+    assert "does_not_call_providers" in summary["non_claims"]


### PR DESCRIPTION
# Goal 103 - Representativeness route-only evaluator

## Summary

- Adds `scripts/evaluate_representativeness_seed_routes.py`, a route-only evaluator for `examples/workloads/kora-representativeness-seed-v0.json`.
- Reuses the Goal 102 shape-only validator before computing counters.
- Adds focused pytest coverage plus a public Goal 103 report and breadcrumb updates.

## Files changed

- `scripts/evaluate_representativeness_seed_routes.py`
- `tests/test_representativeness_route_only_evaluator.py`
- `docs/reports/goal103_representativeness_route_only_evaluator.md`
- `OPEN_THIS_FIRST.md`
- `REVIEW_HUB.md`

## Validation commands and results

- `python3 scripts/validate_representativeness_seed.py` - passed
- `python3 scripts/evaluate_representativeness_seed_routes.py` - passed
- `python3 -m pytest tests/test_representativeness_seed.py` - 3 passed
- `python3 -m pytest tests/test_representativeness_route_only_evaluator.py` - 3 passed
- `python3 scripts/check_markdown_links_goal082b.py` - passed
- `git diff --check` - passed
- `python3 -m pytest` - 406 passed

## Boundary and non-claims

- No provider calls were performed.
- No H100, GPU, CUDA, server, or remote execution was performed.
- No model inference was performed.
- No output-quality proof was added.
- No broader workload representativeness proof was added.
- No production readiness, production workload, production benchmark, production cost reduction, real API-cost, real GPU-cost, H100/GPU/CPU superiority, both-GPU active-use, multi-GPU scaling, customer savings, provider replacement, GPU-serving replacement, or published `getkora` claim was added.

## PR state

- This PR is open only and has not been merged.
