### PR TITLE
Goal 109 - Add bounded local validation runner

### DIFF
--- a/docs/reports/goal109_bounded_local_validation_runner.md
+++ b/docs/reports/goal109_bounded_local_validation_runner.md
@@ -1,6 +1,6 @@
 # Goal 109 Bounded Local Validation Runner
 
-Status: implemented with local validation passing before PR open.
+Status: implemented with local validation passing and PR open.
 
 ## Objective
 
@@ -125,4 +125,9 @@ The expected full-suite baseline from Goal 108 was `410 passed`; this branch obs
 
 ## Final PR Status
 
-Ready for PR open after push. This report does not merge the PR.
+- PR: `https://github.com/Krako-Labs/KORA/pull/259`
+- branch: `codex/goal109-bounded-local-validation-runner`
+- state: open for review
+- merge status: not merged by this task
+
+This report does not merge the PR.

--- a/docs/reports/goal109_bounded_local_validation_runner.md
+++ b/docs/reports/goal109_bounded_local_validation_runner.md
@@ -1,0 +1,128 @@
+# Goal 109 Bounded Local Validation Runner
+
+Status: implemented with local validation passing before PR open.
+
+## Objective
+
+Goal 109 adds a small public-safe bounded local validation runner for the practical development loop. The runner executes only a hardcoded local validation profile and records deterministic step-level results.
+
+This is a local-only bounded validation runner. It is not production validation, output-quality proof, broader workload representativeness proof, provider replacement proof, or GPU/H100 superiority evidence.
+
+## CLI Usage
+
+Run the supported local profile:
+
+```bash
+python3 scripts/run_bounded_local_validation.py --profile kora-local-core
+```
+
+Optionally write structured reports:
+
+```bash
+python3 scripts/run_bounded_local_validation.py \
+  --profile kora-local-core \
+  --json-out /tmp/kora-goal109-bounded-local-validation.json \
+  --md-out /tmp/kora-goal109-bounded-local-validation.md
+```
+
+Preview planned steps without execution:
+
+```bash
+python3 scripts/run_bounded_local_validation.py --profile kora-local-core --dry-run
+```
+
+## Supported Profile
+
+The only supported profile is `kora-local-core`.
+
+Unknown profiles are rejected with a nonzero exit code and a clear error message. The runner does not accept arbitrary user-provided commands or command arguments.
+
+## Approved Command List
+
+The `kora-local-core` profile runs exactly these commands, in this order:
+
+```bash
+python3 scripts/evaluate_fixture_quality_checks.py
+python3 -m pytest tests/test_fixture_quality_checks.py
+python3 -m pytest tests/test_representativeness_seed.py tests/test_representativeness_route_only_evaluator.py
+python3 scripts/check_markdown_links_goal082b.py
+git diff --check
+python3 -m pytest
+```
+
+Commands are stored as structured argv lists and executed with `subprocess.run(..., shell=False)` from the repository root. The runner stops on the first failing command and returns a nonzero exit code for any failed command.
+
+## Dry-Run Behavior
+
+`--dry-run` reports the planned profile steps without executing subprocess commands. Each step is marked `skipped/dry-run` with no return code.
+
+## JSON And Markdown Output
+
+`--json-out` writes a structured JSON report containing the profile, final status, repository root, and step records.
+
+`--md-out` writes a simple Markdown report containing the profile, final status, and a table of step names, statuses, return codes, and commands.
+
+If no output paths are supplied, the runner prints a concise text summary to stdout.
+
+## Safety Boundaries
+
+Goal 109 keeps the runner within these boundaries:
+
+- no arbitrary shell command execution.
+- no auto-repair.
+- no scheduler, daemon, or background runner.
+- no GitHub Actions workflow.
+- no remote runner.
+- no provider-calling runner.
+- no H100, GPU, CUDA, server, or remote execution.
+- no model inference.
+- no semantic judging.
+- no human grading.
+- no file movement.
+- no local-only ChatGPT context changes.
+- no releases, tags, release assets, GitHub issues, project boards, repository settings, or collaborator changes.
+
+## Claim Boundaries
+
+Goal 109 does not claim:
+
+- output-quality proof.
+- broader workload representativeness proof.
+- production proof.
+- production cost reduction.
+- customer savings.
+- H100/GPU/CPU superiority.
+- provider replacement or GPU-serving replacement.
+- that `getkora` is published.
+
+## Validation Commands For This PR
+
+Final validation required before PR:
+
+```bash
+python3 -m pytest tests/test_bounded_local_validation_runner.py
+python3 scripts/run_bounded_local_validation.py --profile kora-local-core --dry-run
+python3 scripts/run_bounded_local_validation.py --profile kora-local-core
+python3 scripts/run_bounded_local_validation.py --profile kora-local-core --json-out /tmp/kora-goal109-bounded-local-validation.json --md-out /tmp/kora-goal109-bounded-local-validation.md
+python3 scripts/check_markdown_links_goal082b.py
+git diff --check
+python3 -m pytest
+```
+
+Observed validation before PR open:
+
+| Command | Result |
+| --- | --- |
+| `python3 -m pytest tests/test_bounded_local_validation_runner.py` | passed, `8 passed` |
+| `python3 scripts/run_bounded_local_validation.py --profile kora-local-core --dry-run` | passed; reported six `skipped/dry-run` steps |
+| `python3 scripts/run_bounded_local_validation.py --profile kora-local-core` | passed; all six bounded profile steps passed; final full suite reported `418 passed` |
+| `python3 scripts/run_bounded_local_validation.py --profile kora-local-core --json-out /tmp/kora-goal109-bounded-local-validation.json --md-out /tmp/kora-goal109-bounded-local-validation.md` | passed; JSON and Markdown reports written; final full suite reported `418 passed` |
+| `python3 scripts/check_markdown_links_goal082b.py` | passed |
+| `git diff --check` | passed |
+| `python3 -m pytest` | passed, `418 passed` |
+
+The expected full-suite baseline from Goal 108 was `410 passed`; this branch observes `418 passed` after adding the Goal 109 runner tests.
+
+## Final PR Status
+
+Ready for PR open after push. This report does not merge the PR.

