### PR TITLE
Group 115 source-install readiness check

### DIFF
--- a/OPEN_THIS_FIRST.md
+++ b/OPEN_THIS_FIRST.md
@@ -2,7 +2,7 @@
 
 Status: current public project breadcrumb.
 
-Last updated by: Group 114.
+Last updated by: Group 115.
 
 ## Current Status
 
@@ -17,6 +17,7 @@ Current state:
 - baseline equivalence and output-fidelity evidence exists over public fixtures.
 - first-value CLI commands exist and the editable-install path has been revalidated for local public-safe onboarding.
 - packaging strategy now documents the PyPI `kora` collision and the planned future distribution name `getkora`; latest-feature testing remains source-install from the current repository.
+- source-install readiness is now checked by an isolated local temporary-venv checker over the current source tree, import surface, `python -m kora`, `kora` CLI entry point, and no-provider `kora examples list` smoke path.
 - public first-run acceptance testing has been run against the README/source-install path, KORA Doctor, deterministic classification, and PyPI collision wording.
 - an offline OpenAI-compatible proxy example exists under `examples/openai_compatible_proxy/`, showing KORA routing OpenAI-style chat request objects through deterministic handlers, local cache reuse, or provider-needed fallback without provider calls.
 - the OpenAI-style proxy demo routing logic is now reusable from `kora.openai_proxy_demo`, and `python3 -m kora proxy-demo examples/openai_compatible_proxy/requests.json` runs the same offline no-provider-call path from the first-class CLI.
@@ -41,24 +42,27 @@ Current state:
 - `kora doctor` is now a first-class CLI command for running the offline Doctor workload-control report against a workload JSON file or all bundled Doctor workloads.
 - the public README and docs index now position KORA as an AI Workload Control Layer, with examples-first onboarding and explicit claim boundaries.
 - the breadcrumb/review-hub pattern has been extracted into a reusable Project Operating System package and validated on KORA as a continuation surface.
-- current public continuation work is focused on Group 114 first-run CLI smoke validation. Documentation movement remains optional only after later explicit Albert approval.
+- current public continuation work is focused on Group 115 source-install readiness review. Documentation movement remains optional only after later explicit Albert approval.
 
 ## Current Branch
 
-- branch: `codex/group114-first-run-cli-smoke-validation`
+- branch: `codex/group115-source-install-readiness`
 - public truth: `origin/main`
