### PR TITLE
Group 111 - Validation report control block

### DIFF
--- a/OPEN_THIS_FIRST.md
+++ b/OPEN_THIS_FIRST.md
@@ -2,7 +2,7 @@
 
 Status: current public project breadcrumb.
 
-Last updated by: Group 110.
+Last updated by: Group 111.
 
 ## Current Status
 
@@ -41,24 +41,27 @@ Current state:
 - `kora doctor` is now a first-class CLI command for running the offline Doctor workload-control report against a workload JSON file or all bundled Doctor workloads.
 - the public README and docs index now position KORA as an AI Workload Control Layer, with examples-first onboarding and explicit claim boundaries.
 - the breadcrumb/review-hub pattern has been extracted into a reusable Project Operating System package and validated on KORA as a continuation surface.
-- current public continuation work is focused on Group 110 Codex inner-loop operating guidance. Documentation movement remains optional only after later explicit Albert approval.
+- current public continuation work is focused on Group 111 validation report control-block tooling over the bounded local validation runner. Documentation movement remains optional only after later explicit Albert approval.
 
 ## Current Branch
 
-- branch: `codex/group110-codex-inner-loop-operating-layer`
+- branch: `codex/group111-validation-report-control-block`
 - public truth: `origin/main`
-- branch pushed to: `origin/codex/group110-codex-inner-loop-operating-layer`
-- open PR: [#262 Group 110 - Add Codex inner-loop operating layer](https://github.com/Krako-Labs/KORA/pull/262)
-- base commit: `3ea3c9f520fdc70370f28f51a7979b918b0599eb`
+- branch pushed to: pending
+- open PR: pending
+- base commit: `a7f5fedc6be534a30818a5b9fc5a877a901f5db7`
 
 ## Active Goal
 
-Group 110 - Codex Inner Loop Ownership with Risk-Gated Self Review.
+Group 111 - Queue-Driven Validation Report Control Block.
 
-Group 110 adds repo-local operating guidance for Codex-owned bounded inner-loop work: queue selection, validation, repair, self-review, risk classification, escalation gates, approval packets, and PR-open stop behavior. It does not create auto-merge, background execution, actual multi-agent execution, provider calls, H100/server execution, or claim expansion.
+Group 111 implements the first queue-driven Codex inner-loop work block after Group 110: a static bounded-local-validation report verifier and deterministic failure classifier. It reconciles open PR #261 by leaving that conflicted branch untouched and superseding it with a clean Group 111 branch from current `origin/main`. It does not execute commands from reports, auto-repair, create background automation, call providers, run H100/server work, or expand claims.
 
 Primary report:
 
+- [Group 111 validation report control block](docs/reports/group111_validation_report_control_block.md)
+- [Bounded local validation report verifier](scripts/verify_bounded_local_validation_report.py)
+- [Bounded local validation failure classifier](scripts/classify_bounded_local_validation_failure.py)
 - [Group 110 Codex inner loop ownership](docs/reports/group110_codex_inner_loop_ownership.md)
 - [Codex inner loop run template](docs/reports/codex_inner_loop_run_template.md)
 - [Codex inner loop queue](docs/context/CODEX_INNER_LOOP_QUEUE.md)
@@ -107,7 +110,19 @@ Current caveat: Goal 109 is a bounded local validation runner over approved comm
 
 Current caveat: Group 110 is repo-local operating guidance and validation for that guidance. It does not create production automation, auto-merge, background execution, provider calls, H100/server execution, actual multi-agent execution, or claim expansion.
 
+Current caveat: Group 111 is static validation-report control-block tooling over local JSON reports. It does not execute report commands, auto-repair, schedule background work, call providers, run H100/GPU/CUDA/server/remote execution, run model inference, perform semantic judging or human grading, add production validation, or prove output quality.
+
 ## Last Completed Goal
+
+Group 110 - Codex Inner Loop Ownership with Risk-Gated Self Review.
+
+Group 110 added repo-local operating guidance for Codex-owned bounded inner-loop work: queue selection, validation, repair, self-review, risk classification, escalation gates, approval packets, and PR-open stop behavior. PR #262 was squash-merged into `origin/main` at `a7f5fedc6be534a30818a5b9fc5a877a901f5db7`.
+
+Primary report:
+
+- [Group 110 Codex inner loop ownership](docs/reports/group110_codex_inner_loop_ownership.md)
+
+Claim boundary: Group 110 is repo-local operating guidance and validation for that guidance. It does not create production automation, auto-merge, background execution, provider calls, H100/server execution, actual multi-agent execution, or claim expansion.
 
 Goal 109 - Add Bounded Local Validation Runner.
 
@@ -610,15 +625,16 @@ KORA makes AI workloads routable. The current KRK public alpha shows how workloa
 
 ## Recommended Next Goal
 
-Group 111 - Review Group 110 Codex inner-loop operating layer and decide whether to run the first queued work block, only after explicit approval.
+Group 112 - Review Group 111 validation report control block and decide whether to run the next queued work block, only after explicit approval.
 
 Recommended scope:
 
 - use the Goal 104 runbooks as the execution checklist.
 - verify the goal envelope, base SHA, KORA identity, and clean worktree.
+- review [Group 111 validation report control block](docs/reports/group111_validation_report_control_block.md).
 - review [Group 110 Codex inner loop ownership](docs/reports/group110_codex_inner_loop_ownership.md).
 - review [Codex inner loop queue](docs/context/CODEX_INNER_LOOP_QUEUE.md).
-- decide whether to run `CIL-001` or reconcile it with any existing bounded validation report verifier PR.
+- decide whether to run `CIL-003` or defer it because the bounded validation profile registry is medium risk.
 - preserve the requirement that Codex pass is not merge-ready pass.
 - run the claim-boundary checklist before PR-open.
 - keep any follow-on work local-only, finite, public-safe, and explicitly bounded.

--- a/OPEN_THIS_FIRST.md
+++ b/OPEN_THIS_FIRST.md
@@ -47,8 +47,8 @@ Current state:
 
 - branch: `codex/group111-validation-report-control-block`
 - public truth: `origin/main`
-- branch pushed to: pending
-- open PR: pending
+- branch pushed to: `origin/codex/group111-validation-report-control-block`
+- open PR: [#263 Group 111 - Validation report control block](https://github.com/Krako-Labs/KORA/pull/263)
 - base commit: `a7f5fedc6be534a30818a5b9fc5a877a901f5db7`
 
 ## Active Goal

--- a/REVIEW_HUB.md
+++ b/REVIEW_HUB.md
@@ -16,8 +16,8 @@ KRK means KORA Routing Kernel. KRK is the deterministic-first execution routing 
 - public truth branch: `origin/main`
 - active verification branch: `codex/group111-validation-report-control-block`
 - worktree label: `group111_validation_report_control_block`
-- branch pushed to: pending
-- open PR: pending
+- branch pushed to: `origin/codex/group111-validation-report-control-block`
+- open PR: [#263 Group 111 - Validation report control block](https://github.com/Krako-Labs/KORA/pull/263)
 - base commit: `a7f5fedc6be534a30818a5b9fc5a877a901f5db7`
 
 ## Current State Summary

--- a/REVIEW_HUB.md
+++ b/REVIEW_HUB.md
@@ -2,7 +2,7 @@
 
 Status: current public review and continuation hub.
 
-Last updated by: Group 110.
+Last updated by: Group 111.
 
 ## Project Identity
 
@@ -14,11 +14,11 @@ KRK means KORA Routing Kernel. KRK is the deterministic-first execution routing 
 
 - repository: `https://github.com/Krako-Labs/KORA`
 - public truth branch: `origin/main`
-- active verification branch: `codex/group110-codex-inner-loop-operating-layer`
-- worktree label: `group110_codex_inner_loop_operating_layer`
-- branch pushed to: `origin/codex/group110-codex-inner-loop-operating-layer`
-- open PR: [#262 Group 110 - Add Codex inner-loop operating layer](https://github.com/Krako-Labs/KORA/pull/262)
-- base commit: `3ea3c9f520fdc70370f28f51a7979b918b0599eb`
+- active verification branch: `codex/group111-validation-report-control-block`
+- worktree label: `group111_validation_report_control_block`
+- branch pushed to: pending
+- open PR: pending
+- base commit: `a7f5fedc6be534a30818a5b9fc5a877a901f5db7`
 
 ## Current State Summary
 
@@ -65,10 +65,11 @@ KORA now has a public-safe first-value path and an evidence package that covers:
 - Goal 108 applies the Goal 107 protocol to one bounded local-only validation batch with pass/fail/skip/gated outcomes and no repairs.
 - Goal 109 adds a bounded local validation runner over the approved `kora-local-core` command profile.
 - Group 110 adds repo-local Codex inner-loop operating guidance with self-review, risk classification, escalation gates, approval packets, and a validator.
+- Group 111 adds a static bounded-local-validation report verifier and deterministic failure classifier for queue items `CIL-001` and `CIL-002`, leaving conflicted PR #261 untouched.
 - reusable Project Operating System templates, prompts, and adoption standard.
 - validated Project Operating System continuation path for KORA.
 - no repository settings should be changed further without explicit owner approval.
-- current work is Group 110: Codex inner-loop operating guidance. Documentation movement remains optional only after later explicit Albert approval.
+- current work is Group 111: validation report control-block tooling for static JSON reports. Documentation movement remains optional only after later explicit Albert approval.
 
 Current status is evidence-centered and local-first. It is not production-readiness evidence.
 
@@ -128,6 +129,7 @@ This is a sufficient recent history backfill, not a complete reconstruction.
 | Goal 108 | Applied the Goal 107 protocol to one bounded local-only validation batch with zero repairs. | [Goal 108 bounded local test loop](docs/reports/goal108_bounded_local_test_loop.md) |
 | Goal 109 | Added a bounded local validation runner over the approved local command profile. | [Goal 109 bounded local validation runner](docs/reports/goal109_bounded_local_validation_runner.md) |
 | Group 110 | Added repo-local Codex inner-loop operating guidance, queue, self-review, risk classification, escalation gates, approval packet, multi-agent model, run template, validator, and tests. | [Group 110 Codex inner loop ownership](docs/reports/group110_codex_inner_loop_ownership.md) |
+| Group 111 | Added static bounded-local-validation report verification and deterministic failure classification without executing report commands. | [Group 111 validation report control block](docs/reports/group111_validation_report_control_block.md) |
 
 ## Evidence Index
 
@@ -157,6 +159,9 @@ Generated summaries:
 
 Current reviewer path:
 
+- [Group 111 validation report control block](docs/reports/group111_validation_report_control_block.md)
+- [Bounded local validation report verifier](scripts/verify_bounded_local_validation_report.py)
+- [Bounded local validation failure classifier](scripts/classify_bounded_local_validation_failure.py)
 - [Group 110 Codex inner loop ownership](docs/reports/group110_codex_inner_loop_ownership.md)
 - [Codex inner loop run template](docs/reports/codex_inner_loop_run_template.md)
 - [Codex inner loop queue](docs/context/CODEX_INNER_LOOP_QUEUE.md)
@@ -290,6 +295,7 @@ Supported:
 - Goal 108 supports that one bounded local-only validation batch ran approved local commands and passed on loop 1 with zero repairs; it does not prove output quality, broader workload representativeness, or production readiness.
 - Goal 109 supports a bounded local validation runner over the approved `kora-local-core` command profile; it does not prove output quality, broader workload representativeness, or production readiness.
 - Group 110 supports repo-local Codex inner-loop operating guidance; it does not create production automation, auto-merge, background execution, provider calls, H100/server execution, actual multi-agent execution, or claim expansion.
+- Group 111 supports static report verification and deterministic triage over bounded local validation JSON; it does not execute report commands, auto-repair, call providers, run H100/server work, or prove output quality.
 - KORA has reusable public-safe Project Operating System templates for breadcrumbs, review hubs, ADRs, reports, evidence, claim registries, bootstrap checklists, and project prompts.
 
 Not supported:
@@ -301,7 +307,7 @@ Not supported:
 - output quality from Goal 103 route-only counters.
 - output quality from Goal 105 methodology documentation.
 - output quality from Goal 106 aggregate scaffold counts.
-- output quality, broader workload representativeness, or production readiness from Goal 108 local validation results, Goal 109 runner results, or Group 110 operating guidance.
+- output quality, broader workload representativeness, or production readiness from Goal 108 local validation results, Goal 109 runner results, Group 110 operating guidance, or Group 111 report-control tooling.
 - self-approval by Codex or any execution agent.
 - merge, release, publication, repository settings changes, provider calls, H100/GPU/server execution, file movement, or public claim expansion without explicit approval.
 - model replacement.
@@ -498,6 +504,7 @@ Boundary: this is positioning grounded in current examples and evidence. It does
 - Goal 108 is one bounded local-only validation batch; it does not prove output quality, broader workload representativeness, production workload handling, or broad workload superiority.
 - Goal 109 is a bounded local validation runner over approved commands; it does not prove output quality, broader workload representativeness, production workload handling, or broad workload superiority.
 - Group 110 is repo-local operating guidance and validation for that guidance; it does not create production automation, auto-merge, background execution, provider calls, H100/server execution, actual multi-agent execution, or claim expansion.
+- Group 111 is static report-control tooling over local bounded-validation JSON; it does not execute report commands, auto-repair, create background automation, call providers, run H100/server work, or prove output quality.
 - Output fidelity is deterministic rule-based over public fixtures, not live semantic judging.
 - The deterministic classification example pack is intentionally synthetic and small; broader workload representativeness remains unproven.
 - The KORA Doctor example is synthetic and does not inspect arbitrary repositories or prove diagnostic accuracy.
@@ -517,7 +524,7 @@ Boundary: this is positioning grounded in current examples and evidence. It does
 
 ## Recommended Next Goals
 
-1. Group 111 - Review Group 110 Codex inner-loop operating layer and decide whether to run the first queued work block, only after explicit approval.
+1. Group 112 - Review Group 111 validation report control block and decide whether to run `CIL-003`, only after explicit approval.
 2. A second route-only fixture slice, only after explicit approval.
 3. Semantic, human, provider, H100, GPU, server, remote, or production-like validation only after separate explicit approval.
 4. Optional documentation movement proposal for one small bucket only after later explicit Albert approval.
@@ -528,7 +535,7 @@ Paste a new Goal with this instruction:
 
 ```text
 Start by reading OPEN_THIS_FIRST.md and REVIEW_HUB.md.
-Use the active branch codex/group110-codex-inner-loop-operating-layer for the current Group 110 review packet, or create a new scoped branch from origin/main for a new Group after Group 110 is merged.
+Use the active branch codex/group111-validation-report-control-block for the current Group 111 review packet, or create a new scoped branch from origin/main for a new Group after Group 111 is merged.
 Keep public/private and claim boundaries from REVIEW_HUB.md.
 Use docs/runbooks/codex_bounded_loop_protocol.md and docs/runbooks/kora_claim_boundary_checklist.md for execution and review gates.
 Use docs/runbooks/long_run_test_loop_protocol.md and docs/runbooks/test_failure_triage_checklist.md for future bounded local test-loop goals.

--- a/docs/README.md
+++ b/docs/README.md
@@ -40,6 +40,7 @@ This documentation index is for readers who want more detail than the root [READ
 - [Goal 108 bounded local test loop](reports/goal108_bounded_local_test_loop.md) - one bounded local-only validation batch; does not prove output quality or production readiness.
 - [Goal 109 bounded local validation runner](reports/goal109_bounded_local_validation_runner.md) - approved-command local validation runner; does not prove output quality or production readiness.
 - [Group 110 Codex inner loop ownership](reports/group110_codex_inner_loop_ownership.md) - repo-local Codex operating guidance; does not create auto-merge, production automation, or claim expansion.
+- [Group 111 validation report control block](reports/group111_validation_report_control_block.md) - static bounded-validation report verifier and failure classifier; does not execute report commands or prove output quality.
 - [Goal 096 documentation navigation and archive-bucket proposal](reports/goal096_documentation_navigation_archive_bucket_proposal.md) - proposal-only navigation buckets; no files moved.
 - [Group 097 H100 evidence inventory and gap audit](reports/group097_h100_evidence_inventory_gap_audit.md) - bounded H100 evidence inventory; no new H100 benchmark claim.
 - [Goal 098 controlled CPU/GPU evidence regeneration](reports/goal098_controlled_cpu_gpu_evidence_regeneration.md) - server-run packet with local no-CUDA `not_run` status; no fresh H100 execution claim.

--- a/docs/context/CODEX_INNER_LOOP_QUEUE.md
+++ b/docs/context/CODEX_INNER_LOOP_QUEUE.md
@@ -17,6 +17,7 @@ This queue records public-safe and local-only work blocks. It is not approval to
 - validation commands: verifier tests, runner tests, dry-run runner, verifier on generated report, markdown links, `git diff --check`, full pytest.
 - repair limits: max loop count 5; max repair attempts per failing subtask 2.
 - expected outputs: verifier CLI, focused tests, report, approval packet.
+- Group 111 status: completed by `codex/group111-validation-report-control-block`; PR #261 was inspected and left untouched because it was conflicted after Group 110.
 - stop gates: unknown profile semantics, command execution risk, claim expansion.
 - claim boundaries: report structure only; no output-quality proof, broader workload representativeness proof, production proof, or production validation.
 - completion status expected: `merge-ready` only if no command-execution or claim risk remains; otherwise `needs-r1` or `needs-cto-review`.
@@ -32,6 +33,7 @@ This queue records public-safe and local-only work blocks. It is not approval to
 - validation commands: focused classifier tests, dry-run runner, markdown links, `git diff --check`, full pytest.
 - repair limits: max loop count 5; max repair attempts per failing subtask 2.
 - expected outputs: classifier, tests, report, approval packet.
+- Group 111 status: completed by `codex/group111-validation-report-control-block` as part of the same static report-control block.
 - stop gates: any attempt to infer semantic quality or execute failed commands.
 - claim boundaries: failure classification only; no production validation or output-quality proof.
 - completion status expected: `merge-ready` only for deterministic local classification over static report inputs.

--- a/docs/context/NEXT_GOAL_QUEUE.md
+++ b/docs/context/NEXT_GOAL_QUEUE.md
@@ -8,15 +8,16 @@ This queue records likely next KORA work without starting it. It is not an appro
 
 ## Current Recommended Next Goal
 
-1. Group 111 - Review Group 110 Codex inner-loop operating layer and decide whether to run the first queued work block.
+1. Group 112 - Review Group 111 validation report control block and decide whether to run `CIL-003`.
 
 Suggested scope:
 
 - use the Goal 104 runbooks and `AGENTS.md` as the execution checklist.
 - verify the goal envelope, base SHA, KORA identity, and clean worktree.
+- review [Group 111 validation report control block](../reports/group111_validation_report_control_block.md).
 - review [Group 110 Codex inner loop ownership](../reports/group110_codex_inner_loop_ownership.md).
 - review [Codex inner loop queue](CODEX_INNER_LOOP_QUEUE.md).
-- decide whether to run `CIL-001` or reconcile it with any existing bounded validation report verifier PR.
+- decide whether to run `CIL-003` or defer it because the bounded validation profile registry is medium risk.
 - preserve the requirement that Codex pass is not merge-ready pass.
 - require final classification as `merge-ready`, `needs-r1`, `needs-cto-review`, or `blocked`.
 - do not add semantic judging, human grading, provider calls, H100/GPU/CUDA/server/remote execution, model inference, production validation, claim expansion, background automation, actual multi-agent execution, or merge automation without separate explicit approval.
@@ -60,3 +61,5 @@ Goal 108 bounded local validation results do not prove output quality, broader w
 Goal 109 bounded local validation runner results do not prove output quality, broader workload representativeness, production workload handling, production readiness, or cost reduction.
 
 Group 110 Codex inner-loop operating guidance does not create production automation, auto-merge, background execution, provider calls, H100/server execution, actual multi-agent execution, output-quality proof, broader workload representativeness proof, production proof, or claim expansion.
+
+Group 111 validation report control-block tooling does not execute report commands, auto-repair, create background automation, call providers, run H100/GPU/CUDA/server/remote execution, run model inference, perform semantic judging or human grading, add production validation, prove output quality, or expand claims.

--- a/docs/reports/group111_validation_report_control_block.md
+++ b/docs/reports/group111_validation_report_control_block.md
@@ -1,6 +1,6 @@
 # Group 111 Validation Report Control Block
 
-Status: implemented with local validation passing and PR pending.
+Status: implemented with local validation passing and PR open.
 
 ## Objective
 
@@ -17,7 +17,7 @@ The tools inspect report content only. They do not execute commands stored in re
 - base public HEAD: `a7f5fedc6be534a30818a5b9fc5a877a901f5db7`
 - branch: `codex/group111-validation-report-control-block`
 - worktree: `/Users/albertkim/02_PROJECTS/05_KORA_Project/worktrees/group111_validation_report_control_block`
-- PR: pending
+- PR: `https://github.com/Krako-Labs/KORA/pull/263`
 
 ## PR #261 Inspection Result
 

--- a/docs/reports/group111_validation_report_control_block.md
+++ b/docs/reports/group111_validation_report_control_block.md
@@ -1,0 +1,185 @@
+# Group 111 Validation Report Control Block
+
+Status: implemented with local validation passing and PR pending.
+
+## Objective
+
+Group 111 executes the first queue-driven Codex inner-loop work block after Group 110. It implements static control tooling for JSON reports produced by `scripts/run_bounded_local_validation.py`:
+
+- `CIL-001`: bounded validation report verifier.
+- `CIL-002`: bounded validation failure classifier.
+
+The tools inspect report content only. They do not execute commands stored in reports, auto-repair failures, schedule background work, call providers, run H100/server work, or expand claims.
+
+## Base And Branch
+
+- public truth: `origin/main`
+- base public HEAD: `a7f5fedc6be534a30818a5b9fc5a877a901f5db7`
+- branch: `codex/group111-validation-report-control-block`
+- worktree: `/Users/albertkim/02_PROJECTS/05_KORA_Project/worktrees/group111_validation_report_control_block`
+- PR: pending
+
+## PR #261 Inspection Result
+
+PR #261 was inspected before implementation:
+
+- URL: `https://github.com/Krako-Labs/KORA/pull/261`
+- title: `Goal 110 - Add bounded validation report verifier`
+- state: open
+- draft: false
+- branch: `codex/goal110-bounded-local-validation-report-verifier`
+- head: `ae45f992ce6880c75660c4883e79d3c3ac61795e`
+- base: `main`
+- merge state: `DIRTY`
+- GitHub `validate`: passed on the PR head.
+- changed files:
+  - `OPEN_THIS_FIRST.md`
+  - `REVIEW_HUB.md`
+  - `docs/README.md`
+  - `docs/context/NEXT_GOAL_QUEUE.md`
+  - `docs/reports/goal110_bounded_local_validation_report_verifier.md`
+  - `scripts/run_bounded_local_validation.py`
+  - `scripts/verify_bounded_local_validation_report.py`
+  - `tests/test_bounded_local_validation_report_verifier.py`
+
+Decision: PR #261 was left untouched. Group 111 supersedes it on a fresh current branch because PR #261 is conflicted after Group 110 and only covers the verifier slice. This branch keeps the existing runner JSON shape stable and adds both verifier and classifier tooling.
+
+## Files Added
+
+- `scripts/verify_bounded_local_validation_report.py`
+- `scripts/classify_bounded_local_validation_failure.py`
+- `tests/test_bounded_local_validation_report_verifier.py`
+- `tests/test_bounded_local_validation_failure_classifier.py`
+- `docs/reports/group111_validation_report_control_block.md`
+
+## Files Updated
+
+- `OPEN_THIS_FIRST.md`
+- `REVIEW_HUB.md`
+- `docs/README.md`
+- `docs/context/NEXT_GOAL_QUEUE.md`
+- `docs/context/CODEX_INNER_LOOP_QUEUE.md`
+
+## CIL-001 Summary
+
+The verifier reads a bounded local validation JSON report and checks:
+
+- valid JSON object.
+- required top-level fields: `profile`, `final_status`, `steps`, and `repo_root` or `repository_root`.
+- report root resolves to the current repository root.
+- expected profile is exactly `kora-local-core`.
+- accepted final statuses: `passed`, `failed`, and `dry-run`.
+- required step fields: `name`, `command`, `return_code`, and `status`.
+- step statuses are limited to `passed`, `failed`, and `skipped/dry-run`.
+- `passed` reports contain all approved commands and all steps passed.
+- `dry-run` reports contain all approved commands and all steps are skipped/dry-run.
+- `failed` reports contain an approved command prefix ending in a failed step.
+- failed reports return nonzero unless `--allow-failed` is supplied.
+
+The verifier does not execute report commands.
+
+## CIL-002 Summary
+
+The classifier reads the same static JSON reports and emits a deterministic JSON triage summary with:
+
+- `profile`
+- `final_status`
+- `category`
+- `failing_step`
+- `failing_command`
+- `failing_return_code`
+- `summary`
+
+Supported categories:
+
+- `all_passed`
+- `dry_run_only`
+- `fixture_quality_failure`
+- `representativeness_failure`
+- `markdown_link_failure`
+- `diff_check_failure`
+- `full_pytest_failure`
+- `unknown_step_failure`
+- `malformed_report`
+- `unsupported_profile`
+
+It returns nonzero for malformed or unsupported input, but not merely because a structurally valid report records a failed validation step. It does not execute report commands.
+
+## Validation Results
+
+Final validation before PR open:
+
+| Command | Result |
+| --- | --- |
+| `python3 -m pytest tests/test_bounded_local_validation_report_verifier.py` | passed, `15 passed` |
+| `python3 -m pytest tests/test_bounded_local_validation_failure_classifier.py` | passed, `14 passed` |
+| `python3 scripts/run_bounded_local_validation.py --profile kora-local-core --dry-run --json-out /tmp/kora-group111-dry-run.json` | passed |
+| `python3 scripts/verify_bounded_local_validation_report.py /tmp/kora-group111-dry-run.json --profile kora-local-core` | passed |
+| `python3 scripts/classify_bounded_local_validation_failure.py /tmp/kora-group111-dry-run.json --profile kora-local-core` | passed; category `dry_run_only` |
+| `python3 scripts/run_bounded_local_validation.py --profile kora-local-core --json-out /tmp/kora-group111-bounded-local-validation.json --md-out /tmp/kora-group111-bounded-local-validation.md` | passed; bounded runner full suite reported `455 passed` |
+| `python3 scripts/verify_bounded_local_validation_report.py /tmp/kora-group111-bounded-local-validation.json --profile kora-local-core` | passed |
+| `python3 scripts/classify_bounded_local_validation_failure.py /tmp/kora-group111-bounded-local-validation.json --profile kora-local-core` | passed; category `all_passed` |
+| `python3 scripts/validate_codex_inner_loop_docs.py` | passed |
+| `python3 scripts/check_markdown_links_goal082b.py` | passed |
+| `git diff --check` | passed |
+| `python3 -m pytest` | passed, `455 passed` |
+
+## Loop Count And Repairs
+
+- loop count: 1
+- repair attempts: 0
+- max loop count: 5
+- max repair attempts per failing subtask: 2
+
+## Risk And Final Classification
+
+- risk level: low
+- final status classification: `merge-ready`
+
+Rationale: the work is deterministic local report-control tooling and focused tests over static JSON input. It does not widen runtime behavior, add command execution beyond the existing bounded runner, modify the runner profile, or change public claims.
+
+## Self-Review
+
+- changed files match the allowed CIL-001/CIL-002 and breadcrumb/report scope.
+- PR #261 was inspected and left untouched.
+- no local-only ChatGPT context changed.
+- no report-command execution was added.
+- no auto-repair, scheduler, daemon, background runner, GitHub Actions workflow, remote runner, provider-calling runner, H100 runner, self-merging agent, or actual multi-agent execution was added.
+- no provider calls, H100/GPU/CUDA/server/remote execution, model inference, semantic judging, human grading, production validation, output-quality proof, broader workload representativeness proof, production proof, or claim expansion was added.
+- no release, tag, GitHub Release, PyPI publication, repo settings, issues, project boards, collaborators, raw artifact uploads, file moves, renames, archives, or deletes were performed.
+
+## Approval Packet
+
+Decision needed: review and decide whether to merge Group 111.
+
+Risk level: low.
+
+Final status classification: `merge-ready`.
+
+Changed files: verifier, classifier, focused tests, report, and narrow breadcrumbs.
+
+Validation summary: all required validation commands passed; standalone full pytest reported `455 passed`.
+
+Repair attempts: 0.
+
+Failures encountered: none so far.
+
+Self-review summary: scope, claim boundaries, forbidden paths, and forbidden actions checked.
+
+Claim-boundary audit: no output-quality proof, broader workload representativeness proof, production proof, production cost reduction, customer savings, H100/GPU/CPU superiority, provider replacement, GPU-serving replacement, or published `getkora` claim added.
+
+Forbidden-action audit: no provider calls, H100/GPU/CUDA/server/remote execution, model inference, semantic judging, human grading, production validation, release, tag, GitHub Release, PyPI publication, repo settings, issues, project boards, collaborator changes, raw artifact uploads, file movement, local-only ChatGPT context changes, actual multi-agent execution, auto-merge, scheduler, daemon, background runner, GitHub Actions workflow, or report-command execution added.
+
+Uncertainty notes: PR #261 remains open and conflicted; this branch supersedes it but does not close or modify it.
+
+Codex recommendation: Merge.
+
+Albert action options: Merge / Request R1 / Stop / CTO Review.
+
+## Next Recommended Queue Item
+
+Group 112 may review this PR and decide whether to run `CIL-003 - Bounded Validation Profile Registry`. Because `CIL-003` touches the approved profile registry and is medium risk, it should start only after explicit approval.
+
+## Claim Boundary Reminder
+
+Group 111 does not prove output quality, broader workload representativeness, production workload handling, production readiness, production cost reduction, H100/GPU/CPU superiority, customer savings, provider replacement, GPU-serving replacement, or published `getkora`.

--- a/scripts/classify_bounded_local_validation_failure.py
+++ b/scripts/classify_bounded_local_validation_failure.py
@@ -1,0 +1,180 @@
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from scripts.verify_bounded_local_validation_report import APPROVED_COMMANDS, SUPPORTED_PROFILE, load_report
+
+
+CATEGORY_BY_COMMAND: dict[tuple[str, ...], str] = {
+    ("python3", "scripts/evaluate_fixture_quality_checks.py"): "fixture_quality_failure",
+    ("python3", "-m", "pytest", "tests/test_fixture_quality_checks.py"): "fixture_quality_failure",
+    (
+        "python3",
+        "-m",
+        "pytest",
+        "tests/test_representativeness_seed.py",
+        "tests/test_representativeness_route_only_evaluator.py",
+    ): "representativeness_failure",
+    ("python3", "scripts/check_markdown_links_goal082b.py"): "markdown_link_failure",
+    ("git", "diff", "--check"): "diff_check_failure",
+    ("python3", "-m", "pytest"): "full_pytest_failure",
+}
+
+
+def _summary(
+    *,
+    profile: str | None,
+    final_status: str | None,
+    category: str,
+    failing_step: str | None = None,
+    failing_command: list[str] | None = None,
+    failing_return_code: int | None = None,
+    summary: str,
+) -> dict[str, Any]:
+    return {
+        "category": category,
+        "failing_command": failing_command,
+        "failing_return_code": failing_return_code,
+        "failing_step": failing_step,
+        "final_status": final_status,
+        "profile": profile,
+        "summary": summary,
+    }
+
+
+def classify_report(report: dict[str, Any], expected_profile: str) -> tuple[int, dict[str, Any]]:
+    profile = report.get("profile")
+    final_status = report.get("final_status")
+
+    if expected_profile != SUPPORTED_PROFILE or profile != expected_profile:
+        return 1, _summary(
+            profile=profile if isinstance(profile, str) else None,
+            final_status=final_status if isinstance(final_status, str) else None,
+            category="unsupported_profile",
+            summary=f"unsupported or mismatched profile; expected {expected_profile}",
+        )
+
+    steps = report.get("steps")
+    if not isinstance(steps, list):
+        return 1, _summary(
+            profile=profile,
+            final_status=final_status if isinstance(final_status, str) else None,
+            category="malformed_report",
+            summary="steps must be a list",
+        )
+
+    if final_status == "dry-run":
+        return 0, _summary(
+            profile=profile,
+            final_status=final_status,
+            category="dry_run_only",
+            summary="bounded validation report is a dry-run; no commands were executed by the runner",
+        )
+
+    failing_step: dict[str, Any] | None = None
+    for step in steps:
+        if not isinstance(step, dict):
+            return 1, _summary(
+                profile=profile,
+                final_status=final_status if isinstance(final_status, str) else None,
+                category="malformed_report",
+                summary="step records must be objects",
+            )
+        return_code = step.get("return_code")
+        status = step.get("status")
+        if status == "failed" or (isinstance(return_code, int) and return_code != 0):
+            failing_step = step
+            break
+
+    if final_status == "passed" and failing_step is None:
+        return 0, _summary(
+            profile=profile,
+            final_status=final_status,
+            category="all_passed",
+            summary="all bounded validation steps passed",
+        )
+
+    if final_status not in {"passed", "failed", "dry-run"}:
+        return 1, _summary(
+            profile=profile,
+            final_status=final_status if isinstance(final_status, str) else None,
+            category="malformed_report",
+            summary=f"invalid final_status: {final_status}",
+        )
+
+    if failing_step is None:
+        return 1, _summary(
+            profile=profile,
+            final_status=final_status,
+            category="malformed_report",
+            summary="failed report did not include a failing step",
+        )
+
+    command = failing_step.get("command")
+    if not isinstance(command, list) or not all(isinstance(part, str) for part in command):
+        return 1, _summary(
+            profile=profile,
+            final_status=final_status,
+            category="malformed_report",
+            failing_step=failing_step.get("name") if isinstance(failing_step.get("name"), str) else None,
+            summary="failing step command must be a list of strings",
+        )
+
+    category = CATEGORY_BY_COMMAND.get(tuple(command), "unknown_step_failure")
+    return_code = failing_step.get("return_code")
+    if not isinstance(return_code, int):
+        return_code = None
+
+    return 0, _summary(
+        profile=profile,
+        final_status=final_status,
+        category=category,
+        failing_step=failing_step.get("name") if isinstance(failing_step.get("name"), str) else None,
+        failing_command=command,
+        failing_return_code=return_code,
+        summary=f"classified first failing bounded validation step as {category}",
+    )
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Classify a bounded local validation report without executing report commands."
+    )
+    parser.add_argument("report", type=Path, help="Path to the JSON report to classify.")
+    parser.add_argument("--profile", required=True, help="Expected approved validation profile.")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    report, load_errors = load_report(args.report)
+    if report is None:
+        print(
+            json.dumps(
+                _summary(
+                    profile=args.profile,
+                    final_status=None,
+                    category="malformed_report",
+                    summary="; ".join(load_errors),
+                ),
+                sort_keys=True,
+            )
+        )
+        return 1
+
+    exit_code, result = classify_report(report, args.profile)
+    print(json.dumps(result, sort_keys=True))
+    return exit_code
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/verify_bounded_local_validation_report.py
+++ b/scripts/verify_bounded_local_validation_report.py
@@ -1,0 +1,196 @@
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from scripts.run_bounded_local_validation import PROFILES
+
+
+SUPPORTED_PROFILE = "kora-local-core"
+ALLOWED_FINAL_STATUSES = {"passed", "failed", "dry-run"}
+ALLOWED_STEP_STATUSES = {"passed", "failed", "skipped/dry-run"}
+REQUIRED_TOP_LEVEL_FIELDS = {"profile", "final_status", "steps"}
+REQUIRED_STEP_FIELDS = {"name", "command", "return_code", "status"}
+
+APPROVED_COMMANDS: dict[str, list[list[str]]] = {
+    profile: [list(step.argv) for step in steps]
+    for profile, steps in PROFILES.items()
+}
+
+
+def load_report(path: Path) -> tuple[dict[str, Any] | None, list[str]]:
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        return None, [f"invalid JSON: {exc}"]
+    except OSError as exc:
+        return None, [f"could not read report: {exc}"]
+
+    if not isinstance(data, dict):
+        return None, ["report must be a JSON object"]
+    return data, []
+
+
+def _step_command(step: dict[str, Any]) -> list[str] | None:
+    command = step.get("command")
+    if isinstance(command, list) and all(isinstance(part, str) for part in command):
+        return list(command)
+    return None
+
+
+def _step_return_code(step: dict[str, Any]) -> int | None | str:
+    value = step.get("return_code")
+    if value is None or isinstance(value, int):
+        return value
+    return "invalid"
+
+
+def _expected_command_prefix_length(final_status: str, step_statuses: list[str]) -> int:
+    if final_status in {"passed", "dry-run"}:
+        return len(step_statuses)
+    if "failed" in step_statuses:
+        return step_statuses.index("failed") + 1
+    return len(step_statuses)
+
+
+def validate_report(report: dict[str, Any], expected_profile: str, allow_failed: bool = False) -> list[str]:
+    errors: list[str] = []
+
+    if expected_profile != SUPPORTED_PROFILE:
+        errors.append(f"unsupported expected profile: {expected_profile}")
+        return errors
+
+    missing = sorted(REQUIRED_TOP_LEVEL_FIELDS - set(report))
+    errors.extend(f"missing top-level field: {field}" for field in missing)
+
+    profile = report.get("profile")
+    if profile != expected_profile:
+        errors.append(f"profile mismatch: expected {expected_profile}, got {profile}")
+
+    final_status = report.get("final_status")
+    if final_status not in ALLOWED_FINAL_STATUSES:
+        errors.append(f"invalid final_status: {final_status}")
+
+    report_root = report.get("repo_root", report.get("repository_root"))
+    if report_root is None:
+        errors.append("missing top-level field: repo_root or repository_root")
+    elif not isinstance(report_root, str):
+        errors.append("repo_root must be a string")
+    else:
+        try:
+            if Path(report_root).resolve() != REPO_ROOT.resolve():
+                errors.append(f"repo_root mismatch: expected {REPO_ROOT}, got {report_root}")
+        except OSError as exc:
+            errors.append(f"repo_root could not be resolved: {exc}")
+
+    steps = report.get("steps")
+    if not isinstance(steps, list):
+        errors.append("steps must be a list")
+        return errors
+
+    expected_commands = APPROVED_COMMANDS.get(expected_profile, [])
+    step_statuses: list[str] = []
+    observed_commands: list[list[str]] = []
+
+    for index, step in enumerate(steps):
+        if not isinstance(step, dict):
+            errors.append(f"step {index} must be an object")
+            continue
+
+        missing_step = sorted(REQUIRED_STEP_FIELDS - set(step))
+        errors.extend(f"step {index} missing field: {field}" for field in missing_step)
+
+        status = step.get("status")
+        if status not in ALLOWED_STEP_STATUSES:
+            errors.append(f"step {index} invalid status: {status}")
+        elif isinstance(status, str):
+            step_statuses.append(status)
+
+        command = _step_command(step)
+        if command is None:
+            errors.append(f"step {index} command must be a list of strings")
+        else:
+            observed_commands.append(command)
+
+        return_code = _step_return_code(step)
+        if return_code == "invalid":
+            errors.append(f"step {index} return_code must be an integer or null")
+
+        if status == "passed" and return_code != 0:
+            errors.append(f"step {index} passed status requires return_code 0")
+        if status == "failed" and (not isinstance(return_code, int) or return_code == 0):
+            errors.append(f"step {index} failed status requires nonzero return_code")
+        if status == "skipped/dry-run" and return_code is not None:
+            errors.append(f"step {index} skipped/dry-run status requires null return_code")
+
+    if final_status in {"passed", "dry-run"} and len(observed_commands) != len(expected_commands):
+        errors.append(
+            f"{final_status} report must contain all approved steps: "
+            f"expected {len(expected_commands)}, got {len(observed_commands)}"
+        )
+
+    if final_status == "failed" and len(observed_commands) > len(expected_commands):
+        errors.append(
+            f"failed report has too many steps: expected at most {len(expected_commands)}, got {len(observed_commands)}"
+        )
+
+    prefix_length = _expected_command_prefix_length(str(final_status), step_statuses)
+    expected_prefix = expected_commands[:prefix_length]
+    observed_prefix = observed_commands[:prefix_length]
+    if observed_prefix != expected_prefix:
+        errors.append("step commands do not match the approved command list")
+
+    if final_status == "passed" and step_statuses and any(status != "passed" for status in step_statuses):
+        errors.append("passed report steps must all be passed")
+    if final_status == "dry-run" and step_statuses and any(status != "skipped/dry-run" for status in step_statuses):
+        errors.append("dry-run report steps must all be skipped/dry-run")
+    if final_status == "failed" and "failed" not in step_statuses:
+        errors.append("failed report must include a failed step")
+    if final_status == "failed" and not allow_failed:
+        errors.append("failed report requires --allow-failed")
+
+    return errors
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Verify a bounded local validation JSON report without executing report commands."
+    )
+    parser.add_argument("report", type=Path, help="Path to the JSON report to verify.")
+    parser.add_argument("--profile", required=True, help="Expected approved validation profile.")
+    parser.add_argument(
+        "--allow-failed",
+        action="store_true",
+        help="Treat structurally valid failed reports as accepted.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    report, load_errors = load_report(args.report)
+    if report is None:
+        for error in load_errors:
+            print(f"FAIL: {error}")
+        return 1
+
+    errors = validate_report(report, args.profile, allow_failed=args.allow_failed)
+    if errors:
+        for error in errors:
+            print(f"FAIL: {error}")
+        return 1
+
+    print(f"PASS: {args.report} matches {args.profile} bounded validation report contract")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_bounded_local_validation_failure_classifier.py
+++ b/tests/test_bounded_local_validation_failure_classifier.py
@@ -1,0 +1,158 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from scripts import classify_bounded_local_validation_failure as classifier
+from scripts import verify_bounded_local_validation_report as verifier
+
+
+APPROVED_COMMANDS = verifier.APPROVED_COMMANDS["kora-local-core"]
+
+
+def _report(status: str = "passed") -> dict:
+    step_status = "skipped/dry-run" if status == "dry-run" else "passed"
+    return_code = None if status == "dry-run" else 0
+    return {
+        "profile": "kora-local-core",
+        "final_status": status,
+        "repo_root": str(verifier.REPO_ROOT),
+        "steps": [
+            {
+                "name": f"step {index}",
+                "command": command,
+                "return_code": return_code,
+                "status": step_status,
+            }
+            for index, command in enumerate(APPROVED_COMMANDS, start=1)
+        ],
+    }
+
+
+def _failed_report(command_index: int, command: list[str] | None = None) -> dict:
+    report = _report("failed")
+    report["steps"] = report["steps"][: command_index + 1]
+    report["steps"][-1]["status"] = "failed"
+    report["steps"][-1]["return_code"] = 3
+    if command is not None:
+        report["steps"][-1]["command"] = command
+    return report
+
+
+def _write(tmp_path: Path, report: dict) -> Path:
+    path = tmp_path / "report.json"
+    path.write_text(json.dumps(report), encoding="utf-8")
+    return path
+
+
+def test_classifies_all_passed() -> None:
+    code, result = classifier.classify_report(_report(), "kora-local-core")
+
+    assert code == 0
+    assert result["category"] == "all_passed"
+
+
+def test_classifies_dry_run_only() -> None:
+    code, result = classifier.classify_report(_report("dry-run"), "kora-local-core")
+
+    assert code == 0
+    assert result["category"] == "dry_run_only"
+
+
+def test_classifies_fixture_quality_evaluator_failure() -> None:
+    code, result = classifier.classify_report(_failed_report(0), "kora-local-core")
+
+    assert code == 0
+    assert result["category"] == "fixture_quality_failure"
+
+
+def test_classifies_fixture_quality_test_failure() -> None:
+    code, result = classifier.classify_report(_failed_report(1), "kora-local-core")
+
+    assert code == 0
+    assert result["category"] == "fixture_quality_failure"
+
+
+def test_classifies_representativeness_failure() -> None:
+    code, result = classifier.classify_report(_failed_report(2), "kora-local-core")
+
+    assert code == 0
+    assert result["category"] == "representativeness_failure"
+
+
+def test_classifies_markdown_link_failure() -> None:
+    code, result = classifier.classify_report(_failed_report(3), "kora-local-core")
+
+    assert code == 0
+    assert result["category"] == "markdown_link_failure"
+
+
+def test_classifies_diff_check_failure() -> None:
+    code, result = classifier.classify_report(_failed_report(4), "kora-local-core")
+
+    assert code == 0
+    assert result["category"] == "diff_check_failure"
+
+
+def test_classifies_full_pytest_failure() -> None:
+    code, result = classifier.classify_report(_failed_report(5), "kora-local-core")
+
+    assert code == 0
+    assert result["category"] == "full_pytest_failure"
+
+
+def test_classifies_unknown_step_failure() -> None:
+    code, result = classifier.classify_report(
+        _failed_report(1, ["python3", "scripts/custom_check.py"]),
+        "kora-local-core",
+    )
+
+    assert code == 0
+    assert result["category"] == "unknown_step_failure"
+
+
+def test_unsupported_profile_returns_nonzero() -> None:
+    report = _report()
+    report["profile"] = "other"
+
+    code, result = classifier.classify_report(report, "kora-local-core")
+
+    assert code == 1
+    assert result["category"] == "unsupported_profile"
+
+
+def test_malformed_steps_returns_nonzero() -> None:
+    report = _report()
+    report["steps"] = "not-a-list"
+
+    code, result = classifier.classify_report(report, "kora-local-core")
+
+    assert code == 1
+    assert result["category"] == "malformed_report"
+
+
+def test_malformed_json_main_returns_nonzero(tmp_path: Path, capsys) -> None:
+    path = tmp_path / "bad.json"
+    path.write_text("{", encoding="utf-8")
+
+    code = classifier.main([str(path), "--profile", "kora-local-core"])
+    output = json.loads(capsys.readouterr().out)
+
+    assert code == 1
+    assert output["category"] == "malformed_report"
+
+
+def test_main_never_executes_report_commands(tmp_path: Path, monkeypatch) -> None:
+    report = _failed_report(0, ["python3", "-c", "raise SystemExit(99)"])
+    path = _write(tmp_path, report)
+
+    def fail_if_called(*args, **kwargs):
+        raise AssertionError("classifier must not execute report commands")
+
+    monkeypatch.setattr("subprocess.run", fail_if_called)
+
+    assert classifier.main([str(path), "--profile", "kora-local-core"]) == 0
+
+
+def test_module_does_not_import_subprocess() -> None:
+    assert "subprocess" not in classifier.__dict__

--- a/tests/test_bounded_local_validation_report_verifier.py
+++ b/tests/test_bounded_local_validation_report_verifier.py
@@ -1,0 +1,161 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from scripts import verify_bounded_local_validation_report as verifier
+
+
+APPROVED_COMMANDS = verifier.APPROVED_COMMANDS["kora-local-core"]
+
+
+def _report(status: str = "passed") -> dict:
+    step_status = "skipped/dry-run" if status == "dry-run" else "passed"
+    return_code = None if status == "dry-run" else 0
+    return {
+        "profile": "kora-local-core",
+        "final_status": status,
+        "repo_root": str(verifier.REPO_ROOT),
+        "steps": [
+            {
+                "name": f"step {index}",
+                "command": command,
+                "return_code": return_code,
+                "status": step_status,
+            }
+            for index, command in enumerate(APPROVED_COMMANDS, start=1)
+        ],
+    }
+
+
+def _write(tmp_path: Path, report: dict) -> Path:
+    path = tmp_path / "report.json"
+    path.write_text(json.dumps(report), encoding="utf-8")
+    return path
+
+
+def test_passed_report_is_valid() -> None:
+    assert verifier.validate_report(_report(), "kora-local-core") == []
+
+
+def test_dry_run_report_is_valid() -> None:
+    assert verifier.validate_report(_report("dry-run"), "kora-local-core") == []
+
+
+def test_failed_report_requires_allow_failed() -> None:
+    report = _report("failed")
+    report["steps"] = report["steps"][:2]
+    report["steps"][-1]["status"] = "failed"
+    report["steps"][-1]["return_code"] = 7
+
+    errors = verifier.validate_report(report, "kora-local-core")
+
+    assert "failed report requires --allow-failed" in errors
+
+
+def test_failed_report_with_approved_prefix_is_valid_when_allowed() -> None:
+    report = _report("failed")
+    report["steps"] = report["steps"][:3]
+    report["steps"][-1]["status"] = "failed"
+    report["steps"][-1]["return_code"] = 2
+
+    assert verifier.validate_report(report, "kora-local-core", allow_failed=True) == []
+
+
+def test_missing_required_top_level_field_fails() -> None:
+    report = _report()
+    del report["steps"]
+
+    errors = verifier.validate_report(report, "kora-local-core")
+
+    assert "missing top-level field: steps" in errors
+
+
+def test_profile_mismatch_fails() -> None:
+    report = _report()
+    report["profile"] = "other"
+
+    errors = verifier.validate_report(report, "kora-local-core")
+
+    assert "profile mismatch: expected kora-local-core, got other" in errors
+
+
+def test_repo_root_mismatch_fails() -> None:
+    report = _report()
+    report["repo_root"] = "/tmp/not-kora"
+
+    errors = verifier.validate_report(report, "kora-local-core")
+
+    assert any(error.startswith("repo_root mismatch:") for error in errors)
+
+
+def test_command_mismatch_fails() -> None:
+    report = _report()
+    report["steps"][1]["command"] = ["python3", "-m", "pytest", "tests/test_other.py"]
+
+    errors = verifier.validate_report(report, "kora-local-core")
+
+    assert "step commands do not match the approved command list" in errors
+
+
+def test_invalid_step_status_fails() -> None:
+    report = _report()
+    report["steps"][0]["status"] = "pending"
+
+    errors = verifier.validate_report(report, "kora-local-core")
+
+    assert "step 0 invalid status: pending" in errors
+
+
+def test_passed_step_requires_zero_return_code() -> None:
+    report = _report()
+    report["steps"][0]["return_code"] = 1
+
+    errors = verifier.validate_report(report, "kora-local-core")
+
+    assert "step 0 passed status requires return_code 0" in errors
+
+
+def test_skipped_step_requires_null_return_code() -> None:
+    report = _report("dry-run")
+    report["steps"][0]["return_code"] = 0
+
+    errors = verifier.validate_report(report, "kora-local-core")
+
+    assert "step 0 skipped/dry-run status requires null return_code" in errors
+
+
+def test_failed_report_without_failed_step_fails() -> None:
+    report = _report("failed")
+
+    errors = verifier.validate_report(report, "kora-local-core", allow_failed=True)
+
+    assert "failed report must include a failed step" in errors
+
+
+def test_load_report_rejects_invalid_json(tmp_path: Path) -> None:
+    path = tmp_path / "bad.json"
+    path.write_text("{", encoding="utf-8")
+
+    report, errors = verifier.load_report(path)
+
+    assert report is None
+    assert errors[0].startswith("invalid JSON:")
+
+
+def test_main_never_executes_report_commands(tmp_path: Path, monkeypatch) -> None:
+    report = _report()
+    report["steps"][0]["command"] = ["python3", "-c", "raise SystemExit(99)"]
+    path = _write(tmp_path, report)
+
+    def fail_if_called(*args, **kwargs):
+        raise AssertionError("verifier must not execute report commands")
+
+    monkeypatch.setattr(verifier, "APPROVED_COMMANDS", {"kora-local-core": APPROVED_COMMANDS})
+    monkeypatch.setattr("subprocess.run", fail_if_called)
+
+    assert verifier.main([str(path), "--profile", "kora-local-core"]) == 1
+
+
+def test_module_does_not_import_subprocess() -> None:
+    assert "subprocess" not in verifier.__dict__


### PR DESCRIPTION
## Summary

- Implements CIL-001 bounded local validation report verifier for static JSON reports from `scripts/run_bounded_local_validation.py`.
- Implements CIL-002 deterministic bounded validation failure classifier.
- Updates Group 111 breadcrumbs, queue status, and approval packet documentation.
- Inspects PR #261 and leaves it untouched because it is open but merge-conflicted after Group 110; this branch supersedes it from current `origin/main`.

## Changed Files

- `scripts/verify_bounded_local_validation_report.py`
- `scripts/classify_bounded_local_validation_failure.py`
- `tests/test_bounded_local_validation_report_verifier.py`
- `tests/test_bounded_local_validation_failure_classifier.py`
- `docs/reports/group111_validation_report_control_block.md`
- `OPEN_THIS_FIRST.md`
- `REVIEW_HUB.md`
- `docs/README.md`
- `docs/context/NEXT_GOAL_QUEUE.md`
- `docs/context/CODEX_INNER_LOOP_QUEUE.md`

## Validation

- `python3 -m pytest tests/test_bounded_local_validation_report_verifier.py` - passed, `15 passed`
- `python3 -m pytest tests/test_bounded_local_validation_failure_classifier.py` - passed, `14 passed`
- `python3 scripts/run_bounded_local_validation.py --profile kora-local-core --dry-run --json-out /tmp/kora-group111-dry-run.json` - passed
- `python3 scripts/verify_bounded_local_validation_report.py /tmp/kora-group111-dry-run.json --profile kora-local-core` - passed
- `python3 scripts/classify_bounded_local_validation_failure.py /tmp/kora-group111-dry-run.json --profile kora-local-core` - passed, category `dry_run_only`
- `python3 scripts/run_bounded_local_validation.py --profile kora-local-core --json-out /tmp/kora-group111-bounded-local-validation.json --md-out /tmp/kora-group111-bounded-local-validation.md` - passed; bounded runner full suite reported `455 passed`
- `python3 scripts/verify_bounded_local_validation_report.py /tmp/kora-group111-bounded-local-validation.json --profile kora-local-core` - passed
- `python3 scripts/classify_bounded_local_validation_failure.py /tmp/kora-group111-bounded-local-validation.json --profile kora-local-core` - passed, category `all_passed`
- `python3 scripts/validate_codex_inner_loop_docs.py` - passed
- `python3 scripts/check_markdown_links_goal082b.py` - passed
- `git diff --check` - passed
- `python3 -m pytest` - passed, `455 passed`
- strict ASCII/LF byte scan over all changed files - passed

## Loop Count And Repairs

- loop count: 1
- repair attempts: 0

## Final Classification

- risk level: low
- final status classification: `merge-ready`

## Approval Packet

Decision needed: review and decide whether to merge Group 111.

Risk level: low.

Final status classification: `merge-ready`.

Changed files: verifier, classifier, focused tests, report, and narrow breadcrumbs.

Validation summary: all required validation commands passed; full pytest reported `455 passed`.

Repair attempts: 0.

Failures encountered: none.

Self-review summary: changed files match the CIL-001/CIL-002 scope; PR #261 inspected and left untouched; local-only ChatGPT context was not changed.

Claim-boundary audit: no output-quality proof, broader workload representativeness proof, production proof, production cost reduction, customer savings, H100/GPU/CPU superiority, provider replacement, GPU-serving replacement, or published `getkora` claim added.

Forbidden-action audit: no provider calls, H100/GPU/CUDA/server/remote execution, model inference, semantic judging, human grading, production validation, release, tag, GitHub Release, PyPI publication, repo settings, issues, project boards, collaborator changes, raw artifact uploads, file movement, local-only ChatGPT context changes, actual multi-agent execution, auto-merge, scheduler, daemon, background runner, GitHub Actions workflow, or report-command execution added.

Uncertainty notes: PR #261 remains open and conflicted; this branch supersedes it but does not close or modify it.

Codex recommendation: Merge.

Albert action options: Merge / Request R1 / Stop / CTO Review.

## Boundary Confirmation

This PR is open only and not merged.