--- a/docs/reports/goal109_bounded_local_validation_runner.md
+++ b/docs/reports/goal109_bounded_local_validation_runner.md
@@ -131,3 +131,13 @@ The expected full-suite baseline from Goal 108 was `410 passed`; this branch obs
 - merge status: not merged by this task
 
 This report does not merge the PR.
+
+## R1 Hidden/Control Unicode Normalization
+
+R1 inspected the three Goal 109 files for hidden, bidirectional, control, and non-ASCII Unicode characters:
+
+- `scripts/run_bounded_local_validation.py`
+- `tests/test_bounded_local_validation_runner.py`
+- `docs/reports/goal109_bounded_local_validation_runner.md`
+
+The scan found no hidden, bidirectional, control, or non-ASCII Unicode code points in the three files. No functionality, command list, safety boundary, or claim boundary changes were made.

--- a/docs/reports/goal109_bounded_local_validation_runner.md
+++ b/docs/reports/goal109_bounded_local_validation_runner.md
@@ -141,3 +141,15 @@ R1 inspected the three Goal 109 files for hidden, bidirectional, control, and no
 - `docs/reports/goal109_bounded_local_validation_runner.md`
 
 The scan found no hidden, bidirectional, control, or non-ASCII Unicode code points in the three files. No functionality, command list, safety boundary, or claim boundary changes were made.
+
+## R2 Byte-Level LF/ASCII Normalization
+
+R2 applied a byte-level normalization pass over the same three Goal 109 files:
+
+- UTF-8 text with strict ASCII content.
+- LF line endings only.
+- no CR, BOM, NUL, C0/C1 control characters except LF and horizontal tab.
+- no bidirectional formatting characters.
+- no hidden Unicode separators.
+
+The runner behavior, approved command profile, tests, safety boundaries, and claim boundaries are unchanged.