-- branch pushed to: `origin/codex/group114-first-run-cli-smoke-validation`
-- open PR: [#266](https://github.com/Krako-Labs/KORA/pull/266)
-- base commit: `bbc673d256f005201925051310342fa78c4af4d2`
+- branch pushed to: pending PR open
+- open PR: pending PR open
+- base commit: `a3c9db3f54e17e3d0e292bae4ffce56d8c9262bf`
 
 ## Active Goal
 
-Group 114 - First-Run CLI Smoke Validation Expansion.
+Group 115 - Source-Install Readiness Check.
 
-Group 114 implements `CIL-004` by adding a deterministic local first-run CLI smoke checker over existing offline commands, focused tests, and a public-safe report. It does not implement `CIL-003`, change validation profile registries, publish packages, call providers, require network access, run H100/server work, or expand claims.
+Group 115 implements `CIL-005` by adding an isolated local source-install readiness checker over the current source tree, focused tests, and a public-safe report. It does not implement `CIL-003`, change validation profile registries, change command profile registries, publish packages, claim PyPI installation support, claim `getkora` is published, call providers, run H100/server work, or expand claims.
 
 Primary report:
 
+- [Group 115 source-install readiness check](docs/reports/group115_source_install_readiness_check.md)
+- [Source-install readiness checker](scripts/check_source_install_readiness.py)
+- [Source-install readiness tests](tests/test_source_install_readiness.py)
 - [Group 114 first-run CLI smoke validation](docs/reports/group114_first_run_cli_smoke_validation.md)
 - [First-run CLI smoke checker](scripts/check_first_run_cli_smoke.py)
 - [First-run CLI smoke tests](tests/test_first_run_cli_smoke.py)
@@ -125,6 +129,8 @@ Current caveat: Group 112 validates approval-packet and report/breadcrumb consis
 Current caveat: Group 113 is operating review and queue hardening only. It does not implement `CIL-003`, change validation profiles, execute report commands, call GitHub APIs, mutate PRs, create issues, auto-repair, create background automation, call providers, run H100/GPU/CUDA/server/remote execution, run model inference, perform semantic judging or human grading, add production validation, or prove output quality.
 
 Current caveat: Group 114 is local first-run CLI smoke validation only. It does not implement `CIL-003`, change validation profile registries, publish packages, call providers, require network access, run H100/GPU/CUDA/server/remote execution, run model inference, perform semantic judging or human grading, add production validation, prove output quality, prove broader workload representativeness, or claim that `getkora` is published.
+
+Current caveat: Group 115 is local source-install readiness only. It does not implement `CIL-003`, change validation profile registries, change command profile registries, check PyPI installation, publish packages, create releases or tags, claim `getkora` is published, claim install-from-PyPI support, call providers, require H100/GPU/CUDA/server/remote execution, run model inference, perform semantic judging or human grading, add production validation, prove output quality, prove broader workload representativeness, or expand claims.
 
 ## Last Completed Goal
 
@@ -669,13 +675,14 @@ KORA makes AI workloads routable. The current KRK public alpha shows how workloa
 
 ## Recommended Next Goal
 
-Group 115 - Consider `CIL-005 - Source-Install Readiness Check`, only after explicit approval.
+Review Group 115 - `CIL-005 - Source-Install Readiness Check`.
 
 Recommended scope:
 
-- use the Goal 104 runbooks as the execution checklist.
-- verify the goal envelope, base SHA, KORA identity, and clean worktree.
-- review [Group 114 first-run CLI smoke validation](docs/reports/group114_first_run_cli_smoke_validation.md).
+- review [Group 115 source-install readiness check](docs/reports/group115_source_install_readiness_check.md).
+- review [Source-install readiness checker](scripts/check_source_install_readiness.py).
+- review [Source-install readiness tests](tests/test_source_install_readiness.py).
+- verify the real local source-install readiness result if needed with `python3 scripts/check_source_install_readiness.py`.
 - review [Group 113 inner loop applied review and queue hardening](docs/reports/group113_inner_loop_applied_review_queue_hardening.md).
 - review [Codex medium-risk profile registry checklist](docs/context/CODEX_MEDIUM_RISK_PROFILE_REGISTRY_CHECKLIST.md).
 - review [Group 112 PR approval and report consistency](docs/reports/group112_pr_approval_and_report_consistency.md).
@@ -683,8 +690,7 @@ Recommended scope:
 - review [Group 110 Codex inner loop ownership](docs/reports/group110_codex_inner_loop_ownership.md).
 - review [Codex inner loop queue](docs/context/CODEX_INNER_LOOP_QUEUE.md).
 - keep `CIL-003` deferred unless Albert explicitly approves the medium-risk profile-registry checklist.
-- verify source-install readiness from local repo state without publishing packages.
-- do not claim that `getkora` is published.
+- confirm the report keeps the local source-install boundary and does not claim that `getkora` is published.
 - expect final classification `needs-cto-review` if user-facing install docs or onboarding language change.
 - preserve the requirement that Codex pass is not merge-ready pass.
 - run the claim-boundary checklist before PR-open.

--- a/OPEN_THIS_FIRST.md
+++ b/OPEN_THIS_FIRST.md
@@ -48,8 +48,8 @@ Current state:
 
 - branch: `codex/group115-source-install-readiness`
 - public truth: `origin/main`
-- branch pushed to: pending PR open
-- open PR: pending PR open
+- branch pushed to: `origin/codex/group115-source-install-readiness`
+- open PR: [#267](https://github.com/Krako-Labs/KORA/pull/267)
 - base commit: `a3c9db3f54e17e3d0e292bae4ffce56d8c9262bf`
 
 ## Active Goal

--- a/REVIEW_HUB.md
+++ b/REVIEW_HUB.md
@@ -2,7 +2,7 @@
 
 Status: current public review and continuation hub.
 
-Last updated by: Group 114.
+Last updated by: Group 115.
 
 ## Project Identity
 
@@ -14,11 +14,11 @@ KRK means KORA Routing Kernel. KRK is the deterministic-first execution routing 
 
 - repository: `https://github.com/Krako-Labs/KORA`
 - public truth branch: `origin/main`
-- active verification branch: `codex/group114-first-run-cli-smoke-validation`
-- worktree label: `group114_first_run_cli_smoke_validation`
-- branch pushed to: `origin/codex/group114-first-run-cli-smoke-validation`
-- open PR: [#266](https://github.com/Krako-Labs/KORA/pull/266)
-- base commit: `bbc673d256f005201925051310342fa78c4af4d2`
+- active verification branch: `codex/group115-source-install-readiness`
+- worktree label: `group115_source_install_readiness`
+- branch pushed to: pending PR open
+- open PR: pending PR open
+- base commit: `a3c9db3f54e17e3d0e292bae4ffce56d8c9262bf`
 
 ## Current State Summary
 
@@ -33,6 +33,7 @@ KORA now has a public-safe first-value path and an evidence package that covers:
 - expanded H100 representativeness measurement.
 - baseline equivalence and output-fidelity evaluation.
 - install-revalidated local first-value CLI workflow.
+- isolated local source-install readiness checking over editable install, import, module CLI, console script, and no-provider `kora examples list` smoke path.
 - distribution strategy documents PyPI `kora` collision, source-install current path, and planned future PyPI distribution name `getkora`.
 - public first-run acceptance testing covers README-only onboarding, fresh source install, KORA Doctor, deterministic classification, and PyPI collision wording.
 - OpenAI-compatible proxy example with offline OpenAI-style chat request fixtures, KORA deterministic routing, local cache reuse, provider-needed fallback labels, and `0` provider calls.
@@ -71,7 +72,7 @@ KORA now has a public-safe first-value path and an evidence package that covers:
 - reusable Project Operating System templates, prompts, and adoption standard.
 - validated Project Operating System continuation path for KORA.
 - no repository settings should be changed further without explicit owner approval.
-- current work is Group 114: first-run CLI smoke validation expansion. Documentation movement remains optional only after later explicit Albert approval.
+- current work is Group 115: source-install readiness checking. Documentation movement remains optional only after later explicit Albert approval.
 
 Current status is evidence-centered and local-first. It is not production-readiness evidence.
 
@@ -135,6 +136,7 @@ This is a sufficient recent history backfill, not a complete reconstruction.
 | Group 112 | Added PR approval packet and report-consistency checks without GitHub API mutation or report-command execution. | [Group 112 PR approval and report consistency](docs/reports/group112_pr_approval_and_report_consistency.md) |
 | Group 113 | Applied the inner-loop tools, added the medium-risk profile-registry checklist, and hardened queue sizing guidance without implementing `CIL-003`. | [Group 113 inner loop applied review and queue hardening](docs/reports/group113_inner_loop_applied_review_queue_hardening.md) |
 | Group 114 | Adds deterministic local first-run CLI smoke validation over existing offline commands without implementing `CIL-003`, publishing packages, or expanding claims. | [Group 114 first-run CLI smoke validation](docs/reports/group114_first_run_cli_smoke_validation.md) |
+| Group 115 | Adds isolated local source-install readiness checking without checking PyPI, publishing packages, claiming `getkora` is published, or expanding claims. | [Group 115 source-install readiness check](docs/reports/group115_source_install_readiness_check.md) |
 
 ## Evidence Index
 
@@ -164,6 +166,9 @@ Generated summaries:
 
 Current reviewer path:
 
+- [Group 115 source-install readiness check](docs/reports/group115_source_install_readiness_check.md)
+- [Source-install readiness checker](scripts/check_source_install_readiness.py)
+- [Source-install readiness tests](tests/test_source_install_readiness.py)
 - [Group 114 first-run CLI smoke validation](docs/reports/group114_first_run_cli_smoke_validation.md)
 - [First-run CLI smoke checker](scripts/check_first_run_cli_smoke.py)
 - [First-run CLI smoke tests](tests/test_first_run_cli_smoke.py)
@@ -523,6 +528,7 @@ Boundary: this is positioning grounded in current examples and evidence. It does
 - Group 112 is approval-packet and report-consistency tooling only; it does not call GitHub APIs, approve PRs, merge PRs, close PRs, create issues, execute report commands, auto-repair, create background automation, call providers, run H100/server work, or prove output quality.
 - Group 113 is operating review and queue hardening only; it does not implement `CIL-003`, change validation profiles, execute report commands, mutate GitHub, create issues, auto-repair, create background automation, call providers, run H100/server work, or prove output quality.
 - Group 114 is local first-run CLI smoke validation only; it does not implement `CIL-003`, change validation profile registries, publish packages, call providers, require network access, run H100/server work, or prove output quality.
+- Group 115 is local source-install readiness only; it does not implement `CIL-003`, change validation profile registries, change command profile registries, check PyPI installation, publish packages, claim `getkora` is published, claim install-from-PyPI support, call providers, run H100/server work, or prove output quality.
 - Output fidelity is deterministic rule-based over public fixtures, not live semantic judging.
 - The deterministic classification example pack is intentionally synthetic and small; broader workload representativeness remains unproven.
 - The KORA Doctor example is synthetic and does not inspect arbitrary repositories or prove diagnostic accuracy.
@@ -542,7 +548,7 @@ Boundary: this is positioning grounded in current examples and evidence. It does
 
 ## Recommended Next Goals
 
-1. Group 115 - Consider `CIL-005 - Source-Install Readiness Check`, only after explicit approval.
+1. Review Group 115 - `CIL-005 - Source-Install Readiness Check`.
 2. A second route-only fixture slice, only after explicit approval.
 3. Semantic, human, provider, H100, GPU, server, remote, or production-like validation only after separate explicit approval.
 4. Optional documentation movement proposal for one small bucket only after later explicit Albert approval.
@@ -555,7 +561,7 @@ Paste a new Goal with this instruction:
 
 ```text
 Start by reading OPEN_THIS_FIRST.md and REVIEW_HUB.md.
-Use the active branch codex/group114-first-run-cli-smoke-validation for the current Group 114 review packet, or create a new scoped branch from origin/main for a new Group after Group 114 is merged.
+Use the active branch codex/group115-source-install-readiness for the current Group 115 review packet, or create a new scoped branch from origin/main for a new Group after Group 115 is merged.
 Keep public/private and claim boundaries from REVIEW_HUB.md.
 Use docs/runbooks/codex_bounded_loop_protocol.md and docs/runbooks/kora_claim_boundary_checklist.md for execution and review gates.
 Use docs/runbooks/long_run_test_loop_protocol.md and docs/runbooks/test_failure_triage_checklist.md for future bounded local test-loop goals.

--- a/REVIEW_HUB.md
+++ b/REVIEW_HUB.md
@@ -16,8 +16,8 @@ KRK means KORA Routing Kernel. KRK is the deterministic-first execution routing 
 - public truth branch: `origin/main`
 - active verification branch: `codex/group115-source-install-readiness`
 - worktree label: `group115_source_install_readiness`
-- branch pushed to: pending PR open
-- open PR: pending PR open
+- branch pushed to: `origin/codex/group115-source-install-readiness`
+- open PR: [#267](https://github.com/Krako-Labs/KORA/pull/267)
 - base commit: `a3c9db3f54e17e3d0e292bae4ffce56d8c9262bf`
 
 ## Current State Summary

--- a/docs/README.md
+++ b/docs/README.md
@@ -44,6 +44,7 @@ This documentation index is for readers who want more detail than the root [READ
 - [Group 112 PR approval and report consistency](reports/group112_pr_approval_and_report_consistency.md) - approval-packet and report-consistency checks; does not mutate GitHub or execute report commands.
 - [Group 113 inner loop applied review and queue hardening](reports/group113_inner_loop_applied_review_queue_hardening.md) - operating review and queue hardening; does not implement `CIL-003` or change validation profiles.
 - [Group 114 first-run CLI smoke validation](reports/group114_first_run_cli_smoke_validation.md) - deterministic local first-run CLI smoke checks over existing offline commands; does not publish packages or prove production readiness.
+- [Group 115 source-install readiness check](reports/group115_source_install_readiness_check.md) - isolated local source-install readiness checking; does not check PyPI, publish packages, or claim `getkora` is published.
 - [Goal 096 documentation navigation and archive-bucket proposal](reports/goal096_documentation_navigation_archive_bucket_proposal.md) - proposal-only navigation buckets; no files moved.
 - [Group 097 H100 evidence inventory and gap audit](reports/group097_h100_evidence_inventory_gap_audit.md) - bounded H100 evidence inventory; no new H100 benchmark claim.
 - [Goal 098 controlled CPU/GPU evidence regeneration](reports/goal098_controlled_cpu_gpu_evidence_regeneration.md) - server-run packet with local no-CUDA `not_run` status; no fresh H100 execution claim.
@@ -69,6 +70,7 @@ KORA uses narrow evidence language. Offline examples and reports may describe sa
 - [Codex escalation gates](context/CODEX_ESCALATION_GATES.md)
 - [Codex approval packet](context/CODEX_APPROVAL_PACKET.md)
 - [Codex medium-risk profile registry checklist](context/CODEX_MEDIUM_RISK_PROFILE_REGISTRY_CHECKLIST.md)
+- [Source-install readiness checker](../scripts/check_source_install_readiness.py)
 - [First-run CLI smoke checker](../scripts/check_first_run_cli_smoke.py)
 - [Codex multi-agent operating model](context/CODEX_MULTI_AGENT_OPERATING_MODEL.md)
 - [Long-run test loop protocol](runbooks/long_run_test_loop_protocol.md)

--- a/docs/context/CODEX_INNER_LOOP_QUEUE.md
+++ b/docs/context/CODEX_INNER_LOOP_QUEUE.md
@@ -118,6 +118,7 @@ Review friction reduction:
 - validation commands: focused readiness tests, source-install smoke in local environment if approved by prompt, markdown links, `git diff --check`, full pytest.
 - repair limits: max loop count 5; max repair attempts per failing subtask 2.
 - expected outputs: readiness checker, report, approval packet.
+- Group 115 status: completed by `codex/group115-source-install-readiness` with an isolated local temporary-venv checker over editable source install, import, module CLI, console script, and no-provider command smoke.
 - stop gates: package publication, external index upload, claim that `getkora` is published.
 - claim boundaries: local source-install readiness only; no release or publication claim.
 - completion status expected: `needs-cto-review` if user-facing install docs change.

--- a/docs/context/NEXT_GOAL_QUEUE.md
+++ b/docs/context/NEXT_GOAL_QUEUE.md
@@ -8,12 +8,16 @@ This queue records likely next KORA work without starting it. It is not an appro
 
 ## Current Recommended Next Goal
 
-1. Group 115 - Consider `CIL-005 - Source-Install Readiness Check`, only after explicit approval.
+1. Review Group 115 - `CIL-005 - Source-Install Readiness Check`.
 
 Suggested scope:
 
 - use the Goal 104 runbooks and `AGENTS.md` as the execution checklist.
 - verify the goal envelope, base SHA, KORA identity, and clean worktree.
+- review [Group 115 source-install readiness check](../reports/group115_source_install_readiness_check.md).
+- review [Source-install readiness checker](../../scripts/check_source_install_readiness.py).
+- review [Source-install readiness tests](../../tests/test_source_install_readiness.py).
+- rerun `python3 scripts/check_source_install_readiness.py` if reviewer wants to reproduce the isolated local source-install check.
 - review [Group 114 first-run CLI smoke validation](../reports/group114_first_run_cli_smoke_validation.md).
 - review [Group 113 inner loop applied review and queue hardening](../reports/group113_inner_loop_applied_review_queue_hardening.md).
 - review [Codex medium-risk profile registry checklist](CODEX_MEDIUM_RISK_PROFILE_REGISTRY_CHECKLIST.md).
@@ -22,8 +26,7 @@ Suggested scope:
 - review [Group 110 Codex inner loop ownership](../reports/group110_codex_inner_loop_ownership.md).
 - review [Codex inner loop queue](CODEX_INNER_LOOP_QUEUE.md).
 - keep `CIL-003` deferred unless Albert explicitly approves the medium-risk profile-registry checklist.
-- for `CIL-005`, verify source-install readiness from local repo state without publishing packages.
-- do not claim that `getkora` is published.
+- confirm `CIL-005` remains local source-install readiness only, without PyPI checks, package publication, or a `getkora` published claim.
 - expect final classification `needs-cto-review` if user-facing install docs or onboarding language change.
 - preserve the requirement that Codex pass is not merge-ready pass.
 - require final classification as `merge-ready`, `needs-r1`, `needs-cto-review`, or `blocked`.
@@ -84,3 +87,5 @@ Group 112 approval-packet and report-consistency checks do not call GitHub APIs,
 Group 113 queue hardening does not implement `CIL-003`, change validation profiles, execute report commands, call GitHub APIs, mutate PRs, create issues, auto-repair, create background automation, call providers, run H100/GPU/CUDA/server/remote execution, run model inference, perform semantic judging or human grading, add production validation, prove output quality, or expand claims.
 
 Group 114 first-run CLI smoke validation does not implement `CIL-003`, change validation profile registries, publish packages, call providers, require network access, run H100/GPU/CUDA/server/remote execution, run model inference, perform semantic judging or human grading, add production validation, prove output quality, prove broader workload representativeness, or claim that `getkora` is published.
+
+Group 115 source-install readiness checking does not implement `CIL-003`, change validation profile registries, change command profile registries, check PyPI installation, publish packages, create releases or tags, claim that `getkora` is published, claim install-from-PyPI support, call providers, run H100/GPU/CUDA/server/remote execution, run model inference, perform semantic judging or human grading, add production validation, prove output quality, or prove broader workload representativeness.

--- a/docs/reports/group115_source_install_readiness_check.md
+++ b/docs/reports/group115_source_install_readiness_check.md
@@ -1,0 +1,161 @@
+# Group 115 Source-Install Readiness Check
+
+Status: implemented with local validation complete; PR open.
+
+## Objective
+
+Group 115 implements `CIL-005 - Source-Install Readiness Check`.
+
+This group adds a bounded, public-safe source-install readiness checker that creates an isolated temporary virtual environment, installs the current local source tree, and verifies core import and CLI availability after install. It is source-install readiness only. It does not implement `CIL-003`, change validation profile registries, change command profile registries, publish packages, call providers, run H100/server work, or expand claims.
+
+## Approval Packet
+
+Decision needed: review and decide whether to merge Group 115 source-install readiness checking.
+
+Risk level: medium
+
+Final status classification: `needs-cto-review`
+
+Changed files: source-install readiness checker, focused tests, Group 115 report, inner-loop queue update, next-goal queue update, docs index, and narrow breadcrumbs.
+
+Validation summary: focused readiness tests, real local source-install readiness run, markdown links, whitespace diff check, and full pytest passed.
+
+Repair attempts: 0.
+
+Failures encountered: none.
+
+Self-review summary: scope is source-install readiness checking, tests, report, and breadcrumbs; `CIL-005` is completed, `CIL-003` remains deferred, and no validation or command profile registry implementation was added.
+
+Claim-boundary audit: this checks local source installation only. It does not check PyPI installation, publish a package, claim `getkora` is published, claim install-from-PyPI support, prove production readiness, prove output quality, prove broader workload representativeness, prove production workload handling, prove production validation, prove production cost reduction, claim customer savings, claim H100/GPU/CPU superiority, claim provider replacement, or claim GPU-serving replacement.
+
+Forbidden-action audit: no `CIL-003` implementation, validation profile registry change, command profile registry change, PyPI command, release/tag/GitHub Release/package upload step, package publication, version change, provider call, H100/GPU/CUDA/server/remote execution, model inference, semantic judging, human grading, GitHub Actions workflow, scheduler, daemon, background runner, GitHub API mutation, PR approval, PR merge, PR close, issue creation, project-board update, repository settings change, collaborator change, file movement, file rename, file archive, file deletion, or local-only ChatGPT context change was added.
+
+Uncertainty notes: this group touches source-install and CLI availability confidence, so it is classified as medium risk and `needs-cto-review` even though the checker is local-only and deterministic after dependency installation succeeds.
+
+Codex recommendation: CTO Review.
+
+Albert action options: Merge / Request R1 / Stop / CTO Review.
+
+## Base And Branch
+
+- public truth: `origin/main`
+- base public HEAD: `a3c9db3f54e17e3d0e292bae4ffce56d8c9262bf`
+- branch: `codex/group115-source-install-readiness`
+- worktree: `/Users/albertkim/02_PROJECTS/05_KORA_Project/worktrees/group115_source_install_readiness`
+- PR: pending until PR open
+
+## Subtasks
+
+- 115-1 Source-install readiness checker: added `scripts/check_source_install_readiness.py`.
+- 115-2 Editable install / import / CLI availability checks: checker installs the local repo with `python -m pip install -e <repo>`, then checks `import kora`, `python -m kora --help`, `kora --help`, and `kora examples list`.
+- 115-3 No PyPI / no package publication boundary check: script and report explicitly state local source-install only and no PyPI/publication/getkora/install-from-PyPI claim.
+- 115-4 Focused tests: added deterministic unit tests with mocked subprocess execution.
+- 115-5 Real local source-install readiness run: ran the checker once from the clean Group 115 worktree; result passed.
+- 115-6 Report / breadcrumbs / queue update: added this report and updated breadcrumbs, docs index, inner-loop queue, and next-goal queue.
+- 115-7 Validation / PR open: validation completed locally; PR opened after commit and push.
+
+## Checker Behavior
+
+The checker creates a temporary environment outside the repository using `python -m venv`, installs the current local source tree, runs readiness checks, prints a concise text summary, exits nonzero on failure, and cleans up the temporary environment by default.
+
+Debug option:
+
+- `--keep-temp` preserves the temporary environment for local debugging.
+
+Install modes:
+
+- default: `editable`, using `python -m pip install -e <repo>`.
+- optional: `source`, using `python -m pip install <repo>`.
+
+The checker uses structured subprocess argument lists with `shell=False`.
+
+## Real Source-Install Readiness Run
+
+Command:
+
+```bash
+python3 scripts/check_source_install_readiness.py
+```
+
+Observed result:
+
+- install mode: `editable`
+- final status: `passed`
+- checks run: `6`
+- passed checks: `6`
+- failed checks: `0`
+- import check result: `passed`
+- `python -m kora` availability check result: `passed`
+- `kora` CLI availability check result: `passed`
+- no-provider command smoke result: `passed`
+- command smoke: `kora examples list`
+- temporary environment cleanup: default cleanup path used; no debug environment preserved.
+
+The real run installed KORA from the local Group 115 worktree path. It did not install KORA from PyPI and did not publish any package.
+
+## Files Added
+
+- `scripts/check_source_install_readiness.py`
+- `tests/test_source_install_readiness.py`
+- `docs/reports/group115_source_install_readiness_check.md`
+
+## Files Updated
+
+- `OPEN_THIS_FIRST.md`
+- `REVIEW_HUB.md`
+- `docs/README.md`
+- `docs/context/CODEX_INNER_LOOP_QUEUE.md`
+- `docs/context/NEXT_GOAL_QUEUE.md`
+
+## Validation Results
+
+Final validation before PR open:
+
+| Command | Result |
+| --- | --- |
+| `python3 -m pytest tests/test_source_install_readiness.py` | passed, `8 passed` |
+| `python3 scripts/check_source_install_readiness.py` | passed; editable install; `6 passed / 0 failed / 6 total` |
+| `python3 scripts/check_markdown_links_goal082b.py` | passed |
+| `git diff --check` | passed |
+| `python3 -m pytest` | passed, `495 passed` |
+
+## Loop Count And Repairs
+
+- loop count: 1
+- repair attempts: 0
+- max loop count: 5
+- max repair attempts per failing subtask: 2
+
+## Risk And Final Classification
+
+- risk level: medium
+- final status classification: `needs-cto-review`
+
+Rationale: this group is bounded local tooling plus tests and docs, but it touches source-install and CLI availability confidence. It does not change public package publication state or claim PyPI availability.
+
+## Self-Review
+
+- changed files match the approved `CIL-005` checker, tests, report, queue, docs index, and breadcrumb scope.
+- `CIL-005` is completed.
+- `CIL-003` remains deferred and was not implemented.
+- no validation profile registry changed.
+- no command profile registry changed.
+- no PyPI command was added.
+- no release, tag, GitHub Release, release asset, or package upload step was added.
+- no package version was changed.
+- no provider calls were added or executed.
+- no H100/GPU/CUDA/server/remote execution was added or executed.
+- no model inference, semantic judging, or human grading was added.
+- no local-only ChatGPT context changed.
+- no repository settings, collaborator, issue, project-board, PR approval, PR merge, or PR close mutation was performed.
+- no file was moved, renamed, archived, or deleted.
+
+## Next Recommendation
+
+Recommended next action: review Group 115.
+
+`CIL-003` remains deferred until Albert explicitly approves the medium-risk profile-registry checklist. Do not treat Group 115 as approval to implement `CIL-003`.
+
+## Non-Claims And Boundaries
+
+Group 115 checks local source installation only. It does not check PyPI installation. It does not publish a package. It does not claim `getkora` is published. It does not claim install-from-PyPI support. It does not prove output quality, broader workload representativeness, production workload handling, production readiness, production validation, production cost reduction, H100/GPU/CPU superiority, customer savings, provider replacement, or GPU-serving replacement.

--- a/docs/reports/group115_source_install_readiness_check.md
+++ b/docs/reports/group115_source_install_readiness_check.md
@@ -42,7 +42,7 @@ Albert action options: Merge / Request R1 / Stop / CTO Review.
 - base public HEAD: `a3c9db3f54e17e3d0e292bae4ffce56d8c9262bf`
 - branch: `codex/group115-source-install-readiness`
 - worktree: `/Users/albertkim/02_PROJECTS/05_KORA_Project/worktrees/group115_source_install_readiness`
-- PR: pending until PR open
+- PR: https://github.com/Krako-Labs/KORA/pull/267
 
 ## Subtasks
 

--- a/scripts/check_source_install_readiness.py
+++ b/scripts/check_source_install_readiness.py
@@ -1,0 +1,301 @@
+from __future__ import annotations
+
+import argparse
+import shutil
+import subprocess
+import sys
+import tempfile
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Callable, Sequence
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+OUTPUT_TAIL_LIMIT = 2000
+BOUNDARY_NOTE = (
+    "Boundary: this checks local source installation only; it does not check PyPI "
+    "installation, publish a package, claim getkora is published, or claim "
+    "install-from-PyPI support."
+)
+
+
+@dataclass(frozen=True)
+class ReadinessCommand:
+    label: str
+    argv: list[str]
+    cwd: Path
+
+
+@dataclass(frozen=True)
+class ReadinessStep:
+    label: str
+    status: str
+    return_code: int
+    elapsed_seconds: float
+    stdout_tail: str = ""
+    stderr_tail: str = ""
+
+
+Runner = Callable[..., subprocess.CompletedProcess[str]]
+Clock = Callable[[], float]
+
+
+def _tail_text(value: str | None) -> str:
+    if not value:
+        return ""
+    if len(value) <= OUTPUT_TAIL_LIMIT:
+        return value
+    return value[-OUTPUT_TAIL_LIMIT:]
+
+
+def _venv_python(venv_dir: Path) -> Path:
+    if sys.platform == "win32":
+        return venv_dir / "Scripts" / "python.exe"
+    return venv_dir / "bin" / "python"
+
+
+def _venv_entry_point(venv_dir: Path, name: str) -> Path:
+    if sys.platform == "win32":
+        return venv_dir / "Scripts" / f"{name}.exe"
+    return venv_dir / "bin" / name
+
+
+def build_install_command(
+    *,
+    repo_root: Path,
+    venv_dir: Path,
+    install_mode: str,
+) -> ReadinessCommand:
+    if install_mode == "editable":
+        install_args = ["install", "-e", str(repo_root)]
+    elif install_mode == "source":
+        install_args = ["install", str(repo_root)]
+    else:
+        raise ValueError(f"unsupported install mode: {install_mode}")
+
+    return ReadinessCommand(
+        label=f"{install_mode} source install",
+        argv=[str(_venv_python(venv_dir)), "-m", "pip", *install_args],
+        cwd=repo_root,
+    )
+
+
+def build_check_commands(*, repo_root: Path, venv_dir: Path) -> list[ReadinessCommand]:
+    python_path = _venv_python(venv_dir)
+    kora_entry = _venv_entry_point(venv_dir, "kora")
+    return [
+        ReadinessCommand(
+            label="import kora",
+            argv=[str(python_path), "-c", "import kora; print(kora.__name__)"],
+            cwd=repo_root,
+        ),
+        ReadinessCommand(
+            label="python -m kora availability",
+            argv=[str(python_path), "-m", "kora", "--help"],
+            cwd=repo_root,
+        ),
+        ReadinessCommand(
+            label="kora CLI entry point availability",
+            argv=[str(kora_entry), "--help"],
+            cwd=repo_root,
+        ),
+        ReadinessCommand(
+            label="no-provider command smoke",
+            argv=[str(kora_entry), "examples", "list"],
+            cwd=repo_root,
+        ),
+    ]
+
+
+def _run_command(
+    command: ReadinessCommand,
+    *,
+    runner: Runner,
+    clock: Clock,
+) -> ReadinessStep:
+    start = clock()
+    completed = runner(
+        command.argv,
+        cwd=command.cwd,
+        shell=False,
+        check=False,
+        text=True,
+        capture_output=True,
+    )
+    elapsed = clock() - start
+    return ReadinessStep(
+        label=command.label,
+        status="passed" if completed.returncode == 0 else "failed",
+        return_code=int(completed.returncode),
+        elapsed_seconds=round(elapsed, 3),
+        stdout_tail=_tail_text(completed.stdout),
+        stderr_tail=_tail_text(completed.stderr),
+    )
+
+
+def _step_to_dict(step: ReadinessStep) -> dict[str, object]:
+    return {
+        "label": step.label,
+        "status": step.status,
+        "return_code": step.return_code,
+        "elapsed_seconds": step.elapsed_seconds,
+        "stdout_tail": step.stdout_tail,
+        "stderr_tail": step.stderr_tail,
+    }
+
+
+def run_readiness_check(
+    *,
+    repo_root: Path = REPO_ROOT,
+    install_mode: str = "editable",
+    keep_temp: bool = False,
+    runner: Runner = subprocess.run,
+    clock: Clock = time.perf_counter,
+    python_executable: str = sys.executable,
+) -> tuple[int, dict[str, object]]:
+    repo_root = repo_root.resolve()
+    temp_root = Path(tempfile.mkdtemp(prefix="kora-source-install-"))
+    venv_dir = temp_root / "venv"
+    steps: list[ReadinessStep] = []
+    exit_code = 0
+    cleanup_performed = False
+
+    try:
+        create_venv = ReadinessCommand(
+            label="create isolated virtual environment",
+            argv=[python_executable, "-m", "venv", str(venv_dir)],
+            cwd=repo_root,
+        )
+        create_step = _run_command(create_venv, runner=runner, clock=clock)
+        steps.append(create_step)
+        if create_step.return_code != 0:
+            exit_code = 1
+
+        if exit_code == 0:
+            install_step = _run_command(
+                build_install_command(repo_root=repo_root, venv_dir=venv_dir, install_mode=install_mode),
+                runner=runner,
+                clock=clock,
+            )
+            steps.append(install_step)
+            if install_step.return_code != 0:
+                exit_code = 1
+
+        if exit_code == 0:
+            for command in build_check_commands(repo_root=repo_root, venv_dir=venv_dir):
+                step = _run_command(command, runner=runner, clock=clock)
+                steps.append(step)
+                if step.return_code != 0:
+                    exit_code = 1
+                    break
+    finally:
+        if not keep_temp:
+            shutil.rmtree(temp_root, ignore_errors=True)
+            cleanup_performed = True
+
+    return exit_code, _build_report(
+        repo_root,
+        temp_root,
+        install_mode,
+        keep_temp,
+        cleanup_performed,
+        steps,
+    )
+
+
+def _build_report(
+    repo_root: Path,
+    temp_root: Path,
+    install_mode: str,
+    keep_temp: bool,
+    cleanup_performed: bool,
+    steps: Sequence[ReadinessStep],
+) -> dict[str, object]:
+    failed = sum(1 for step in steps if step.status == "failed")
+    passed = sum(1 for step in steps if step.status == "passed")
+    final_status = "failed" if failed else "passed"
+    return {
+        "repo_root": str(repo_root),
+        "temp_root": str(temp_root),
+        "install_mode": install_mode,
+        "final_status": final_status,
+        "total_checks": len(steps),
+        "passed_checks": passed,
+        "failed_checks": failed,
+        "cleanup_performed": cleanup_performed,
+        "temp_preserved_for_debug": keep_temp,
+        "boundary_note": BOUNDARY_NOTE,
+        "steps": [_step_to_dict(step) for step in steps],
+    }
+
+
+def render_text_summary(report: dict[str, object]) -> str:
+    lines = [
+        "KORA Source-Install Readiness Check",
+        f"install mode used: {report['install_mode']}",
+        f"final status: {report['final_status']}",
+        f"checks: {report['passed_checks']} passed / {report['failed_checks']} failed / {report['total_checks']} total",
+    ]
+    steps = list(report["steps"])
+    for step_obj in steps:
+        step = dict(step_obj)
+        lines.append(f"- {step['status']}: {step['label']} ({step['return_code']})")
+    import_result = _status_for_label(steps, "import kora")
+    module_cli_result = _status_for_label(steps, "python -m kora availability")
+    entry_cli_result = _status_for_label(steps, "kora CLI entry point availability")
+    smoke_result = _status_for_label(steps, "no-provider command smoke")
+    lines.extend(
+        [
+            f"import check result: {import_result}",
+            f"python -m kora availability check result: {module_cli_result}",
+            f"kora CLI availability check result: {entry_cli_result}",
+            f"command smoke result: {smoke_result}",
+            str(report["boundary_note"]),
+        ]
+    )
+    if report["temp_preserved_for_debug"]:
+        lines.append(f"debug temp preserved: {report['temp_root']}")
+    return "\n".join(lines)
+
+
+def _status_for_label(steps: Sequence[object], label: str) -> str:
+    for step_obj in steps:
+        step = dict(step_obj)
+        if step["label"] == label:
+            return str(step["status"])
+    return "not-run"
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Check local KORA source-install readiness in an isolated temporary virtual environment."
+        )
+    )
+    parser.add_argument(
+        "--install-mode",
+        choices=["editable", "source"],
+        default="editable",
+        help="Install mode to use for the local source tree. Defaults to editable.",
+    )
+    parser.add_argument(
+        "--keep-temp",
+        action="store_true",
+        help="Preserve the temporary environment for debugging instead of cleaning it up.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    exit_code, report = run_readiness_check(
+        install_mode=args.install_mode,
+        keep_temp=args.keep_temp,
+    )
+    print(render_text_summary(report))
+    return exit_code
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_source_install_readiness.py
+++ b/tests/test_source_install_readiness.py
@@ -1,0 +1,148 @@
+from __future__ import annotations
+
+import subprocess
+import shutil
+from pathlib import Path
+
+from scripts import check_source_install_readiness as readiness
+
+
+def test_editable_install_command_uses_local_repo_path() -> None:
+    repo_root = Path("/tmp/kora-repo")
+    venv_dir = Path("/tmp/kora-venv")
+
+    command = readiness.build_install_command(
+        repo_root=repo_root,
+        venv_dir=venv_dir,
+        install_mode="editable",
+    )
+
+    assert command.argv[-2:] == ["-e", str(repo_root)]
+    assert "pip" in command.argv
+    assert "pypi" not in " ".join(command.argv).lower()
+
+
+def test_source_install_command_uses_local_repo_path_without_editable_flag() -> None:
+    repo_root = Path("/tmp/kora-repo")
+    venv_dir = Path("/tmp/kora-venv")
+
+    command = readiness.build_install_command(
+        repo_root=repo_root,
+        venv_dir=venv_dir,
+        install_mode="source",
+    )
+
+    assert command.argv[-1] == str(repo_root)
+    assert "-e" not in command.argv
+
+
+def test_check_commands_cover_import_module_cli_entrypoint_and_smoke() -> None:
+    commands = readiness.build_check_commands(
+        repo_root=Path("/tmp/kora-repo"),
+        venv_dir=Path("/tmp/kora-venv"),
+    )
+
+    labels = [command.label for command in commands]
+    assert labels == [
+        "import kora",
+        "python -m kora availability",
+        "kora CLI entry point availability",
+        "no-provider command smoke",
+    ]
+    assert commands[0].argv[-1] == "import kora; print(kora.__name__)"
+    assert commands[1].argv[-3:] == ["-m", "kora", "--help"]
+    assert commands[2].argv[-1] == "--help"
+    assert commands[3].argv[-2:] == ["examples", "list"]
+
+
+def test_success_summary_contains_required_markers(tmp_path: Path) -> None:
+    def passing_runner(argv: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
+        return subprocess.CompletedProcess(argv, 0, stdout="ok", stderr="")
+
+    exit_code, report = readiness.run_readiness_check(
+        repo_root=tmp_path,
+        runner=passing_runner,
+        python_executable="python3",
+    )
+    text = readiness.render_text_summary(report)
+
+    assert exit_code == 0
+    assert report["install_mode"] == "editable"
+    assert report["total_checks"] == 6
+    assert report["passed_checks"] == 6
+    assert "install mode used: editable" in text
+    assert "import check result: passed" in text
+    assert "python -m kora availability check result: passed" in text
+    assert "kora CLI availability check result: passed" in text
+    assert "command smoke result: passed" in text
+
+
+def test_boundary_text_is_explicit() -> None:
+    note = readiness.BOUNDARY_NOTE
+
+    assert "local source installation only" in note
+    assert "does not check PyPI installation" in note
+    assert "publish a package" in note
+    assert "claim getkora is published" in note
+    assert "install-from-PyPI support" in note
+
+
+def test_install_failure_returns_nonzero_and_skips_later_checks(tmp_path: Path) -> None:
+    calls: list[list[str]] = []
+
+    def runner(argv: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
+        calls.append(argv)
+        if len(calls) == 2:
+            return subprocess.CompletedProcess(argv, 9, stdout="", stderr="install failed")
+        return subprocess.CompletedProcess(argv, 0, stdout="", stderr="")
+
+    exit_code, report = readiness.run_readiness_check(
+        repo_root=tmp_path,
+        runner=runner,
+        python_executable="python3",
+    )
+    text = readiness.render_text_summary(report)
+
+    assert exit_code == 1
+    assert report["final_status"] == "failed"
+    assert report["failed_checks"] == 1
+    assert len(calls) == 2
+    assert "import check result: not-run" in text
+    assert report["steps"][1]["stderr_tail"] == "install failed"
+
+
+def test_subprocess_invocations_use_shell_false(tmp_path: Path) -> None:
+    seen_kwargs: list[dict[str, object]] = []
+
+    def runner(argv: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
+        seen_kwargs.append(kwargs)
+        return subprocess.CompletedProcess(argv, 0, stdout="", stderr="")
+
+    readiness.run_readiness_check(
+        repo_root=tmp_path,
+        runner=runner,
+        python_executable="python3",
+    )
+
+    assert seen_kwargs
+    assert all(kwargs["shell"] is False for kwargs in seen_kwargs)
+    assert all(kwargs["check"] is False for kwargs in seen_kwargs)
+
+
+def test_keep_temp_reports_debug_path(tmp_path: Path) -> None:
+    def passing_runner(argv: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
+        return subprocess.CompletedProcess(argv, 0, stdout="", stderr="")
+
+    exit_code, report = readiness.run_readiness_check(
+        repo_root=tmp_path,
+        keep_temp=True,
+        runner=passing_runner,
+        python_executable="python3",
+    )
+    text = readiness.render_text_summary(report)
+
+    assert exit_code == 0
+    assert report["temp_preserved_for_debug"] is True
+    assert report["cleanup_performed"] is False
+    assert "debug temp preserved:" in text
+    shutil.rmtree(str(report["temp_root"]), ignore_errors=True)


### PR DESCRIPTION
## Summary

Group 115 implements `CIL-005 - Source-Install Readiness Check`.

This PR adds a bounded local source-install readiness checker that creates an isolated temporary virtual environment, installs the current local source tree, and verifies core post-install surfaces:

- editable local source install with `python -m pip install -e <repo>`
- `import kora`
- `python -m kora --help`
- `kora --help`
- no-provider smoke command: `kora examples list`

## Boundaries

This checks local source installation only. It does not check PyPI installation, publish a package, claim `getkora` is published, claim install-from-PyPI support, implement `CIL-003`, change validation profile registries, change command profile registries, call providers, run model inference, run H100/GPU/CUDA/server/remote execution, or expand claims.

## Validation

- `python3 -m pytest tests/test_source_install_readiness.py` - passed, `8 passed`
- `python3 scripts/check_source_install_readiness.py` - passed, editable install, `6 passed / 0 failed / 6 total`
- `python3 scripts/check_markdown_links_goal082b.py` - passed
- `git diff --check` - passed
- `python3 -m pytest` - passed, `495 passed`

## Review Notes

Risk level: medium.

Final status classification: `needs-cto-review` because the work touches source-install and CLI availability confidence.

`CIL-003` remains deferred.
