### PR TITLE
Group 114 - Add first-run CLI smoke validation

### DIFF
--- a/OPEN_THIS_FIRST.md
+++ b/OPEN_THIS_FIRST.md
@@ -47,8 +47,8 @@ Current state:
 
 - branch: `codex/group114-first-run-cli-smoke-validation`
 - public truth: `origin/main`
-- branch pushed to: pending
-- open PR: pending
+- branch pushed to: `origin/codex/group114-first-run-cli-smoke-validation`
+- open PR: [#266](https://github.com/Krako-Labs/KORA/pull/266)
 - base commit: `bbc673d256f005201925051310342fa78c4af4d2`
 
 ## Active Goal

--- a/OPEN_THIS_FIRST.md
+++ b/OPEN_THIS_FIRST.md
@@ -2,7 +2,7 @@
 
 Status: current public project breadcrumb.
 
-Last updated by: Group 113.
+Last updated by: Group 114.
 
 ## Current Status
 
@@ -41,24 +41,27 @@ Current state:
 - `kora doctor` is now a first-class CLI command for running the offline Doctor workload-control report against a workload JSON file or all bundled Doctor workloads.
 - the public README and docs index now position KORA as an AI Workload Control Layer, with examples-first onboarding and explicit claim boundaries.
 - the breadcrumb/review-hub pattern has been extracted into a reusable Project Operating System package and validated on KORA as a continuation surface.
-- current public continuation work is focused on Group 113 inner-loop applied review and queue hardening. Documentation movement remains optional only after later explicit Albert approval.
+- current public continuation work is focused on Group 114 first-run CLI smoke validation. Documentation movement remains optional only after later explicit Albert approval.
 
 ## Current Branch
 
-- branch: `codex/group113-inner-loop-queue-hardening`
+- branch: `codex/group114-first-run-cli-smoke-validation`
 - public truth: `origin/main`
-- branch pushed to: `origin/codex/group113-inner-loop-queue-hardening`
-- open PR: [#265](https://github.com/Krako-Labs/KORA/pull/265)
-- base commit: `11232af9027209c0cfd4ae7a5edee79c91d791d4`
+- branch pushed to: pending
+- open PR: pending
+- base commit: `bbc673d256f005201925051310342fa78c4af4d2`
 
 ## Active Goal
 
-Group 113 - Inner Loop Applied Review and Queue Hardening Audit.
+Group 114 - First-Run CLI Smoke Validation Expansion.
 
-Group 113 applies the Group 110-112 operating layer, runs the Group 112 checkers against the merged Group 112 report, records the PR #261 supersession state, adds a medium-risk `CIL-003` checklist, and hardens queue sizing guidance to avoid micro-task collapse. It does not implement `CIL-003`, change validation profiles, execute report commands, call providers, run H100/server work, mutate GitHub, or expand claims.
+Group 114 implements `CIL-004` by adding a deterministic local first-run CLI smoke checker over existing offline commands, focused tests, and a public-safe report. It does not implement `CIL-003`, change validation profile registries, publish packages, call providers, require network access, run H100/server work, or expand claims.
 
 Primary report:
 
+- [Group 114 first-run CLI smoke validation](docs/reports/group114_first_run_cli_smoke_validation.md)
+- [First-run CLI smoke checker](scripts/check_first_run_cli_smoke.py)
+- [First-run CLI smoke tests](tests/test_first_run_cli_smoke.py)
 - [Group 113 inner loop applied review and queue hardening](docs/reports/group113_inner_loop_applied_review_queue_hardening.md)
 - [Codex medium-risk profile registry checklist](docs/context/CODEX_MEDIUM_RISK_PROFILE_REGISTRY_CHECKLIST.md)
 - [Group 112 PR approval and report consistency](docs/reports/group112_pr_approval_and_report_consistency.md)
@@ -121,7 +124,19 @@ Current caveat: Group 112 validates approval-packet and report/breadcrumb consis
 
 Current caveat: Group 113 is operating review and queue hardening only. It does not implement `CIL-003`, change validation profiles, execute report commands, call GitHub APIs, mutate PRs, create issues, auto-repair, create background automation, call providers, run H100/GPU/CUDA/server/remote execution, run model inference, perform semantic judging or human grading, add production validation, or prove output quality.
 
+Current caveat: Group 114 is local first-run CLI smoke validation only. It does not implement `CIL-003`, change validation profile registries, publish packages, call providers, require network access, run H100/GPU/CUDA/server/remote execution, run model inference, perform semantic judging or human grading, add production validation, prove output quality, prove broader workload representativeness, or claim that `getkora` is published.
+
 ## Last Completed Goal
+
+Group 113 - Inner Loop Applied Review and Queue Hardening Audit.
+
+Group 113 applied the Group 110-112 operating layer, confirmed the Group 112 checkers pass on the merged Group 112 report, added a medium-risk `CIL-003` checklist, and hardened queue sizing guidance. PR #265 was squash-merged into `origin/main` at `bbc673d256f005201925051310342fa78c4af4d2`.
+
+Primary report:
+
+- [Group 113 inner loop applied review and queue hardening](docs/reports/group113_inner_loop_applied_review_queue_hardening.md)
+
+Claim boundary: Group 113 is operating review and queue hardening only. It does not implement `CIL-003`, change validation profiles, execute report commands, call GitHub APIs, mutate PRs, call providers, run H100/server work, or prove output quality.
 
 Group 112 - PR Approval and Report Consistency Control Block.
 
@@ -654,28 +669,30 @@ KORA makes AI workloads routable. The current KRK public alpha shows how workloa
 
 ## Recommended Next Goal
 
-Group 114 - Decide whether to explicitly approve `CIL-003` using the medium-risk profile-registry checklist, or defer it.
+Group 115 - Consider `CIL-005 - Source-Install Readiness Check`, only after explicit approval.
 
 Recommended scope:
 
 - use the Goal 104 runbooks as the execution checklist.
 - verify the goal envelope, base SHA, KORA identity, and clean worktree.
+- review [Group 114 first-run CLI smoke validation](docs/reports/group114_first_run_cli_smoke_validation.md).
 - review [Group 113 inner loop applied review and queue hardening](docs/reports/group113_inner_loop_applied_review_queue_hardening.md).
 - review [Codex medium-risk profile registry checklist](docs/context/CODEX_MEDIUM_RISK_PROFILE_REGISTRY_CHECKLIST.md).
 - review [Group 112 PR approval and report consistency](docs/reports/group112_pr_approval_and_report_consistency.md).
 - review [Group 111 validation report control block](docs/reports/group111_validation_report_control_block.md).
 - review [Group 110 Codex inner loop ownership](docs/reports/group110_codex_inner_loop_ownership.md).
 - review [Codex inner loop queue](docs/context/CODEX_INNER_LOOP_QUEUE.md).
-- approve `CIL-003` only if the checklist constraints are accepted explicitly.
-- otherwise defer `CIL-003` and choose a lower-risk 2-4 hour operating block later.
-- if approved, expect final classification `needs-cto-review` unless the scope is extremely narrow.
+- keep `CIL-003` deferred unless Albert explicitly approves the medium-risk profile-registry checklist.
+- verify source-install readiness from local repo state without publishing packages.
+- do not claim that `getkora` is published.
+- expect final classification `needs-cto-review` if user-facing install docs or onboarding language change.
 - preserve the requirement that Codex pass is not merge-ready pass.
 - run the claim-boundary checklist before PR-open.
 - keep any follow-on work local-only, finite, public-safe, and explicitly bounded.
 - do not add semantic judging, human grading, provider calls, H100/GPU/CUDA/server/remote execution, model inference, production validation, claim expansion, background automation, actual multi-agent execution, or merge automation without separate explicit approval.
 - stop at PR-open unless a separate merge-gate prompt is provided.
 
-Alternative future goals remain a second route-only fixture slice or documentation movement for one small bucket, but only after explicit approval.
+Alternative future goals remain `CIL-003`, a second route-only fixture slice, or documentation movement for one small bucket, but only after explicit approval.
 
 Optional docs-navigation movement remains a separate future track only if Albert explicitly approves movement.
 

--- a/REVIEW_HUB.md
+++ b/REVIEW_HUB.md
@@ -2,7 +2,7 @@
 
 Status: current public review and continuation hub.
 
-Last updated by: Group 113.
+Last updated by: Group 114.
 
 ## Project Identity
 
@@ -14,11 +14,11 @@ KRK means KORA Routing Kernel. KRK is the deterministic-first execution routing 
 
 - repository: `https://github.com/Krako-Labs/KORA`
 - public truth branch: `origin/main`
-- active verification branch: `codex/group113-inner-loop-queue-hardening`
-- worktree label: `group113_inner_loop_queue_hardening`
-- branch pushed to: `origin/codex/group113-inner-loop-queue-hardening`
-- open PR: [#265](https://github.com/Krako-Labs/KORA/pull/265)
-- base commit: `11232af9027209c0cfd4ae7a5edee79c91d791d4`
+- active verification branch: `codex/group114-first-run-cli-smoke-validation`
+- worktree label: `group114_first_run_cli_smoke_validation`
+- branch pushed to: pending
+- open PR: pending
+- base commit: `bbc673d256f005201925051310342fa78c4af4d2`
 
 ## Current State Summary
 
@@ -71,7 +71,7 @@ KORA now has a public-safe first-value path and an evidence package that covers:
 - reusable Project Operating System templates, prompts, and adoption standard.
 - validated Project Operating System continuation path for KORA.
 - no repository settings should be changed further without explicit owner approval.
-- current work is Group 113: inner-loop applied review and queue hardening. Documentation movement remains optional only after later explicit Albert approval.
+- current work is Group 114: first-run CLI smoke validation expansion. Documentation movement remains optional only after later explicit Albert approval.
 
 Current status is evidence-centered and local-first. It is not production-readiness evidence.
 
@@ -134,6 +134,7 @@ This is a sufficient recent history backfill, not a complete reconstruction.
 | Group 111 | Added static bounded-local-validation report verification and deterministic failure classification without executing report commands. | [Group 111 validation report control block](docs/reports/group111_validation_report_control_block.md) |
 | Group 112 | Added PR approval packet and report-consistency checks without GitHub API mutation or report-command execution. | [Group 112 PR approval and report consistency](docs/reports/group112_pr_approval_and_report_consistency.md) |
 | Group 113 | Applied the inner-loop tools, added the medium-risk profile-registry checklist, and hardened queue sizing guidance without implementing `CIL-003`. | [Group 113 inner loop applied review and queue hardening](docs/reports/group113_inner_loop_applied_review_queue_hardening.md) |
+| Group 114 | Adds deterministic local first-run CLI smoke validation over existing offline commands without implementing `CIL-003`, publishing packages, or expanding claims. | [Group 114 first-run CLI smoke validation](docs/reports/group114_first_run_cli_smoke_validation.md) |
 
 ## Evidence Index
 
@@ -163,6 +164,9 @@ Generated summaries:
 
 Current reviewer path:
 
+- [Group 114 first-run CLI smoke validation](docs/reports/group114_first_run_cli_smoke_validation.md)
+- [First-run CLI smoke checker](scripts/check_first_run_cli_smoke.py)
+- [First-run CLI smoke tests](tests/test_first_run_cli_smoke.py)
 - [Group 113 inner loop applied review and queue hardening](docs/reports/group113_inner_loop_applied_review_queue_hardening.md)
 - [Codex medium-risk profile registry checklist](docs/context/CODEX_MEDIUM_RISK_PROFILE_REGISTRY_CHECKLIST.md)
 - [Group 112 PR approval and report consistency](docs/reports/group112_pr_approval_and_report_consistency.md)
@@ -518,6 +522,7 @@ Boundary: this is positioning grounded in current examples and evidence. It does
 - Group 111 is static report-control tooling over local bounded-validation JSON; it does not execute report commands, auto-repair, create background automation, call providers, run H100/server work, or prove output quality.
 - Group 112 is approval-packet and report-consistency tooling only; it does not call GitHub APIs, approve PRs, merge PRs, close PRs, create issues, execute report commands, auto-repair, create background automation, call providers, run H100/server work, or prove output quality.
 - Group 113 is operating review and queue hardening only; it does not implement `CIL-003`, change validation profiles, execute report commands, mutate GitHub, create issues, auto-repair, create background automation, call providers, run H100/server work, or prove output quality.
+- Group 114 is local first-run CLI smoke validation only; it does not implement `CIL-003`, change validation profile registries, publish packages, call providers, require network access, run H100/server work, or prove output quality.
 - Output fidelity is deterministic rule-based over public fixtures, not live semantic judging.
 - The deterministic classification example pack is intentionally synthetic and small; broader workload representativeness remains unproven.
 - The KORA Doctor example is synthetic and does not inspect arbitrary repositories or prove diagnostic accuracy.
@@ -537,10 +542,12 @@ Boundary: this is positioning grounded in current examples and evidence. It does
 
 ## Recommended Next Goals
 
-1. Group 114 - Decide whether to explicitly approve `CIL-003` using the medium-risk profile-registry checklist, or defer it.
+1. Group 115 - Consider `CIL-005 - Source-Install Readiness Check`, only after explicit approval.
 2. A second route-only fixture slice, only after explicit approval.
 3. Semantic, human, provider, H100, GPU, server, remote, or production-like validation only after separate explicit approval.
 4. Optional documentation movement proposal for one small bucket only after later explicit Albert approval.
+
+`CIL-003` remains deferred unless Albert explicitly approves the medium-risk profile-registry checklist.
 
 ## How To Resume Review
 
@@ -548,7 +555,7 @@ Paste a new Goal with this instruction:
 
 ```text
 Start by reading OPEN_THIS_FIRST.md and REVIEW_HUB.md.
-Use the active branch codex/group113-inner-loop-queue-hardening for the current Group 113 review packet, or create a new scoped branch from origin/main for a new Group after Group 113 is merged.
+Use the active branch codex/group114-first-run-cli-smoke-validation for the current Group 114 review packet, or create a new scoped branch from origin/main for a new Group after Group 114 is merged.
 Keep public/private and claim boundaries from REVIEW_HUB.md.
 Use docs/runbooks/codex_bounded_loop_protocol.md and docs/runbooks/kora_claim_boundary_checklist.md for execution and review gates.
 Use docs/runbooks/long_run_test_loop_protocol.md and docs/runbooks/test_failure_triage_checklist.md for future bounded local test-loop goals.

--- a/REVIEW_HUB.md
+++ b/REVIEW_HUB.md
@@ -16,8 +16,8 @@ KRK means KORA Routing Kernel. KRK is the deterministic-first execution routing 
 - public truth branch: `origin/main`
 - active verification branch: `codex/group114-first-run-cli-smoke-validation`
 - worktree label: `group114_first_run_cli_smoke_validation`
-- branch pushed to: pending
-- open PR: pending
+- branch pushed to: `origin/codex/group114-first-run-cli-smoke-validation`
+- open PR: [#266](https://github.com/Krako-Labs/KORA/pull/266)
 - base commit: `bbc673d256f005201925051310342fa78c4af4d2`
 
 ## Current State Summary

--- a/docs/README.md
+++ b/docs/README.md
@@ -43,6 +43,7 @@ This documentation index is for readers who want more detail than the root [READ
 - [Group 111 validation report control block](reports/group111_validation_report_control_block.md) - static bounded-validation report verifier and failure classifier; does not execute report commands or prove output quality.
 - [Group 112 PR approval and report consistency](reports/group112_pr_approval_and_report_consistency.md) - approval-packet and report-consistency checks; does not mutate GitHub or execute report commands.
 - [Group 113 inner loop applied review and queue hardening](reports/group113_inner_loop_applied_review_queue_hardening.md) - operating review and queue hardening; does not implement `CIL-003` or change validation profiles.
+- [Group 114 first-run CLI smoke validation](reports/group114_first_run_cli_smoke_validation.md) - deterministic local first-run CLI smoke checks over existing offline commands; does not publish packages or prove production readiness.
 - [Goal 096 documentation navigation and archive-bucket proposal](reports/goal096_documentation_navigation_archive_bucket_proposal.md) - proposal-only navigation buckets; no files moved.
 - [Group 097 H100 evidence inventory and gap audit](reports/group097_h100_evidence_inventory_gap_audit.md) - bounded H100 evidence inventory; no new H100 benchmark claim.
 - [Goal 098 controlled CPU/GPU evidence regeneration](reports/goal098_controlled_cpu_gpu_evidence_regeneration.md) - server-run packet with local no-CUDA `not_run` status; no fresh H100 execution claim.
@@ -68,6 +69,7 @@ KORA uses narrow evidence language. Offline examples and reports may describe sa
 - [Codex escalation gates](context/CODEX_ESCALATION_GATES.md)
 - [Codex approval packet](context/CODEX_APPROVAL_PACKET.md)
 - [Codex medium-risk profile registry checklist](context/CODEX_MEDIUM_RISK_PROFILE_REGISTRY_CHECKLIST.md)
+- [First-run CLI smoke checker](../scripts/check_first_run_cli_smoke.py)
 - [Codex multi-agent operating model](context/CODEX_MULTI_AGENT_OPERATING_MODEL.md)
 - [Long-run test loop protocol](runbooks/long_run_test_loop_protocol.md)
 - [Test failure triage checklist](runbooks/test_failure_triage_checklist.md)

--- a/docs/context/CODEX_INNER_LOOP_QUEUE.md
+++ b/docs/context/CODEX_INNER_LOOP_QUEUE.md
@@ -96,14 +96,16 @@ Review friction reduction:
 - title: First-run CLI smoke validation expansion
 - objective: expand local first-run CLI smoke checks using existing offline commands.
 - risk level: medium.
+- expected duration band: `2-4 hr`.
 - allowed files: smoke validation script/tests/report docs/narrow breadcrumbs.
 - forbidden files/actions: no provider calls, no network-dependent smoke tests, no packaging publication, no broad README rewrite.
 - validation commands: focused smoke tests, selected offline CLI commands, markdown links, `git diff --check`, full pytest.
 - repair limits: max loop count 5; max repair attempts per failing subtask 2.
 - expected outputs: smoke checks, tests, report, approval packet.
+- Group 114 status: completed by `codex/group114-first-run-cli-smoke-validation` with a static local-only `first-run-cli-core` smoke profile.
 - stop gates: public install-claim expansion, release/PyPI implication, network dependency.
 - claim boundaries: local source-install readiness only; no published package claim.
-- completion status expected: `needs-cto-review` if public onboarding language changes.
+- completion status expected: `needs-cto-review` because first-run validation can affect public onboarding confidence.
 
 ### CIL-005 - Source-Install Readiness Check
 

--- a/docs/context/NEXT_GOAL_QUEUE.md
+++ b/docs/context/NEXT_GOAL_QUEUE.md
@@ -8,21 +8,23 @@ This queue records likely next KORA work without starting it. It is not an appro
 
 ## Current Recommended Next Goal
 
-1. Group 114 - Decide whether to explicitly approve `CIL-003` using the medium-risk profile-registry checklist, or defer it.
+1. Group 115 - Consider `CIL-005 - Source-Install Readiness Check`, only after explicit approval.
 
 Suggested scope:
 
 - use the Goal 104 runbooks and `AGENTS.md` as the execution checklist.
 - verify the goal envelope, base SHA, KORA identity, and clean worktree.
+- review [Group 114 first-run CLI smoke validation](../reports/group114_first_run_cli_smoke_validation.md).
 - review [Group 113 inner loop applied review and queue hardening](../reports/group113_inner_loop_applied_review_queue_hardening.md).
 - review [Codex medium-risk profile registry checklist](CODEX_MEDIUM_RISK_PROFILE_REGISTRY_CHECKLIST.md).
 - review [Group 112 PR approval and report consistency](../reports/group112_pr_approval_and_report_consistency.md).
 - review [Group 111 validation report control block](../reports/group111_validation_report_control_block.md).
 - review [Group 110 Codex inner loop ownership](../reports/group110_codex_inner_loop_ownership.md).
 - review [Codex inner loop queue](CODEX_INNER_LOOP_QUEUE.md).
-- approve `CIL-003` only if the checklist constraints are accepted explicitly.
-- otherwise defer `CIL-003` and choose a lower-risk 2-4 hour operating block later.
-- if approved, expect final classification `needs-cto-review` unless the scope is extremely narrow.
+- keep `CIL-003` deferred unless Albert explicitly approves the medium-risk profile-registry checklist.
+- for `CIL-005`, verify source-install readiness from local repo state without publishing packages.
+- do not claim that `getkora` is published.
+- expect final classification `needs-cto-review` if user-facing install docs or onboarding language change.
 - preserve the requirement that Codex pass is not merge-ready pass.
 - require final classification as `merge-ready`, `needs-r1`, `needs-cto-review`, or `blocked`.
 - do not add semantic judging, human grading, provider calls, H100/GPU/CUDA/server/remote execution, model inference, production validation, claim expansion, background automation, actual multi-agent execution, or merge automation without separate explicit approval.
@@ -78,3 +80,7 @@ Group 110 Codex inner-loop operating guidance does not create production automat
 Group 111 validation report control-block tooling does not execute report commands, auto-repair, create background automation, call providers, run H100/GPU/CUDA/server/remote execution, run model inference, perform semantic judging or human grading, add production validation, prove output quality, or expand claims.
 
 Group 112 approval-packet and report-consistency checks do not call GitHub APIs, approve PRs, merge PRs, close PRs, create issues, execute report commands, auto-repair, create background automation, call providers, run H100/GPU/CUDA/server/remote execution, run model inference, perform semantic judging or human grading, add production validation, prove output quality, or expand claims.
+
+Group 113 queue hardening does not implement `CIL-003`, change validation profiles, execute report commands, call GitHub APIs, mutate PRs, create issues, auto-repair, create background automation, call providers, run H100/GPU/CUDA/server/remote execution, run model inference, perform semantic judging or human grading, add production validation, prove output quality, or expand claims.
+
+Group 114 first-run CLI smoke validation does not implement `CIL-003`, change validation profile registries, publish packages, call providers, require network access, run H100/GPU/CUDA/server/remote execution, run model inference, perform semantic judging or human grading, add production validation, prove output quality, prove broader workload representativeness, or claim that `getkora` is published.

--- a/docs/reports/group114_first_run_cli_smoke_validation.md
+++ b/docs/reports/group114_first_run_cli_smoke_validation.md
@@ -42,7 +42,7 @@ Albert action options: Merge / Request R1 / Stop / CTO Review.
 - base public HEAD: `bbc673d256f005201925051310342fa78c4af4d2`
 - branch: `codex/group114-first-run-cli-smoke-validation`
 - worktree: `/Users/albertkim/02_PROJECTS/05_KORA_Project/worktrees/group114_first_run_cli_smoke_validation`
-- PR: pending
+- PR: https://github.com/Krako-Labs/KORA/pull/266
 
 ## Queue-State Check
 

--- a/docs/reports/group114_first_run_cli_smoke_validation.md
+++ b/docs/reports/group114_first_run_cli_smoke_validation.md
@@ -1,0 +1,197 @@
+# Group 114 First-Run CLI Smoke Validation
+
+Status: implemented with local validation complete; PR open.
+
+## Objective
+
+Group 114 implements `CIL-004 - First-Run CLI Smoke Validation Expansion`.
+
+This group adds a deterministic local first-run CLI smoke checker over existing offline KORA commands, focused tests, and a public-safe report. It does not implement `CIL-003`, change the bounded validation profile registry, change command profiles, publish packages, call providers, run H100/server work, or expand claims.
+
+## Approval Packet
+
+Decision needed: review and decide whether to merge Group 114 first-run CLI smoke validation.
+
+Risk level: medium
+
+Final status classification: `needs-cto-review`
+
+Changed files: first-run CLI smoke checker, focused tests, Group 114 report, inner-loop queue update, next-goal queue update, docs index, and narrow breadcrumbs.
+
+Validation summary: focused smoke tests, dry-run smoke report, real local offline smoke run, Group 113 approval-packet and report-consistency checks, inner-loop docs validation, bounded local validation dry-run/report verifier/classifier, markdown links, whitespace diff check, and full pytest passed.
+
+Repair attempts: 0.
+
+Failures encountered: none.
+
+Self-review summary: scope is deterministic local first-run CLI smoke validation, tests, report, and breadcrumbs; `CIL-004` is completed, `CIL-003` remains deferred, and no validation profile registry implementation was added.
+
+Claim-boundary audit: no output-quality proof, broader workload representativeness proof, production proof, production validation, production cost reduction, customer savings, H100/GPU/CPU superiority, provider replacement, GPU-serving replacement, or published `getkora` claim added.
+
+Forbidden-action audit: no `CIL-003` implementation, validation profile registry change, command profile registry change, dynamic shell loading, external config execution, user command text execution, provider calls, H100/GPU/CUDA/server/remote execution, model inference, semantic judging, human grading, production validation, scheduler, daemon, background runner, GitHub Actions workflow, remote runner, provider-calling runner, H100 runner, self-merging agent, actual multi-agent execution, GitHub API mutation, PR approval, PR merge, PR close, issue creation, project-board update, repository settings change, collaborator change, release, tag, GitHub Release, PyPI publication, raw artifact upload, file movement, local-only ChatGPT context change, or claim expansion added.
+
+Uncertainty notes: this group touches the local first-run validation surface, so it is classified as medium risk and `needs-cto-review` even though the implementation is deterministic and local-only.
+
+Codex recommendation: CTO Review.
+
+Albert action options: Merge / Request R1 / Stop / CTO Review.
+
+## Base And Branch
+
+- public truth: `origin/main`
+- base public HEAD: `bbc673d256f005201925051310342fa78c4af4d2`
+- branch: `codex/group114-first-run-cli-smoke-validation`
+- worktree: `/Users/albertkim/02_PROJECTS/05_KORA_Project/worktrees/group114_first_run_cli_smoke_validation`
+- PR: pending
+
+## Queue-State Check
+
+- `CIL-001`: completed by Group 111.
+- `CIL-002`: completed by Group 111.
+- `CIL-003`: remains deferred and was not run in Group 114.
+- `CIL-004`: completed by Group 114.
+- `CIL-005`: remains pending and separately approval-gated.
+- `CIL-006`: completed by Group 112.
+- `CIL-007`: completed by Group 112.
+
+## Implementation Summary
+
+Added `scripts/check_first_run_cli_smoke.py`.
+
+The checker supports one default profile:
+
+- `first-run-cli-core`
+
+It records:
+
+- command label.
+- structured argv list.
+- status: `passed`, `failed`, or `planned`.
+- return code.
+- elapsed seconds.
+- stdout tail.
+- stderr tail.
+- aggregate totals.
+- final status.
+
+The checker uses static in-repo command definitions and executes subprocesses with `shell=False`. Unknown profiles fail closed with a nonzero exit code. Dry-run mode reports planned commands without executing subprocesses. By default, execution stops on the first failure. `--continue-on-failure` is available for explicit local diagnostics.
+
+Optional report outputs:
+
+- `--json-out`
+- `--md-out`
+
+The script does not load commands from external configuration, accept arbitrary user command text, call providers, require network access, run H100/GPU/server/remote execution, or mutate repository files during normal reporting except for explicit output paths supplied by the caller.
+
+## Smoke Command List
+
+The `first-run-cli-core` profile runs these existing offline commands:
+
+| Order | Command |
+| --- | --- |
+| 1 | `python3 -m kora doctor examples/kora_doctor/customer_support_workload.json` |
+| 2 | `python3 -m kora doctor --all examples/kora_doctor/` |
+| 3 | `python3 -m kora proxy-demo examples/openai_compatible_proxy/requests.json` |
+| 4 | `python3 examples/deterministic_classification/run.py` |
+| 5 | `python3 examples/cache_reuse/run.py` |
+| 6 | `python3 examples/rag_routing/run.py` |
+| 7 | `python3 examples/agent_workflow_optimization/run.py` |
+
+## Real Smoke Result
+
+Observed real local smoke result:
+
+- profile: `first-run-cli-core`
+- final status: `passed`
+- total commands: `7`
+- passed commands: `7`
+- failed commands: `0`
+- planned commands: `0`
+
+Observed dry-run smoke result:
+
+- profile: `first-run-cli-core`
+- final status: `planned`
+- total commands: `7`
+- planned commands: `7`
+- passed commands: `0`
+- failed commands: `0`
+
+These results are local first-run smoke validation only. They do not prove output quality, production readiness, production workload handling, production cost reduction, broader workload representativeness, provider replacement, or published package availability.
+
+## Files Added
+
+- `scripts/check_first_run_cli_smoke.py`
+- `tests/test_first_run_cli_smoke.py`
+- `docs/reports/group114_first_run_cli_smoke_validation.md`
+
+## Files Updated
+
+- `OPEN_THIS_FIRST.md`
+- `REVIEW_HUB.md`
+- `docs/README.md`
+- `docs/context/CODEX_INNER_LOOP_QUEUE.md`
+- `docs/context/NEXT_GOAL_QUEUE.md`
+
+## Validation Results
+
+Final validation before PR open:
+
+| Command | Result |
+| --- | --- |
+| `python3 -m pytest tests/test_first_run_cli_smoke.py` | passed, `13 passed` |
+| `python3 scripts/check_first_run_cli_smoke.py --profile first-run-cli-core --dry-run --json-out /tmp/kora-group114-smoke-dry-run.json --md-out /tmp/kora-group114-smoke-dry-run.md` | passed; reported 7 planned commands |
+| `python3 scripts/check_first_run_cli_smoke.py --profile first-run-cli-core --json-out /tmp/kora-group114-smoke.json --md-out /tmp/kora-group114-smoke.md` | passed; reported 7 passed commands |
+| `python3 scripts/check_pr_approval_packet.py docs/reports/group113_inner_loop_applied_review_queue_hardening.md` | passed |
+| `python3 scripts/check_report_consistency.py docs/reports/group113_inner_loop_applied_review_queue_hardening.md --breadcrumb OPEN_THIS_FIRST.md --breadcrumb REVIEW_HUB.md` | passed |
+| `python3 scripts/validate_codex_inner_loop_docs.py` | passed |
+| `python3 scripts/run_bounded_local_validation.py --profile kora-local-core --dry-run --json-out /tmp/kora-group114-bounded-dry-run.json` | passed |
+| `python3 scripts/verify_bounded_local_validation_report.py /tmp/kora-group114-bounded-dry-run.json --profile kora-local-core` | passed |
+| `python3 scripts/classify_bounded_local_validation_failure.py /tmp/kora-group114-bounded-dry-run.json --profile kora-local-core` | passed with `dry_run_only` classification |
+| `python3 scripts/check_markdown_links_goal082b.py` | passed |
+| `git diff --check` | passed |
+| `python3 -m pytest` | passed, `487 passed` |
+
+Expected full-suite baseline after Group 113 was `474 passed`; Group 114 observed `487 passed` after adding 13 first-run smoke tests.
+
+## Loop Count And Repairs
+
+- loop count: 1
+- repair attempts: 0
+- max loop count: 5
+- max repair attempts per failing subtask: 2
+
+## Risk And Final Classification
+
+- risk level: medium
+- final status classification: `needs-cto-review`
+
+Rationale: this group is deterministic, local-only tooling plus tests and docs, but it touches the first-run validation surface and may influence public onboarding confidence. It does not change README claims or package publication state.
+
+## Self-Review
+
+- changed files match the approved `CIL-004` smoke checker, tests, report, queue, docs index, and breadcrumb scope.
+- `CIL-004` is completed.
+- `CIL-003` remains deferred and was not implemented.
+- no validation profile registry code changed.
+- no command profile registry changed.
+- no dynamic shell loading was added.
+- no external config execution was added.
+- no user-provided command text execution was added.
+- no `shell=True` execution was added.
+- no local-only ChatGPT context changed.
+- no GitHub API mutation was added.
+- no PR close, approval, merge, issue creation, project-board update, repository settings change, or collaborator change was added.
+- no auto-repair, scheduler, daemon, background runner, GitHub Actions workflow, remote runner, provider-calling runner, H100 runner, self-merging agent, or actual multi-agent execution was added.
+- no provider calls, H100/GPU/CUDA/server/remote execution, model inference, semantic judging, human grading, production validation, output-quality proof, broader workload representativeness proof, production proof, or claim expansion was added.
+- no release, tag, GitHub Release, PyPI publication, raw artifact upload, file move, rename, archive, or delete was performed.
+
+## Next Recommendation
+
+Recommended next action: review Group 114. After merge, consider `CIL-005 - Source-Install Readiness Check` only after explicit approval.
+
+`CIL-003` remains deferred until Albert explicitly approves the medium-risk profile-registry checklist. Do not treat Group 114 as approval to implement `CIL-003`.
+
+## Claim Boundary Reminder
+
+Group 114 validates a local offline first-run smoke path only. It does not prove output quality, broader workload representativeness, production workload handling, production readiness, production validation, production cost reduction, H100/GPU/CPU superiority, customer savings, provider replacement, GPU-serving replacement, or published `getkora`.

--- a/scripts/check_first_run_cli_smoke.py
+++ b/scripts/check_first_run_cli_smoke.py
@@ -1,0 +1,275 @@
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable, Sequence
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+OUTPUT_TAIL_LIMIT = 2000
+
+
+@dataclass(frozen=True)
+class SmokeCommand:
+    label: str
+    argv: list[str]
+
+
+SMOKE_PROFILES: dict[str, list[SmokeCommand]] = {
+    "first-run-cli-core": [
+        SmokeCommand(
+            label="kora doctor single workload",
+            argv=[
+                "python3",
+                "-m",
+                "kora",
+                "doctor",
+                "examples/kora_doctor/customer_support_workload.json",
+            ],
+        ),
+        SmokeCommand(
+            label="kora doctor aggregate workloads",
+            argv=["python3", "-m", "kora", "doctor", "--all", "examples/kora_doctor/"],
+        ),
+        SmokeCommand(
+            label="kora proxy demo",
+            argv=[
+                "python3",
+                "-m",
+                "kora",
+                "proxy-demo",
+                "examples/openai_compatible_proxy/requests.json",
+            ],
+        ),
+        SmokeCommand(
+            label="deterministic classification example",
+            argv=["python3", "examples/deterministic_classification/run.py"],
+        ),
+        SmokeCommand(
+            label="cache reuse example",
+            argv=["python3", "examples/cache_reuse/run.py"],
+        ),
+        SmokeCommand(
+            label="rag routing example",
+            argv=["python3", "examples/rag_routing/run.py"],
+        ),
+        SmokeCommand(
+            label="agent workflow optimization example",
+            argv=["python3", "examples/agent_workflow_optimization/run.py"],
+        ),
+    ],
+}
+
+
+Runner = Callable[..., subprocess.CompletedProcess[str]]
+
+
+def _tail_text(value: str | None) -> str:
+    if not value:
+        return ""
+    if len(value) <= OUTPUT_TAIL_LIMIT:
+        return value
+    return value[-OUTPUT_TAIL_LIMIT:]
+
+
+def _command_record(
+    command: SmokeCommand,
+    status: str,
+    return_code: int | None,
+    elapsed_seconds: float,
+    stdout: str = "",
+    stderr: str = "",
+) -> dict[str, Any]:
+    return {
+        "label": command.label,
+        "argv": list(command.argv),
+        "status": status,
+        "return_code": return_code,
+        "elapsed_seconds": round(elapsed_seconds, 3),
+        "stdout_tail": _tail_text(stdout),
+        "stderr_tail": _tail_text(stderr),
+    }
+
+
+def _summary(records: Sequence[dict[str, Any]]) -> dict[str, Any]:
+    planned = sum(1 for record in records if record["status"] == "planned")
+    passed = sum(1 for record in records if record["status"] == "passed")
+    failed = sum(1 for record in records if record["status"] == "failed")
+    if failed:
+        final_status = "failed"
+    elif planned:
+        final_status = "planned"
+    else:
+        final_status = "passed"
+    return {
+        "total_commands": len(records),
+        "planned_commands": planned,
+        "passed_commands": passed,
+        "failed_commands": failed,
+        "final_status": final_status,
+    }
+
+
+def build_report(
+    profile: str,
+    *,
+    dry_run: bool = False,
+    continue_on_failure: bool = False,
+    runner: Runner = subprocess.run,
+    clock: Callable[[], float] = time.perf_counter,
+) -> tuple[int, dict[str, Any]]:
+    if profile not in SMOKE_PROFILES:
+        report = {
+            "profile": profile,
+            "repo_root": str(REPO_ROOT),
+            "final_status": "failed",
+            "summary": {
+                "total_commands": 0,
+                "planned_commands": 0,
+                "passed_commands": 0,
+                "failed_commands": 0,
+                "final_status": "failed",
+            },
+            "error": f"unknown profile: {profile}",
+            "supported_profiles": sorted(SMOKE_PROFILES),
+            "commands": [],
+        }
+        return 2, report
+
+    records: list[dict[str, Any]] = []
+    exit_code = 0
+    for command in SMOKE_PROFILES[profile]:
+        if dry_run:
+            records.append(_command_record(command, "planned", None, 0.0))
+            continue
+
+        start = clock()
+        completed = runner(
+            command.argv,
+            cwd=REPO_ROOT,
+            shell=False,
+            check=False,
+            text=True,
+            capture_output=True,
+        )
+        elapsed = clock() - start
+        status = "passed" if completed.returncode == 0 else "failed"
+        records.append(
+            _command_record(
+                command,
+                status,
+                completed.returncode,
+                elapsed,
+                stdout=completed.stdout,
+                stderr=completed.stderr,
+            )
+        )
+        if completed.returncode != 0:
+            exit_code = completed.returncode
+            if not continue_on_failure:
+                break
+
+    summary = _summary(records)
+    report = {
+        "profile": profile,
+        "repo_root": str(REPO_ROOT),
+        "final_status": summary["final_status"],
+        "summary": summary,
+        "commands": records,
+    }
+    return exit_code, report
+
+
+def render_text_summary(report: dict[str, Any]) -> str:
+    lines = [
+        f"profile: {report['profile']}",
+        f"final_status: {report['final_status']}",
+    ]
+    if "error" in report:
+        lines.append(f"error: {report['error']}")
+    for command in report["commands"]:
+        return_code = "not-run" if command["return_code"] is None else str(command["return_code"])
+        lines.append(f"- {command['status']}: {command['label']} ({return_code})")
+    return "\n".join(lines)
+
+
+def render_markdown_report(report: dict[str, Any]) -> str:
+    summary = report["summary"]
+    lines = [
+        "# First-Run CLI Smoke Report",
+        "",
+        f"- profile: `{report['profile']}`",
+        f"- final_status: `{report['final_status']}`",
+        f"- repo_root: `{report['repo_root']}`",
+        f"- total_commands: `{summary['total_commands']}`",
+        f"- planned_commands: `{summary['planned_commands']}`",
+        f"- passed_commands: `{summary['passed_commands']}`",
+        f"- failed_commands: `{summary['failed_commands']}`",
+        "",
+        "## Commands",
+        "",
+        "| Label | Status | Return code | Elapsed seconds | Command |",
+        "| --- | --- | --- | --- | --- |",
+    ]
+    for command in report["commands"]:
+        return_code = "" if command["return_code"] is None else str(command["return_code"])
+        argv = " ".join(command["argv"])
+        lines.append(
+            f"| {command['label']} | `{command['status']}` | `{return_code}` | "
+            f"`{command['elapsed_seconds']}` | `{argv}` |"
+        )
+    if "error" in report:
+        lines.extend(["", f"Error: `{report['error']}`"])
+    return "\n".join(lines) + "\n"
+
+
+def write_reports(report: dict[str, Any], json_out: Path | None, md_out: Path | None) -> None:
+    if json_out is not None:
+        json_out.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    if md_out is not None:
+        md_out.write_text(render_markdown_report(report), encoding="utf-8")
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Run approved local first-run KORA CLI smoke checks."
+    )
+    parser.add_argument(
+        "--profile",
+        default="first-run-cli-core",
+        help="Approved smoke profile to run. Defaults to first-run-cli-core.",
+    )
+    parser.add_argument("--dry-run", action="store_true", help="List planned commands without executing them.")
+    parser.add_argument(
+        "--continue-on-failure",
+        action="store_true",
+        help="Continue running remaining smoke commands after a failed command.",
+    )
+    parser.add_argument("--json-out", type=Path, help="Optional path for a structured JSON report.")
+    parser.add_argument("--md-out", type=Path, help="Optional path for a Markdown report.")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    exit_code, report = build_report(
+        args.profile,
+        dry_run=args.dry_run,
+        continue_on_failure=args.continue_on_failure,
+    )
+    write_reports(report, args.json_out, args.md_out)
+
+    if args.json_out is None and args.md_out is None:
+        print(render_text_summary(report))
+    elif exit_code != 0:
+        print(render_text_summary(report))
+
+    return exit_code
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_first_run_cli_smoke.py
+++ b/tests/test_first_run_cli_smoke.py
@@ -1,0 +1,160 @@
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+from scripts import check_first_run_cli_smoke as smoke
+
+
+EXPECTED_COMMANDS = [
+    ["python3", "-m", "kora", "doctor", "examples/kora_doctor/customer_support_workload.json"],
+    ["python3", "-m", "kora", "doctor", "--all", "examples/kora_doctor/"],
+    ["python3", "-m", "kora", "proxy-demo", "examples/openai_compatible_proxy/requests.json"],
+    ["python3", "examples/deterministic_classification/run.py"],
+    ["python3", "examples/cache_reuse/run.py"],
+    ["python3", "examples/rag_routing/run.py"],
+    ["python3", "examples/agent_workflow_optimization/run.py"],
+]
+
+
+def test_default_command_list_includes_expected_offline_commands() -> None:
+    commands = smoke.SMOKE_PROFILES["first-run-cli-core"]
+    assert [command.argv for command in commands] == EXPECTED_COMMANDS
+
+
+def test_command_records_use_structured_argv_lists() -> None:
+    _, report = smoke.build_report("first-run-cli-core", dry_run=True)
+    for command in report["commands"]:
+        assert isinstance(command["argv"], list)
+        assert all(isinstance(part, str) for part in command["argv"])
+
+
+def test_dry_run_does_not_execute_subprocess_commands() -> None:
+    def forbidden_runner(*args: object, **kwargs: object) -> subprocess.CompletedProcess[str]:
+        raise AssertionError("dry-run must not execute subprocess commands")
+
+    exit_code, report = smoke.build_report(
+        "first-run-cli-core",
+        dry_run=True,
+        runner=forbidden_runner,
+    )
+
+    assert exit_code == 0
+    assert report["final_status"] == "planned"
+    assert report["summary"]["planned_commands"] == len(EXPECTED_COMMANDS)
+
+
+def test_unknown_profile_fails_closed() -> None:
+    exit_code, report = smoke.build_report("unknown-profile")
+    assert exit_code == 2
+    assert report["final_status"] == "failed"
+    assert report["commands"] == []
+    assert "first-run-cli-core" in report["supported_profiles"]
+
+
+def test_json_output_works(tmp_path: Path) -> None:
+    json_out = tmp_path / "smoke.json"
+    exit_code = smoke.main(["--dry-run", "--json-out", str(json_out)])
+
+    assert exit_code == 0
+    saved = json.loads(json_out.read_text(encoding="utf-8"))
+    assert saved["profile"] == "first-run-cli-core"
+    assert saved["summary"]["total_commands"] == len(EXPECTED_COMMANDS)
+
+
+def test_markdown_output_works(tmp_path: Path) -> None:
+    md_out = tmp_path / "smoke.md"
+    exit_code = smoke.main(["--dry-run", "--md-out", str(md_out)])
+
+    assert exit_code == 0
+    text = md_out.read_text(encoding="utf-8")
+    assert "# First-Run CLI Smoke Report" in text
+    assert "kora doctor single workload" in text
+
+
+def test_failure_result_returns_nonzero_and_stops_by_default() -> None:
+    calls: list[list[str]] = []
+
+    def failing_runner(argv: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
+        calls.append(argv)
+        return subprocess.CompletedProcess(argv, 7, stdout="bad", stderr="failed")
+
+    exit_code, report = smoke.build_report("first-run-cli-core", runner=failing_runner)
+
+    assert exit_code == 7
+    assert report["final_status"] == "failed"
+    assert len(calls) == 1
+    assert report["commands"][0]["status"] == "failed"
+    assert report["commands"][0]["stderr_tail"] == "failed"
+
+
+def test_continue_on_failure_runs_remaining_commands() -> None:
+    calls: list[list[str]] = []
+
+    def failing_runner(argv: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
+        calls.append(argv)
+        return subprocess.CompletedProcess(argv, 1, stdout="", stderr="")
+
+    exit_code, report = smoke.build_report(
+        "first-run-cli-core",
+        runner=failing_runner,
+        continue_on_failure=True,
+    )
+
+    assert exit_code == 1
+    assert len(calls) == len(EXPECTED_COMMANDS)
+    assert report["summary"]["failed_commands"] == len(EXPECTED_COMMANDS)
+
+
+def test_success_result_returns_zero() -> None:
+    def passing_runner(argv: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
+        return subprocess.CompletedProcess(argv, 0, stdout="ok", stderr="")
+
+    exit_code, report = smoke.build_report("first-run-cli-core", runner=passing_runner)
+
+    assert exit_code == 0
+    assert report["final_status"] == "passed"
+    assert report["summary"]["passed_commands"] == len(EXPECTED_COMMANDS)
+
+
+def test_runner_invocation_uses_shell_false() -> None:
+    seen_kwargs: list[dict[str, object]] = []
+
+    def passing_runner(argv: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
+        seen_kwargs.append(kwargs)
+        return subprocess.CompletedProcess(argv, 0, stdout="", stderr="")
+
+    smoke.build_report("first-run-cli-core", runner=passing_runner)
+
+    assert seen_kwargs
+    assert all(kwargs["shell"] is False for kwargs in seen_kwargs)
+
+
+def test_script_source_does_not_use_shell_true_or_external_command_config() -> None:
+    source = Path(smoke.__file__).read_text(encoding="utf-8")
+    assert "shell=True" not in source
+    assert "yaml" not in source
+    assert "tomllib" not in source
+    assert "config" not in source.lower()
+
+
+def test_output_paths_are_optional(capsys) -> None:
+    exit_code = smoke.main(["--dry-run"])
+
+    captured = capsys.readouterr()
+    assert exit_code == 0
+    assert "final_status: planned" in captured.out
+
+
+def test_script_does_not_mutate_repo_files_during_tests(tmp_path: Path) -> None:
+    before = {path.name for path in smoke.REPO_ROOT.iterdir()}
+    json_out = tmp_path / "smoke.json"
+    md_out = tmp_path / "smoke.md"
+
+    smoke.main(["--dry-run", "--json-out", str(json_out), "--md-out", str(md_out)])
+
+    after = {path.name for path in smoke.REPO_ROOT.iterdir()}
+    assert after == before
+    assert json_out.exists()
+    assert md_out.exists()


### PR DESCRIPTION
## Summary

- Adds `scripts/check_first_run_cli_smoke.py` for deterministic local first-run CLI smoke validation.
- Adds focused tests for dry-run behavior, static argv command records, output reports, failure handling, success handling, `shell=False`, and no external command config.
- Updates Group 114 report, CIL queue state, docs index, next-goal queue, and breadcrumbs.

## Validation

- `python3 -m pytest tests/test_first_run_cli_smoke.py` - passed, `13 passed`
- `python3 scripts/check_first_run_cli_smoke.py --profile first-run-cli-core --dry-run --json-out /tmp/kora-group114-smoke-dry-run.json --md-out /tmp/kora-group114-smoke-dry-run.md` - passed
- `python3 scripts/check_first_run_cli_smoke.py --profile first-run-cli-core --json-out /tmp/kora-group114-smoke.json --md-out /tmp/kora-group114-smoke.md` - passed, 7 commands passed
- `python3 scripts/check_pr_approval_packet.py docs/reports/group113_inner_loop_applied_review_queue_hardening.md` - passed
- `python3 scripts/check_report_consistency.py docs/reports/group113_inner_loop_applied_review_queue_hardening.md --breadcrumb OPEN_THIS_FIRST.md --breadcrumb REVIEW_HUB.md` - passed
- `python3 scripts/validate_codex_inner_loop_docs.py` - passed
- `python3 scripts/run_bounded_local_validation.py --profile kora-local-core --dry-run --json-out /tmp/kora-group114-bounded-dry-run.json` - passed
- `python3 scripts/verify_bounded_local_validation_report.py /tmp/kora-group114-bounded-dry-run.json --profile kora-local-core` - passed
- `python3 scripts/classify_bounded_local_validation_failure.py /tmp/kora-group114-bounded-dry-run.json --profile kora-local-core` - passed with `dry_run_only`
- `python3 scripts/check_markdown_links_goal082b.py` - passed
- `git diff --check` - passed
- `python3 -m pytest` - passed, `487 passed`

## Boundaries

- Completes `CIL-004`.
- Keeps `CIL-003` deferred.
- No provider calls, H100/GPU/CUDA/server/remote execution, model inference, semantic judging, human grading, production validation, package publication, release, tag, repo settings, issues, project boards, file movement, local-only ChatGPT context changes, or claim expansion.
- Final status classification: `needs-cto-review` because this touches the local first-run validation surface.
