### PR TITLE
Goal 105 - Public-safe output-quality methodology

### DIFF
--- a/OPEN_THIS_FIRST.md
+++ b/OPEN_THIS_FIRST.md
@@ -2,7 +2,7 @@
 
 Status: current public project breadcrumb.
 
-Last updated by: Goal 104.
+Last updated by: Goal 105.
 
 ## Current Status
 
@@ -41,24 +41,26 @@ Current state:
 - `kora doctor` is now a first-class CLI command for running the offline Doctor workload-control report against a workload JSON file or all bundled Doctor workloads.
 - the public README and docs index now position KORA as an AI Workload Control Layer, with examples-first onboarding and explicit claim boundaries.
 - the breadcrumb/review-hub pattern has been extracted into a reusable Project Operating System package and validated on KORA as a continuation surface.
-- current public continuation work is focused on Goal 104 Codex bounded-loop protocol and claim-boundary automation guidance. Documentation movement remains optional only after later explicit Albert approval.
+- current public continuation work is focused on Goal 105 public-safe output-quality methodology for fixture-derived work. Documentation movement remains optional only after later explicit Albert approval.
 
 ## Current Branch
 
-- branch: `goal104-codex-bounded-loop-protocol`
+- branch: `goal105-public-safe-output-quality-methodology`
 - public truth: `origin/main`