--- a/scripts/run_bounded_local_validation.py
+++ b/scripts/run_bounded_local_validation.py
@@ -150,7 +150,9 @@ def write_reports(report: dict[str, Any], json_out: Path | None, md_out: Path | 
 
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
-    parser = argparse.ArgumentParser(description="Run approved bounded local KORA validation profiles.")
+    parser = argparse.ArgumentParser(
+        description="Run approved bounded local KORA validation profiles."
+    )
     parser.add_argument("--profile", required=True, help="Approved validation profile to run.")
     parser.add_argument("--dry-run", action="store_true", help="Report planned steps without executing commands.")
     parser.add_argument("--json-out", type=Path, help="Optional path for a structured JSON report.")

--- a/scripts/run_bounded_local_validation.py
+++ b/scripts/run_bounded_local_validation.py
@@ -1,0 +1,175 @@
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+@dataclass(frozen=True)
+class ValidationStep:
+    name: str
+    argv: list[str]
+
+
+PROFILES: dict[str, list[ValidationStep]] = {
+    "kora-local-core": [
+        ValidationStep(
+            name="fixture quality check evaluator",
+            argv=["python3", "scripts/evaluate_fixture_quality_checks.py"],
+        ),
+        ValidationStep(
+            name="fixture quality check tests",
+            argv=["python3", "-m", "pytest", "tests/test_fixture_quality_checks.py"],
+        ),
+        ValidationStep(
+            name="representativeness tests",
+            argv=[
+                "python3",
+                "-m",
+                "pytest",
+                "tests/test_representativeness_seed.py",
+                "tests/test_representativeness_route_only_evaluator.py",
+            ],
+        ),
+        ValidationStep(
+            name="markdown link check",
+            argv=["python3", "scripts/check_markdown_links_goal082b.py"],
+        ),
+        ValidationStep(
+            name="git whitespace check",
+            argv=["git", "diff", "--check"],
+        ),
+        ValidationStep(
+            name="full pytest suite",
+            argv=["python3", "-m", "pytest"],
+        ),
+    ],
+}
+
+
+def _step_record(step: ValidationStep, return_code: int | None, status: str) -> dict[str, Any]:
+    return {
+        "name": step.name,
+        "command": list(step.argv),
+        "return_code": return_code,
+        "status": status,
+    }
+
+
+def build_report(profile: str, dry_run: bool = False) -> tuple[int, dict[str, Any]]:
+    if profile not in PROFILES:
+        return 2, {
+            "profile": profile,
+            "final_status": "failed",
+            "error": f"unknown profile: {profile}",
+            "supported_profiles": sorted(PROFILES),
+            "steps": [],
+        }
+
+    steps = PROFILES[profile]
+    if dry_run:
+        return 0, {
+            "profile": profile,
+            "final_status": "dry-run",
+            "repo_root": str(REPO_ROOT),
+            "steps": [_step_record(step, None, "skipped/dry-run") for step in steps],
+        }
+
+    records: list[dict[str, Any]] = []
+    exit_code = 0
+    final_status = "passed"
+
+    for step in steps:
+        completed = subprocess.run(
+            step.argv,
+            cwd=REPO_ROOT,
+            shell=False,
+            check=False,
+        )
+        status = "passed" if completed.returncode == 0 else "failed"
+        records.append(_step_record(step, completed.returncode, status))
+        if completed.returncode != 0:
+            exit_code = completed.returncode
+            final_status = "failed"
+            break
+
+    return exit_code, {
+        "profile": profile,
+        "final_status": final_status,
+        "repo_root": str(REPO_ROOT),
+        "steps": records,
+    }
+
+
+def render_text_summary(report: dict[str, Any]) -> str:
+    lines = [
+        f"profile: {report['profile']}",
+        f"final_status: {report['final_status']}",
+    ]
+    if "error" in report:
+        lines.append(f"error: {report['error']}")
+    for step in report["steps"]:
+        return_code = "not-run" if step["return_code"] is None else str(step["return_code"])
+        lines.append(f"- {step['status']}: {step['name']} ({return_code})")
+    return "\n".join(lines)
+
+
+def render_markdown_report(report: dict[str, Any]) -> str:
+    lines = [
+        "# Bounded Local Validation Report",
+        "",
+        f"- profile: `{report['profile']}`",
+        f"- final_status: `{report['final_status']}`",
+        f"- repo_root: `{report.get('repo_root', REPO_ROOT)}`",
+        "",
+        "## Steps",
+        "",
+        "| Step | Status | Return code | Command |",
+        "| --- | --- | --- | --- |",
+    ]
+    for step in report["steps"]:
+        return_code = "" if step["return_code"] is None else str(step["return_code"])
+        command = " ".join(step["command"])
+        lines.append(f"| {step['name']} | `{step['status']}` | `{return_code}` | `{command}` |")
+    if "error" in report:
+        lines.extend(["", f"Error: `{report['error']}`"])
+    return "\n".join(lines) + "\n"
+
+
+def write_reports(report: dict[str, Any], json_out: Path | None, md_out: Path | None) -> None:
+    if json_out is not None:
+        json_out.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    if md_out is not None:
+        md_out.write_text(render_markdown_report(report), encoding="utf-8")
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run approved bounded local KORA validation profiles.")
+    parser.add_argument("--profile", required=True, help="Approved validation profile to run.")
+    parser.add_argument("--dry-run", action="store_true", help="Report planned steps without executing commands.")
+    parser.add_argument("--json-out", type=Path, help="Optional path for a structured JSON report.")
+    parser.add_argument("--md-out", type=Path, help="Optional path for a Markdown report.")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    exit_code, report = build_report(args.profile, dry_run=args.dry_run)
+    write_reports(report, args.json_out, args.md_out)
+
+    if args.json_out is None and args.md_out is None:
+        print(render_text_summary(report))
+    elif exit_code != 0:
+        print(render_text_summary(report))
+
+    return exit_code
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_bounded_local_validation_runner.py
+++ b/tests/test_bounded_local_validation_runner.py
@@ -1,0 +1,136 @@
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+from scripts import run_bounded_local_validation as runner
+
+
+APPROVED_COMMANDS = [
+    ["python3", "scripts/evaluate_fixture_quality_checks.py"],
+    ["python3", "-m", "pytest", "tests/test_fixture_quality_checks.py"],
+    [
+        "python3",
+        "-m",
+        "pytest",
+        "tests/test_representativeness_seed.py",
+        "tests/test_representativeness_route_only_evaluator.py",
+    ],
+    ["python3", "scripts/check_markdown_links_goal082b.py"],
+    ["git", "diff", "--check"],
+    ["python3", "-m", "pytest"],
+]
+
+
+def test_supported_profile_contains_exact_approved_commands_in_order() -> None:
+    steps = runner.PROFILES["kora-local-core"]
+
+    assert [step.argv for step in steps] == APPROVED_COMMANDS
+
+
+def test_unknown_profile_fails() -> None:
+    exit_code, report = runner.build_report("unknown-profile")
+
+    assert exit_code != 0
+    assert report["final_status"] == "failed"
+    assert report["steps"] == []
+    assert "unknown profile" in report["error"]
+
+
+def test_dry_run_does_not_execute_subprocess_commands(monkeypatch) -> None:
+    def fail_if_called(*args, **kwargs):
+        raise AssertionError("subprocess.run should not be called during dry-run")
+
+    monkeypatch.setattr(runner.subprocess, "run", fail_if_called)
+
+    exit_code, report = runner.build_report("kora-local-core", dry_run=True)
+
+    assert exit_code == 0
+    assert report["final_status"] == "dry-run"
+    assert [step["status"] for step in report["steps"]] == ["skipped/dry-run"] * 6
+    assert [step["return_code"] for step in report["steps"]] == [None] * 6
+
+
+def test_successful_run_records_all_steps_passed(monkeypatch) -> None:
+    calls: list[list[str]] = []
+
+    def fake_run(argv, **kwargs):
+        calls.append(argv)
+        return subprocess.CompletedProcess(argv, 0)
+
+    monkeypatch.setattr(runner.subprocess, "run", fake_run)
+
+    exit_code, report = runner.build_report("kora-local-core")
+
+    assert exit_code == 0
+    assert report["final_status"] == "passed"
+    assert calls == APPROVED_COMMANDS
+    assert [step["status"] for step in report["steps"]] == ["passed"] * 6
+    assert [step["return_code"] for step in report["steps"]] == [0] * 6
+
+
+def test_failing_step_stops_later_steps(monkeypatch) -> None:
+    calls: list[list[str]] = []
+
+    def fake_run(argv, **kwargs):
+        calls.append(argv)
+        return_code = 3 if len(calls) == 2 else 0
+        return subprocess.CompletedProcess(argv, return_code)
+
+    monkeypatch.setattr(runner.subprocess, "run", fake_run)
+
+    exit_code, report = runner.build_report("kora-local-core")
+
+    assert exit_code == 3
+    assert report["final_status"] == "failed"
+    assert calls == APPROVED_COMMANDS[:2]
+    assert [step["status"] for step in report["steps"]] == ["passed", "failed"]
+
+
+def test_json_output_contains_profile_final_status_and_steps(tmp_path: Path) -> None:
+    report = {
+        "profile": "kora-local-core",
+        "final_status": "passed",
+        "repo_root": "/repo",
+        "steps": [{"name": "one", "command": ["python3"], "return_code": 0, "status": "passed"}],
+    }
+    json_out = tmp_path / "report.json"
+
+    runner.write_reports(report, json_out=json_out, md_out=None)
+
+    written = json.loads(json_out.read_text(encoding="utf-8"))
+    assert written["profile"] == "kora-local-core"
+    assert written["final_status"] == "passed"
+    assert written["steps"] == report["steps"]
+
+
+def test_markdown_output_contains_profile_and_step_names(tmp_path: Path) -> None:
+    report = {
+        "profile": "kora-local-core",
+        "final_status": "dry-run",
+        "repo_root": "/repo",
+        "steps": [
+            {
+                "name": "fixture quality check evaluator",
+                "command": ["python3", "scripts/evaluate_fixture_quality_checks.py"],
+                "return_code": None,
+                "status": "skipped/dry-run",
+            }
+        ],
+    }
+    md_out = tmp_path / "report.md"
+
+    runner.write_reports(report, json_out=None, md_out=md_out)
+
+    text = md_out.read_text(encoding="utf-8")
+    assert "profile: `kora-local-core`" in text
+    assert "fixture quality check evaluator" in text
+
+
+def test_commands_are_argv_lists_not_shell_strings() -> None:
+    for steps in runner.PROFILES.values():
+        for step in steps:
+            assert isinstance(step.argv, list)
+            assert step.argv
+            assert all(isinstance(part, str) for part in step.argv)


### PR DESCRIPTION
## Summary

Adds Goal 109's bounded local validation runner for the practical development loop.

This is a local-only bounded validation runner. It is not production validation, output-quality proof, broader workload representativeness proof, provider replacement proof, or GPU/H100 superiority evidence.

## Changed files

- `scripts/run_bounded_local_validation.py`
- `tests/test_bounded_local_validation_runner.py`
- `docs/reports/goal109_bounded_local_validation_runner.md`

## Validation results

- `python3 -m pytest tests/test_bounded_local_validation_runner.py` - passed, `8 passed`
- `python3 scripts/run_bounded_local_validation.py --profile kora-local-core --dry-run` - passed; reported six `skipped/dry-run` steps
- `python3 scripts/run_bounded_local_validation.py --profile kora-local-core` - passed; all six bounded profile steps passed; final full suite reported `418 passed`
- `python3 scripts/run_bounded_local_validation.py --profile kora-local-core --json-out /tmp/kora-goal109-bounded-local-validation.json --md-out /tmp/kora-goal109-bounded-local-validation.md` - passed; JSON and Markdown reports written; final full suite reported `418 passed`
- `python3 scripts/check_markdown_links_goal082b.py` - passed
- `git diff --check` - passed
- `python3 -m pytest` - passed, `418 passed`

Expected full-suite baseline from Goal 108 was `410 passed`; this branch observes `418 passed` after adding the Goal 109 runner tests.

## Safety boundary confirmation

- Approved profiles are hardcoded; only `kora-local-core` is supported.
- Unknown profiles return nonzero with a clear error.
- Commands are stored as structured argv lists and executed with `subprocess.run(..., shell=False)`.
- The runner does not accept arbitrary shell commands, arbitrary command arguments, auto-repair actions, schedulers, daemons, background runners, GitHub Actions workflows, remote runners, provider-calling runners, provider calls, H100/GPU/CUDA/server/remote execution, model inference, semantic judging, or human grading.
- No local-only ChatGPT context files were changed.
- No release, tag, release asset, GitHub issue, project board, repository setting, or collaborator change was created.

## Claim boundary confirmation

This PR does not claim output-quality proof, broader workload representativeness proof, production proof, production cost reduction, customer savings, H100/GPU/CPU superiority, provider replacement, GPU-serving replacement, or that `getkora` is published.