-- branch pushed to: `origin/goal104-codex-bounded-loop-protocol`
-- open PR: [#254 Goal 104 - Codex bounded loop protocol](https://github.com/Krako-Labs/KORA/pull/254)
-- base commit: `9d4fff45a448a16c23e2907db68ce68f91e77865`
+- branch pushed to: `origin/goal105-public-safe-output-quality-methodology`
+- open PR: pending branch push
+- base commit: `2dfcabb2e1949fae12fb41e5d21ae093f3e0802d`
 
 ## Active Goal
 
-Goal 104 - Codex Bounded Loop Protocol and Claim-Boundary Automation.
+Goal 105 - Public-Safe Output-Quality Methodology.
 
-Goal 104 adds KORA-specific runbooks for semi-autonomous Codex execution with human approval gates, claim-boundary review, PR-open then stop behavior, fix-loop cleanup, merge-gate separation, and local source-refresh after merge. It is documentation/protocol only and adds no runtime feature code.
+Goal 105 adds a public-safe methodology for future fixture-derived output-quality validation without executing evaluation or turning Goal 103 route-only counters into output-quality proof. It is methodology/design documentation only and adds no runtime feature code or executable automation.
 
 Primary report:
 
+- [Goal 105 public-safe output-quality methodology](docs/reports/goal105_public_safe_output_quality_methodology.md)
+- [Public-safe output-quality methodology](docs/methodology/public_safe_output_quality_methodology.md)
 - [Goal 104 Codex bounded loop protocol](docs/reports/goal104_codex_bounded_loop_protocol.md)
 - [Codex bounded loop protocol](docs/runbooks/codex_bounded_loop_protocol.md)
 - [KORA claim-boundary checklist](docs/runbooks/kora_claim_boundary_checklist.md)
@@ -76,9 +78,23 @@ git diff --check
 python3 -m pytest
 ```
 
-Current caveat: Goal 104 is a bounded-loop operating protocol and claim-boundary checklist. It does not authorize merge, release, publication, repository settings changes, provider calls, H100/GPU/server execution, file movement, claim expansion, or local-only source refresh without separate explicit approval.
+Current caveat: Goal 105 is future validation design only. It does not execute output-quality evaluation, make provider calls, run model inference, perform H100/GPU/CUDA/server/remote execution, add output-quality proof, add broader workload representativeness proof, add production proof, or authorize merge, release, publication, repository settings changes, file movement, claim expansion, or local-only source refresh without separate explicit approval.
 
 ## Last Completed Goal
+
+Goal 104 - Codex Bounded Loop Protocol and Claim-Boundary Automation.
+
+Goal 104 added KORA-specific runbooks for semi-autonomous Codex execution with human approval gates, claim-boundary review, PR-open then stop behavior, fix-loop cleanup, merge-gate separation, and local source-refresh after merge. PR #254 was squash-merged into `origin/main` at `2dfcabb2e1949fae12fb41e5d21ae093f3e0802d`.
+
+Primary report:
+
+- [Goal 104 Codex bounded loop protocol](docs/reports/goal104_codex_bounded_loop_protocol.md)
+- [Codex bounded loop protocol](docs/runbooks/codex_bounded_loop_protocol.md)
+- [KORA claim-boundary checklist](docs/runbooks/kora_claim_boundary_checklist.md)
+- [KORA PR completion format](docs/runbooks/kora_pr_completion_format.md)
+- [KORA next goal queue](docs/context/NEXT_GOAL_QUEUE.md)
+
+Claim boundary: Goal 104 is protocol documentation only. It does not authorize merge, release, publication, repository settings changes, provider calls, H100/GPU/server execution, file movement, claim expansion, or local-only source refresh without separate explicit approval.
 
 Goal 103 - Representativeness Route-Only Evaluator.
 
@@ -464,6 +480,9 @@ Primary report:
 ## Primary Reports
 
 - [Review hub](REVIEW_HUB.md)
+- [Goal 105 public-safe output-quality methodology](docs/reports/goal105_public_safe_output_quality_methodology.md)
+- [Public-safe output-quality methodology](docs/methodology/public_safe_output_quality_methodology.md)
+- [Goal 104 Codex bounded loop protocol](docs/reports/goal104_codex_bounded_loop_protocol.md)
 - [Goal 091 README compression](docs/reports/goal091_readme_compression.md)
 - [Goal 088 cache reuse example](docs/reports/goal088_cache_reuse_example.md)
 - [Cache reuse example README](examples/cache_reuse/README.md)
@@ -515,16 +534,18 @@ KORA makes AI workloads routable. The current KRK public alpha shows how workloa
 
 ## Recommended Next Goal
 
-Goal 105 - Apply the Codex bounded-loop protocol to the next approved KORA task.
+Goal 106 - Tiny public-safe fixture-based quality-check scaffold, only after explicit approval.
 
 Recommended scope:
 
 - use the Goal 104 runbooks as the execution checklist.
 - verify the goal envelope, base SHA, KORA identity, and clean worktree.
 - run the claim-boundary checklist before PR-open.
+- keep any scaffold public-safe and fixture-derived.
+- do not add semantic, human, provider, H100, GPU, server, remote, or production-like validation without separate explicit approval.
 - stop at PR-open unless a separate merge-gate prompt is provided.
 
-Alternative future goals remain public-safe output-quality methodology design or a second route-only fixture slice, but only after explicit approval.
+Alternative future goals remain a second route-only fixture slice or documentation movement for one small bucket, but only after explicit approval.
 
 Optional docs-navigation movement remains a separate future track only if Albert explicitly approves movement.
 

--- a/OPEN_THIS_FIRST.md
+++ b/OPEN_THIS_FIRST.md
@@ -48,7 +48,7 @@ Current state:
 - branch: `goal105-public-safe-output-quality-methodology`
 - public truth: `origin/main`
 - branch pushed to: `origin/goal105-public-safe-output-quality-methodology`
-- open PR: pending branch push
+- open PR: [#255 Goal 105 - Public-safe output-quality methodology](https://github.com/Krako-Labs/KORA/pull/255)
 - base commit: `2dfcabb2e1949fae12fb41e5d21ae093f3e0802d`
 
 ## Active Goal

--- a/REVIEW_HUB.md
+++ b/REVIEW_HUB.md
@@ -2,7 +2,7 @@
 
 Status: current public review and continuation hub.
 
-Last updated by: Goal 104.
+Last updated by: Goal 105.
 
 ## Project Identity
 
@@ -14,11 +14,11 @@ KRK means KORA Routing Kernel. KRK is the deterministic-first execution routing 
 
 - repository: `https://github.com/Krako-Labs/KORA`
 - public truth branch: `origin/main`
-- active verification branch: `goal104-codex-bounded-loop-protocol`
-- worktree label: `goal104-codex-bounded-loop-protocol`
-- branch pushed to: `origin/goal104-codex-bounded-loop-protocol`
-- open PR: [#254 Goal 104 - Codex bounded loop protocol](https://github.com/Krako-Labs/KORA/pull/254)
-- base commit: `9d4fff45a448a16c23e2907db68ce68f91e77865`
+- active verification branch: `goal105-public-safe-output-quality-methodology`
+- worktree label: `goal105-public-safe-output-quality-methodology`
+- branch pushed to: `origin/goal105-public-safe-output-quality-methodology`
+- open PR: pending branch push
+- base commit: `2dfcabb2e1949fae12fb41e5d21ae093f3e0802d`
 
 ## Current State Summary
 
@@ -59,10 +59,11 @@ KORA now has a public-safe first-value path and an evidence package that covers:
 - Goal 102 starts broader workload representativeness planning with a public-safe synthetic seed fixture and shape-only validator.
 - Goal 103 adds a route-only evaluator over the Goal 102 seed fixture, producing aggregate public-safe route and workload-category counters only.
 - Goal 104 adds a KORA-specific Codex bounded-loop protocol, claim-boundary checklist, PR completion format, and next-goal queue for semi-autonomous execution with human approval gates.
+- Goal 105 adds a public-safe output-quality methodology for future fixture-derived checks without executing evaluation or turning Goal 103 route-only counters into output-quality proof.
 - reusable Project Operating System templates, prompts, and adoption standard.
 - validated Project Operating System continuation path for KORA.
 - no repository settings should be changed further without explicit owner approval.
-- current work is Goal 104: bounded-loop operating protocol and claim-boundary gate documentation. Documentation movement remains optional only after later explicit Albert approval.
+- current work is Goal 105: public-safe output-quality methodology design. Documentation movement remains optional only after later explicit Albert approval.
 
 Current status is evidence-centered and local-first. It is not production-readiness evidence.
 
@@ -116,6 +117,7 @@ This is a sufficient recent history backfill, not a complete reconstruction.
 | Goal 102 | Added a public-safe synthetic representativeness seed fixture and shape-only validator for future route-only evaluation design. | [Goal 102 workload representativeness seed](docs/reports/goal102_workload_representativeness_seed.md) |
 | Goal 103 | Added a route-only evaluator that validates the Goal 102 seed fixture and emits aggregate public-safe route/category counters without provider calls or H100 execution. | [Goal 103 representativeness route-only evaluator](docs/reports/goal103_representativeness_route_only_evaluator.md) |
 | Goal 104 | Added KORA-specific bounded-loop runbooks for Codex execution, claim-boundary review, PR completion, and next-goal queueing with human approval gates. | [Goal 104 Codex bounded loop protocol](docs/reports/goal104_codex_bounded_loop_protocol.md) |
+| Goal 105 | Added public-safe output-quality methodology for future fixture-derived checks without executing evaluation. | [Goal 105 public-safe output-quality methodology](docs/reports/goal105_public_safe_output_quality_methodology.md) |
 
 ## Evidence Index
 
@@ -145,6 +147,8 @@ Generated summaries:
 
 Current reviewer path:
 
+- [Goal 105 public-safe output-quality methodology](docs/reports/goal105_public_safe_output_quality_methodology.md)
+- [Public-safe output-quality methodology](docs/methodology/public_safe_output_quality_methodology.md)
 - [Goal 104 Codex bounded loop protocol](docs/reports/goal104_codex_bounded_loop_protocol.md)
 - [Codex bounded loop protocol](docs/runbooks/codex_bounded_loop_protocol.md)
 - [KORA claim-boundary checklist](docs/runbooks/kora_claim_boundary_checklist.md)
@@ -202,6 +206,8 @@ Current reviewer path:
 
 Current evidence path:
 
+- [Goal 105 public-safe output-quality methodology](docs/reports/goal105_public_safe_output_quality_methodology.md)
+- [Public-safe output-quality methodology](docs/methodology/public_safe_output_quality_methodology.md)
 - [Goal 104 Codex bounded loop protocol](docs/reports/goal104_codex_bounded_loop_protocol.md)
 - [Goal 103 representativeness route-only evaluator](docs/reports/goal103_representativeness_route_only_evaluator.md)
 - [Goal 102 workload representativeness seed](docs/reports/goal102_workload_representativeness_seed.md)
@@ -246,6 +252,7 @@ Supported:
 - Current evidence supports bounded statements about route selectivity, dry-run runtime integration, provider-path validation, bounded H100 execution, expanded H100 representativeness, and fixture-derived output fidelity.
 - Goal 103 supports aggregate route-only counters over the public-safe synthetic representativeness seed fixture after shape validation.
 - Goal 104 supports a bounded-loop operating protocol for PR-open execution with human approval gates and claim-boundary review.
+- Goal 105 supports methodology and future validation design for public-safe fixture-derived checks; it does not execute evaluation and does not prove output quality.
 - KORA has reusable public-safe Project Operating System templates for breadcrumbs, review hubs, ADRs, reports, evidence, claim registries, bootstrap checklists, and project prompts.
 
 Not supported:
@@ -253,6 +260,7 @@ Not supported:
 - production readiness.
 - broad workload representativeness from Goal 103 route-only counters.
 - output quality from Goal 103 route-only counters.
+- output quality from Goal 105 methodology documentation.
 - self-approval by Codex or any execution agent.
 - merge, release, publication, repository settings changes, provider calls, H100/GPU/server execution, file movement, or public claim expansion without explicit approval.
 - model replacement.
@@ -443,6 +451,7 @@ Boundary: this is positioning grounded in current examples and evidence. It does
 - Goal 102 is a fixture-design seed only; it does not prove broader workload representativeness, output quality, production workload handling, or broad workload superiority.
 - Goal 103 is route-only aggregate seed analysis only; it does not prove output quality, broad workload representativeness, production workload handling, or broad workload superiority.
 - Goal 104 is protocol documentation only; it does not authorize merge, release, publication, repository settings changes, provider calls, H100/GPU/server execution, file movement, claim expansion, or local-only source refresh without separate explicit approval.
+- Goal 105 is methodology and future validation design only; it does not execute evaluation, prove output quality, prove broader workload representativeness, or prove production workload handling.
 - Output fidelity is deterministic rule-based over public fixtures, not live semantic judging.
 - The deterministic classification example pack is intentionally synthetic and small; broader workload representativeness remains unproven.
 - The KORA Doctor example is synthetic and does not inspect arbitrary repositories or prove diagnostic accuracy.
@@ -462,9 +471,9 @@ Boundary: this is positioning grounded in current examples and evidence. It does
 
 ## Recommended Next Goals
 
-1. Goal 105 - Apply the Codex bounded-loop protocol to the next approved KORA task.
-2. Public-safe output-quality methodology design, only after explicit approval.
-3. A second route-only fixture slice, only after explicit approval.
+1. Goal 106 - Tiny public-safe fixture-based quality-check scaffold, only after explicit approval.
+2. A second route-only fixture slice, only after explicit approval.
+3. Semantic, human, provider, H100, GPU, server, remote, or production-like validation only after separate explicit approval.
 4. Optional documentation movement proposal for one small bucket only after later explicit Albert approval.
 
 ## How To Resume Review
@@ -473,7 +482,7 @@ Paste a new Goal with this instruction:
 
 ```text
 Start by reading OPEN_THIS_FIRST.md and REVIEW_HUB.md.
-Use the active branch goal104-codex-bounded-loop-protocol for the current Goal 104 review packet, or create a new scoped branch from origin/main for a new Goal after Goal 104 is merged.
+Use the active branch goal105-public-safe-output-quality-methodology for the current Goal 105 review packet, or create a new scoped branch from origin/main for a new Goal after Goal 105 is merged.
 Keep public/private and claim boundaries from REVIEW_HUB.md.
 Use docs/runbooks/codex_bounded_loop_protocol.md and docs/runbooks/kora_claim_boundary_checklist.md for execution and review gates.
 Update OPEN_THIS_FIRST.md and REVIEW_HUB.md before committing unless explicitly exempted.

--- a/REVIEW_HUB.md
+++ b/REVIEW_HUB.md
@@ -17,7 +17,7 @@ KRK means KORA Routing Kernel. KRK is the deterministic-first execution routing 
 - active verification branch: `goal105-public-safe-output-quality-methodology`
 - worktree label: `goal105-public-safe-output-quality-methodology`
 - branch pushed to: `origin/goal105-public-safe-output-quality-methodology`
-- open PR: pending branch push
+- open PR: [#255 Goal 105 - Public-safe output-quality methodology](https://github.com/Krako-Labs/KORA/pull/255)
 - base commit: `2dfcabb2e1949fae12fb41e5d21ae093f3e0802d`
 
 ## Current State Summary

--- a/docs/README.md
+++ b/docs/README.md
@@ -34,6 +34,7 @@ This documentation index is for readers who want more detail than the root [READ
 - [Evidence docs](evidence/)
 - [Benchmarks](benchmarks/)
 - [Workloads](workloads/)
+- [Public-safe output-quality methodology](methodology/public_safe_output_quality_methodology.md) - future validation design for fixture-derived checks; does not execute evaluation or prove output quality.
 - [Goal 096 documentation navigation and archive-bucket proposal](reports/goal096_documentation_navigation_archive_bucket_proposal.md) - proposal-only navigation buckets; no files moved.
 - [Group 097 H100 evidence inventory and gap audit](reports/group097_h100_evidence_inventory_gap_audit.md) - bounded H100 evidence inventory; no new H100 benchmark claim.
 - [Goal 098 controlled CPU/GPU evidence regeneration](reports/goal098_controlled_cpu_gpu_evidence_regeneration.md) - server-run packet with local no-CUDA `not_run` status; no fresh H100 execution claim.
@@ -42,6 +43,7 @@ This documentation index is for readers who want more detail than the root [READ
 - [Goal 102 workload representativeness seed](reports/goal102_workload_representativeness_seed.md) - public-safe fixture-design seed for broader workload coverage planning; not production workload proof.
 - [Goal 103 representativeness route-only evaluator](reports/goal103_representativeness_route_only_evaluator.md) - aggregate route-only counters over the Goal 102 seed; not output-quality or broader representativeness proof.
 - [Goal 104 Codex bounded loop protocol](reports/goal104_codex_bounded_loop_protocol.md) - operating protocol for PR-open bounded-loop execution with human approval gates.
+- [Goal 105 public-safe output-quality methodology](reports/goal105_public_safe_output_quality_methodology.md) - methodology for future public-safe fixture-derived checks.
 
 KORA uses narrow evidence language. Offline examples and reports may describe sample workloads and simulated avoided provider/model invocations, but they do not prove production cost reduction or production readiness.
 

--- a/docs/context/NEXT_GOAL_QUEUE.md
+++ b/docs/context/NEXT_GOAL_QUEUE.md
@@ -8,18 +8,21 @@ This queue records likely next KORA work without starting it. It is not an appro
 
 ## Current Recommended Next Goal
 
-1. Goal 105 - Apply the Codex bounded-loop protocol to the next approved KORA task.
+1. Goal 106 - Tiny public-safe fixture-based quality-check scaffold.
 
 Suggested scope:
 
 - use the Goal 104 runbooks as the execution checklist.
 - verify the goal envelope, base SHA, KORA identity, and clean worktree.
+- start from the Goal 105 public-safe output-quality methodology.
+- implement only a tiny fixture-based scaffold after explicit approval.
+- keep checks public-safe and fixture-derived.
+- do not add semantic, human, provider, H100, GPU, server, remote, or production-like validation without separate explicit approval.
 - run the claim-boundary checklist before PR-open.
 - stop at PR-open unless a separate merge-gate prompt is provided.
 
 ## Approved Alternatives Only After Explicit Prompt
 
-- Public-safe output-quality methodology design for fixture-derived work.
 - A second route-only fixture slice.
 - Documentation movement for one small bucket.
 - Larger bounded H100 or provider validation work.
@@ -41,3 +44,5 @@ Do not start without explicit approval:
 ## Current Claim Reminder
 
 Goal 103 route-only counters do not prove output quality, broader workload representativeness, production workload handling, production readiness, cost reduction, H100/GPU/CPU superiority, customer savings, provider replacement, GPU-serving replacement, or published `getkora`.
+
+Goal 105 methodology documentation does not execute evaluation, prove output quality, prove broader workload representativeness, prove production workload handling, prove production readiness, or prove cost reduction.

--- a/docs/methodology/public_safe_output_quality_methodology.md
+++ b/docs/methodology/public_safe_output_quality_methodology.md
@@ -1,0 +1,125 @@
+# Public-Safe Output-Quality Methodology
+
+Status: methodology and future validation design only; no evaluation executed.
+
+## Purpose
+
+This document defines a public-safe methodology for how a later approved KORA goal could evaluate output quality for fixture-derived work.
+
+Goal 105 does not execute evaluation, does not add runtime feature code, and does not add executable automation. It documents how future public-safe fixture-derived checks can separate route-only evidence from output-quality validation without expanding the claim boundary of Goal 103.
+
+## Scope
+
+This methodology applies to public fixture-derived work, especially synthetic fixtures that are already marked:
+
+- `public_safe: true`
+- `claim_scope: fixture_only`
+
+The immediate reference fixture is:
+
+- [KORA representativeness seed fixture v0](../../examples/workloads/kora-representativeness-seed-v0.json)
+
+The immediate route-only reference is:
+
+- [Goal 103 representativeness route-only evaluator](../reports/goal103_representativeness_route_only_evaluator.md)
+
+## Route-Only Evidence
+
+Route-only evidence describes how KORA classifies or groups work before any output-quality validation.
+
+Allowed route-only evidence includes:
+
+- route labels.
+- route groups.
+- shape validation.
+- aggregate counters.
+
+Examples from Goal 103 include:
+
+- expected route labels such as `deterministic`, `cache`, `cpu`, `gpu`, `provider_needed`, `retrieval_needed`, `tool_needed`, and `fallback`.
+- route groups such as `deterministic_local_route_candidates`, `provider_model_candidates`, `cache_reuse_candidates`, and `fallback_control_candidates`.
+- shape validation that confirms required fixture fields, duplicate-id checks, allowed route-label vocabulary, `public_safe: true`, and `claim_scope: fixture_only`.
+- aggregate counters over the public-safe seed fixture.
+
+Route-only evidence answers routing and fixture-coverage questions. It does not prove output quality.
+
+## Output-Quality Validation
+
+Output-quality validation is a separate later step. A future approved goal could add public-safe fixture-derived checks only after the fixture includes expected outputs or acceptance criteria that are safe to publish.
+
+Potential check types:
+
+- deterministic expected-output checks for fixed classification, routing, normalization, or validation tasks.
+- schema conformance checks for structured outputs.
+- exact match where the fixture specifies a single canonical expected value.
+- structured-equivalent match where field order, harmless formatting, or equivalent normalized values should not cause failure.
+- fixture-level acceptance criteria that define what is checked, what is skipped, and what remains out of scope.
+- optional later human review gate, only after explicit approval.
+- optional later semantic review gate, only after explicit approval.
+
+A public-safe fixture-derived check should report only bounded fixture-level results. It should avoid raw private inputs, raw provider responses, hidden infrastructure details, or production workload data.
+
+## Fixture Requirements For A Later Goal
+
+A later output-quality scaffold should require each checked item to declare enough public-safe information to make the expected result reviewable:
+
+- stable fixture id.
+- public-safe input.
+- expected route label, if route behavior is also being checked.
+- expected output or expected structured fields.
+- check type, such as exact, schema, or structured-equivalent.
+- acceptance criteria.
+- public-safe rationale.
+- explicit `claim_scope: fixture_only`.
+
+Items without public-safe expected outputs should remain route-only or should be skipped by any future output-quality scaffold.
+
+## Reporting Rules For A Later Goal
+
+A future output-quality report should separate at least four result classes:
+
+- route-only items, where only route labels, route groups, shape validation, and aggregate counters are reported.
+- deterministic checked items, where expected-output or schema conformance checks were possible.
+- skipped items, where public-safe expected outputs or acceptance criteria were not present.
+- gated items, where human, semantic, provider, H100, GPU, server, or remote validation would require separate approval.
+
+The report should include denominators for each class, so readers can see the difference between checked fixture items and route-only fixture items.
+
+## What Is Not Allowed In Goal 105
+
+Goal 105 does not allow:
+
+- provider calls.
+- H100/GPU/CUDA/server/remote execution.
+- model inference.
+- live semantic judging.
+- human grading results.
+- output-quality proof.
+- broader workload representativeness proof.
+- production workload proof.
+- production readiness proof.
+- cost-reduction proof.
+
+Goal 105 also does not allow file moves, renames, archival, deletion, release, tag, GitHub Release, PyPI publication, repository settings change, issue creation, project-board creation, raw artifact upload, or local-only ChatGPT context changes.
+
+## Future-Goal Path
+
+Goal 106 may implement a tiny fixture-based quality-check scaffold only after explicit approval.
+
+A Goal 106 scaffold should remain narrow:
+
+- public-safe fixture-derived checks only.
+- no provider calls.
+- no model inference.
+- no H100/GPU/CUDA/server/remote execution.
+- no semantic or human review results unless separately approved.
+- no production workload proof.
+- no output-quality proof; any later scaffold may report only exact bounded fixture-check results implemented and validated in that future goal.
+
+Any semantic, human, provider, H100, GPU, server, remote, or production-like validation remains separately gated.
+
+## Claim Boundary
+
+This methodology supports future validation design only.
+
+It does not prove output quality, broader workload representativeness, production workload handling, production readiness, production cost reduction, H100/GPU/CPU superiority, customer savings, provider replacement, GPU-serving replacement, or published `getkora`.

--- a/docs/reports/goal105_public_safe_output_quality_methodology.md
+++ b/docs/reports/goal105_public_safe_output_quality_methodology.md
@@ -1,0 +1,91 @@
+# Goal 105 Public-Safe Output-Quality Methodology
+
+Status: methodology document added; documentation/design only.
+
+## Objective
+
+Goal 105 designs a public-safe output-quality methodology for fixture-derived KORA work.
+
+This goal does not execute evaluation. It does not add runtime feature code and does not add executable automation.
+
+## Why This Follows Goal 103 And Goal 104
+
+Goal 103 added a route-only evaluator over the Goal 102 public-safe synthetic representativeness seed. That evaluator produces shape-validated aggregate route counters only.
+
+Goal 104 added the bounded-loop protocol and claim-boundary checklist. Those runbooks make clear that route-only evidence must not become output-quality proof, broader workload representativeness proof, or production proof.
+
+Goal 105 is the next documentation step: it defines a future validation design for public-safe fixture-derived checks while preserving the Goal 103 route-only boundary.
+
+## Files Added Or Updated
+
+Added:
+
+- [Public-safe output-quality methodology](../methodology/public_safe_output_quality_methodology.md)
+- [Goal 105 public-safe output-quality methodology report](goal105_public_safe_output_quality_methodology.md)
+
+Updated:
+
+- [OPEN_THIS_FIRST.md](../../OPEN_THIS_FIRST.md)
+- [REVIEW_HUB.md](../../REVIEW_HUB.md)
+- [KORA next goal queue](../context/NEXT_GOAL_QUEUE.md)
+- [Documentation index](../README.md)
+
+## Methodology Summary
+
+The methodology distinguishes route-only evidence from output-quality validation.
+
+Route-only evidence includes:
+
+- route labels.
+- route groups.
+- shape validation.
+- aggregate counters.
+
+Future output-quality validation may include, only after explicit approval:
+
+- deterministic expected-output checks.
+- schema conformance.
+- exact match where appropriate.
+- structured-equivalent match where appropriate.
+- fixture-level acceptance criteria.
+- optional later human review gate.
+- optional later semantic review gate.
+
+The methodology requires later work to keep denominators clear across route-only items, checked deterministic items, skipped items, and separately gated semantic, human, provider, H100, GPU, server, remote, or production-like validation.
+
+## Validation Performed
+
+Validation for this PR:
+
+- `python3 scripts/check_markdown_links_goal082b.py`
+- `git diff --check`
+- `python3 -m pytest`
+
+## Explicit Non-Claims
+
+Goal 105 does not:
+
+- execute output-quality evaluation.
+- add runtime feature code.
+- add executable automation.
+- make provider calls.
+- perform H100/GPU/CUDA/server/remote execution.
+- run model inference.
+- perform live semantic judging.
+- add human grading results.
+- add output-quality proof.
+- add broader workload representativeness proof.
+- add production workload proof.
+- add production readiness proof.
+- add cost-reduction proof.
+- add superiority, customer-savings, provider-replacement, or GPU-serving replacement claims.
+- move, rename, archive, or delete files.
+- modify local-only ChatGPT context files.
+
+## Next Recommended Goal
+
+Recommended next goal:
+
+- Goal 106 - Tiny public-safe fixture-based quality-check scaffold, only after explicit approval.
+
+Any semantic, human, provider, H100, GPU, server, remote, or production-like validation remains separately gated.


### PR DESCRIPTION
# Goal 105 - Public-safe output-quality methodology

## Summary

- Adds a public-safe output-quality methodology for future fixture-derived checks.
- Separates route-only evidence from later output-quality validation design.
- Updates KORA breadcrumbs, review hub, next-goal queue, and docs index for Goal 105.

## Files changed

- `OPEN_THIS_FIRST.md`
- `REVIEW_HUB.md`
- `docs/README.md`
- `docs/context/NEXT_GOAL_QUEUE.md`
- `docs/methodology/public_safe_output_quality_methodology.md`
- `docs/reports/goal105_public_safe_output_quality_methodology.md`

## Validation

- `python3 scripts/check_markdown_links_goal082b.py` - passed
- `git diff --check` - passed
- `python3 -m pytest` - 406 passed

## Boundary audit

- No provider calls added or performed.
- No H100/GPU/CUDA/server/remote execution added or performed.
- No model inference added or performed.
- No output-quality proof added.
- No broader workload representativeness proof added.
- No production proof, superiority, customer-savings, provider-replacement, or GPU-serving replacement claims added.
- No release, tag, GitHub Release, PyPI/package publication, repository settings change, issue/project-board creation, raw artifact upload, file move, rename, archive, or delete operation performed.
- No local-only ChatGPT context files modified or committed.

## Explicit non-claims

This PR does not prove production readiness, production workload handling, production cost reduction, real API/GPU cost reduction, output quality, broader workload representativeness, H100/GPU/CPU superiority, both-GPU active use, multi-GPU scaling, customer savings, provider replacement, GPU-serving replacement, or published `getkora`.

## Stop-gate confirmation

This PR is open only and not merged. Merge, release, publication, repository settings changes, claim expansion, provider calls, H100/GPU/server execution, file movement, and local source refresh require separate explicit approval.

## Next recommended task

- Goal 106 - Tiny public-safe fixture-based quality-check scaffold, only after explicit approval.
