### PR TITLE
Group 116 second route-only fixture slice

### DIFF
--- a/OPEN_THIS_FIRST.md
+++ b/OPEN_THIS_FIRST.md
@@ -49,8 +49,8 @@ Current state:
 
 - branch: `codex/group116-route-only-fixture-slice`
 - public truth: `origin/main`
-- branch pushed to: pending PR open
-- open PR: pending PR open
+- branch pushed to: `origin/codex/group116-route-only-fixture-slice`
+- open PR: [#268](https://github.com/Krako-Labs/KORA/pull/268)
 - base commit: `49affdfb25bb7551e30255839a4816047971ced9`
 
 ## Active Goal

--- a/OPEN_THIS_FIRST.md
+++ b/OPEN_THIS_FIRST.md
@@ -2,7 +2,7 @@
 
 Status: current public project breadcrumb.
 
-Last updated by: Group 115.
+Last updated by: Group 116.
 
 ## Current Status
 
@@ -18,6 +18,7 @@ Current state:
 - first-value CLI commands exist and the editable-install path has been revalidated for local public-safe onboarding.
 - packaging strategy now documents the PyPI `kora` collision and the planned future distribution name `getkora`; latest-feature testing remains source-install from the current repository.
 - source-install readiness is now checked by an isolated local temporary-venv checker over the current source tree, import surface, `python -m kora`, `kora` CLI entry point, and no-provider `kora examples list` smoke path.
+- a second public-safe route-only fixture slice exists at `examples/workloads/kora-representativeness-slice-v1.json`, with aggregate-only evaluation through `scripts/evaluate_representativeness_slice_routes.py`.
 - public first-run acceptance testing has been run against the README/source-install path, KORA Doctor, deterministic classification, and PyPI collision wording.
 - an offline OpenAI-compatible proxy example exists under `examples/openai_compatible_proxy/`, showing KORA routing OpenAI-style chat request objects through deterministic handlers, local cache reuse, or provider-needed fallback without provider calls.
 - the OpenAI-style proxy demo routing logic is now reusable from `kora.openai_proxy_demo`, and `python3 -m kora proxy-demo examples/openai_compatible_proxy/requests.json` runs the same offline no-provider-call path from the first-class CLI.
@@ -42,24 +43,28 @@ Current state:
 - `kora doctor` is now a first-class CLI command for running the offline Doctor workload-control report against a workload JSON file or all bundled Doctor workloads.
 - the public README and docs index now position KORA as an AI Workload Control Layer, with examples-first onboarding and explicit claim boundaries.
 - the breadcrumb/review-hub pattern has been extracted into a reusable Project Operating System package and validated on KORA as a continuation surface.
-- current public continuation work is focused on Group 115 source-install readiness review. Documentation movement remains optional only after later explicit Albert approval.
+- current public continuation work is focused on Group 116 second route-only fixture slice review. Documentation movement remains optional only after later explicit Albert approval.
 
 ## Current Branch
 
-- branch: `codex/group115-source-install-readiness`
+- branch: `codex/group116-route-only-fixture-slice`
 - public truth: `origin/main`
-- branch pushed to: `origin/codex/group115-source-install-readiness`
-- open PR: [#267](https://github.com/Krako-Labs/KORA/pull/267)
-- base commit: `a3c9db3f54e17e3d0e292bae4ffce56d8c9262bf`
+- branch pushed to: pending PR open
+- open PR: pending PR open
+- base commit: `49affdfb25bb7551e30255839a4816047971ced9`
 
 ## Active Goal
 
-Group 115 - Source-Install Readiness Check.
+Group 116 - Second Route-Only Fixture Slice.
 
-Group 115 implements `CIL-005` by adding an isolated local source-install readiness checker over the current source tree, focused tests, and a public-safe report. It does not implement `CIL-003`, change validation profile registries, change command profile registries, publish packages, claim PyPI installation support, claim `getkora` is published, call providers, run H100/server work, or expand claims.
+Group 116 adds a second synthetic route-only fixture slice, an aggregate route-only evaluator, focused tests, and a public-safe report. It does not implement `CIL-003`, change validation profile registries, change command profile registries, call providers, run model inference, run H100/server work, perform semantic judging or human grading, or expand claims.
 
 Primary report:
 
+- [Group 116 second route-only fixture slice](docs/reports/group116_second_route_only_fixture_slice.md)
+- [Second route-only fixture](examples/workloads/kora-representativeness-slice-v1.json)
+- [Second slice route-only evaluator](scripts/evaluate_representativeness_slice_routes.py)
+- [Second slice route-only evaluator tests](tests/test_representativeness_slice_route_only_evaluator.py)
 - [Group 115 source-install readiness check](docs/reports/group115_source_install_readiness_check.md)
 - [Source-install readiness checker](scripts/check_source_install_readiness.py)
 - [Source-install readiness tests](tests/test_source_install_readiness.py)
@@ -131,6 +136,8 @@ Current caveat: Group 113 is operating review and queue hardening only. It does 
 Current caveat: Group 114 is local first-run CLI smoke validation only. It does not implement `CIL-003`, change validation profile registries, publish packages, call providers, require network access, run H100/GPU/CUDA/server/remote execution, run model inference, perform semantic judging or human grading, add production validation, prove output quality, prove broader workload representativeness, or claim that `getkora` is published.
 
 Current caveat: Group 115 is local source-install readiness only. It does not implement `CIL-003`, change validation profile registries, change command profile registries, check PyPI installation, publish packages, create releases or tags, claim `getkora` is published, claim install-from-PyPI support, call providers, require H100/GPU/CUDA/server/remote execution, run model inference, perform semantic judging or human grading, add production validation, prove output quality, prove broader workload representativeness, or expand claims.
+
+Current caveat: Group 116 is route-only aggregate fixture evidence only. It does not implement `CIL-003`, change validation profile registries, change command profile registries, call providers, run H100/GPU/CUDA/server/remote execution, run model inference, perform semantic judging or human grading, add production validation, prove output quality, prove broader workload representativeness, prove cost reduction, or expand claims.
 
 ## Last Completed Goal
 
@@ -675,14 +682,16 @@ KORA makes AI workloads routable. The current KRK public alpha shows how workloa
 
 ## Recommended Next Goal
 
-Review Group 115 - `CIL-005 - Source-Install Readiness Check`.
+Review Group 116 - Second Route-Only Fixture Slice.
 
 Recommended scope:
 
+- review [Group 116 second route-only fixture slice](docs/reports/group116_second_route_only_fixture_slice.md).
+- review [Second route-only fixture](examples/workloads/kora-representativeness-slice-v1.json).
+- review [Second slice route-only evaluator](scripts/evaluate_representativeness_slice_routes.py).
+- review [Second slice route-only evaluator tests](tests/test_representativeness_slice_route_only_evaluator.py).
+- verify the real local route-only result if needed with `python3 scripts/evaluate_representativeness_slice_routes.py`.
 - review [Group 115 source-install readiness check](docs/reports/group115_source_install_readiness_check.md).
-- review [Source-install readiness checker](scripts/check_source_install_readiness.py).
-- review [Source-install readiness tests](tests/test_source_install_readiness.py).
-- verify the real local source-install readiness result if needed with `python3 scripts/check_source_install_readiness.py`.
 - review [Group 113 inner loop applied review and queue hardening](docs/reports/group113_inner_loop_applied_review_queue_hardening.md).
 - review [Codex medium-risk profile registry checklist](docs/context/CODEX_MEDIUM_RISK_PROFILE_REGISTRY_CHECKLIST.md).
 - review [Group 112 PR approval and report consistency](docs/reports/group112_pr_approval_and_report_consistency.md).
@@ -690,15 +699,15 @@ Recommended scope:
 - review [Group 110 Codex inner loop ownership](docs/reports/group110_codex_inner_loop_ownership.md).
 - review [Codex inner loop queue](docs/context/CODEX_INNER_LOOP_QUEUE.md).
 - keep `CIL-003` deferred unless Albert explicitly approves the medium-risk profile-registry checklist.
-- confirm the report keeps the local source-install boundary and does not claim that `getkora` is published.
-- expect final classification `needs-cto-review` if user-facing install docs or onboarding language change.
+- confirm the report keeps the route-only aggregate boundary and does not claim output quality, broader representativeness, production readiness, cost reduction, provider replacement, or GPU-serving replacement.
+- expected final classification is `merge-ready` if CI passes and claim boundaries remain unchanged.
 - preserve the requirement that Codex pass is not merge-ready pass.
 - run the claim-boundary checklist before PR-open.
 - keep any follow-on work local-only, finite, public-safe, and explicitly bounded.
 - do not add semantic judging, human grading, provider calls, H100/GPU/CUDA/server/remote execution, model inference, production validation, claim expansion, background automation, actual multi-agent execution, or merge automation without separate explicit approval.
 - stop at PR-open unless a separate merge-gate prompt is provided.
 
-Alternative future goals remain `CIL-003`, a second route-only fixture slice, or documentation movement for one small bucket, but only after explicit approval.
+Alternative future goals remain `CIL-003`, another bounded public-safe fixture/check slice, or documentation movement for one small bucket, but only after explicit approval.
 
 Optional docs-navigation movement remains a separate future track only if Albert explicitly approves movement.
 

--- a/REVIEW_HUB.md
+++ b/REVIEW_HUB.md
@@ -2,7 +2,7 @@
 
 Status: current public review and continuation hub.
 
-Last updated by: Group 115.
+Last updated by: Group 116.
 
 ## Project Identity
 
@@ -14,11 +14,11 @@ KRK means KORA Routing Kernel. KRK is the deterministic-first execution routing 
 
 - repository: `https://github.com/Krako-Labs/KORA`
 - public truth branch: `origin/main`
-- active verification branch: `codex/group115-source-install-readiness`
-- worktree label: `group115_source_install_readiness`
-- branch pushed to: `origin/codex/group115-source-install-readiness`
-- open PR: [#267](https://github.com/Krako-Labs/KORA/pull/267)
-- base commit: `a3c9db3f54e17e3d0e292bae4ffce56d8c9262bf`
+- active verification branch: `codex/group116-route-only-fixture-slice`
+- worktree label: `group116_route_only_fixture_slice`
+- branch pushed to: pending PR open
+- open PR: pending PR open
+- base commit: `49affdfb25bb7551e30255839a4816047971ced9`
 
 ## Current State Summary
 
@@ -59,6 +59,7 @@ KORA now has a public-safe first-value path and an evidence package that covers:
 - Goal 099 executed the Goal 098 server-run packet through SSH remote execution on the AI Champion H100 server, separating CPU/non-GPU and bounded GPU/H100 paths.
 - Goal 102 starts broader workload representativeness planning with a public-safe synthetic seed fixture and shape-only validator.
 - Goal 103 adds a route-only evaluator over the Goal 102 seed fixture, producing aggregate public-safe route and workload-category counters only.
+- Group 116 adds a second public-safe synthetic route-only fixture slice with aggregate counters only.
 - Goal 104 adds a KORA-specific Codex bounded-loop protocol, claim-boundary checklist, PR completion format, and next-goal queue for semi-autonomous execution with human approval gates.
 - Goal 105 adds a public-safe output-quality methodology for future fixture-derived checks without executing evaluation or turning Goal 103 route-only counters into output-quality proof.
 - Goal 106 adds a tiny public-safe fixture-based quality-check scaffold with deterministic fixture-only checks and aggregate JSON output.
@@ -72,7 +73,7 @@ KORA now has a public-safe first-value path and an evidence package that covers:
 - reusable Project Operating System templates, prompts, and adoption standard.
 - validated Project Operating System continuation path for KORA.
 - no repository settings should be changed further without explicit owner approval.
-- current work is Group 115: source-install readiness checking. Documentation movement remains optional only after later explicit Albert approval.
+- current work is Group 116: second route-only fixture slice. Documentation movement remains optional only after later explicit Albert approval.
 
 Current status is evidence-centered and local-first. It is not production-readiness evidence.
 
@@ -137,6 +138,7 @@ This is a sufficient recent history backfill, not a complete reconstruction.
 | Group 113 | Applied the inner-loop tools, added the medium-risk profile-registry checklist, and hardened queue sizing guidance without implementing `CIL-003`. | [Group 113 inner loop applied review and queue hardening](docs/reports/group113_inner_loop_applied_review_queue_hardening.md) |
 | Group 114 | Adds deterministic local first-run CLI smoke validation over existing offline commands without implementing `CIL-003`, publishing packages, or expanding claims. | [Group 114 first-run CLI smoke validation](docs/reports/group114_first_run_cli_smoke_validation.md) |
 | Group 115 | Adds isolated local source-install readiness checking without checking PyPI, publishing packages, claiming `getkora` is published, or expanding claims. | [Group 115 source-install readiness check](docs/reports/group115_source_install_readiness_check.md) |
+| Group 116 | Adds a second synthetic route-only fixture slice with aggregate counters only, without output-quality or broader representativeness claims. | [Group 116 second route-only fixture slice](docs/reports/group116_second_route_only_fixture_slice.md) |
 
 ## Evidence Index
 
@@ -166,6 +168,10 @@ Generated summaries:
 
 Current reviewer path:
 
+- [Group 116 second route-only fixture slice](docs/reports/group116_second_route_only_fixture_slice.md)
+- [Second route-only fixture](examples/workloads/kora-representativeness-slice-v1.json)
+- [Second slice route-only evaluator](scripts/evaluate_representativeness_slice_routes.py)
+- [Second slice route-only evaluator tests](tests/test_representativeness_slice_route_only_evaluator.py)
 - [Group 115 source-install readiness check](docs/reports/group115_source_install_readiness_check.md)
 - [Source-install readiness checker](scripts/check_source_install_readiness.py)
 - [Source-install readiness tests](tests/test_source_install_readiness.py)
@@ -529,6 +535,7 @@ Boundary: this is positioning grounded in current examples and evidence. It does
 - Group 113 is operating review and queue hardening only; it does not implement `CIL-003`, change validation profiles, execute report commands, mutate GitHub, create issues, auto-repair, create background automation, call providers, run H100/server work, or prove output quality.
 - Group 114 is local first-run CLI smoke validation only; it does not implement `CIL-003`, change validation profile registries, publish packages, call providers, require network access, run H100/server work, or prove output quality.
 - Group 115 is local source-install readiness only; it does not implement `CIL-003`, change validation profile registries, change command profile registries, check PyPI installation, publish packages, claim `getkora` is published, claim install-from-PyPI support, call providers, run H100/server work, or prove output quality.
+- Group 116 is route-only aggregate fixture evidence only; it does not implement `CIL-003`, change validation profile registries, change command profile registries, call providers, run H100/server work, run model inference, perform semantic judging or human grading, prove output quality, prove broader workload representativeness, or expand claims.
 - Output fidelity is deterministic rule-based over public fixtures, not live semantic judging.
 - The deterministic classification example pack is intentionally synthetic and small; broader workload representativeness remains unproven.
 - The KORA Doctor example is synthetic and does not inspect arbitrary repositories or prove diagnostic accuracy.
@@ -548,8 +555,8 @@ Boundary: this is positioning grounded in current examples and evidence. It does
 
 ## Recommended Next Goals
 
-1. Review Group 115 - `CIL-005 - Source-Install Readiness Check`.
-2. A second route-only fixture slice, only after explicit approval.
+1. Review Group 116 - Second Route-Only Fixture Slice.
+2. Another bounded public-safe fixture/check slice, only after explicit approval.
 3. Semantic, human, provider, H100, GPU, server, remote, or production-like validation only after separate explicit approval.
 4. Optional documentation movement proposal for one small bucket only after later explicit Albert approval.
 
@@ -561,7 +568,7 @@ Paste a new Goal with this instruction:
 
 ```text
 Start by reading OPEN_THIS_FIRST.md and REVIEW_HUB.md.
-Use the active branch codex/group115-source-install-readiness for the current Group 115 review packet, or create a new scoped branch from origin/main for a new Group after Group 115 is merged.
+Use the active branch codex/group116-route-only-fixture-slice for the current Group 116 review packet, or create a new scoped branch from origin/main for a new Group after Group 116 is merged.
 Keep public/private and claim boundaries from REVIEW_HUB.md.
 Use docs/runbooks/codex_bounded_loop_protocol.md and docs/runbooks/kora_claim_boundary_checklist.md for execution and review gates.
 Use docs/runbooks/long_run_test_loop_protocol.md and docs/runbooks/test_failure_triage_checklist.md for future bounded local test-loop goals.

--- a/REVIEW_HUB.md
+++ b/REVIEW_HUB.md
@@ -16,8 +16,8 @@ KRK means KORA Routing Kernel. KRK is the deterministic-first execution routing 
 - public truth branch: `origin/main`
 - active verification branch: `codex/group116-route-only-fixture-slice`
 - worktree label: `group116_route_only_fixture_slice`
-- branch pushed to: pending PR open
-- open PR: pending PR open
+- branch pushed to: `origin/codex/group116-route-only-fixture-slice`
+- open PR: [#268](https://github.com/Krako-Labs/KORA/pull/268)
 - base commit: `49affdfb25bb7551e30255839a4816047971ced9`
 
 ## Current State Summary

--- a/docs/README.md
+++ b/docs/README.md
@@ -45,6 +45,7 @@ This documentation index is for readers who want more detail than the root [READ
 - [Group 113 inner loop applied review and queue hardening](reports/group113_inner_loop_applied_review_queue_hardening.md) - operating review and queue hardening; does not implement `CIL-003` or change validation profiles.
 - [Group 114 first-run CLI smoke validation](reports/group114_first_run_cli_smoke_validation.md) - deterministic local first-run CLI smoke checks over existing offline commands; does not publish packages or prove production readiness.
 - [Group 115 source-install readiness check](reports/group115_source_install_readiness_check.md) - isolated local source-install readiness checking; does not check PyPI, publish packages, or claim `getkora` is published.
+- [Group 116 second route-only fixture slice](reports/group116_second_route_only_fixture_slice.md) - second synthetic route-only fixture slice with aggregate counters only; does not prove output quality or broader representativeness.
 - [Goal 096 documentation navigation and archive-bucket proposal](reports/goal096_documentation_navigation_archive_bucket_proposal.md) - proposal-only navigation buckets; no files moved.
 - [Group 097 H100 evidence inventory and gap audit](reports/group097_h100_evidence_inventory_gap_audit.md) - bounded H100 evidence inventory; no new H100 benchmark claim.
 - [Goal 098 controlled CPU/GPU evidence regeneration](reports/goal098_controlled_cpu_gpu_evidence_regeneration.md) - server-run packet with local no-CUDA `not_run` status; no fresh H100 execution claim.
@@ -70,6 +71,7 @@ KORA uses narrow evidence language. Offline examples and reports may describe sa
 - [Codex escalation gates](context/CODEX_ESCALATION_GATES.md)
 - [Codex approval packet](context/CODEX_APPROVAL_PACKET.md)
 - [Codex medium-risk profile registry checklist](context/CODEX_MEDIUM_RISK_PROFILE_REGISTRY_CHECKLIST.md)
+- [Second slice route-only evaluator](../scripts/evaluate_representativeness_slice_routes.py)
 - [Source-install readiness checker](../scripts/check_source_install_readiness.py)
 - [First-run CLI smoke checker](../scripts/check_first_run_cli_smoke.py)
 - [Codex multi-agent operating model](context/CODEX_MULTI_AGENT_OPERATING_MODEL.md)

--- a/docs/context/NEXT_GOAL_QUEUE.md
+++ b/docs/context/NEXT_GOAL_QUEUE.md
@@ -8,16 +8,18 @@ This queue records likely next KORA work without starting it. It is not an appro
 
 ## Current Recommended Next Goal
 
-1. Review Group 115 - `CIL-005 - Source-Install Readiness Check`.
+1. Review Group 116 - Second Route-Only Fixture Slice.
 
 Suggested scope:
 
 - use the Goal 104 runbooks and `AGENTS.md` as the execution checklist.
 - verify the goal envelope, base SHA, KORA identity, and clean worktree.
+- review [Group 116 second route-only fixture slice](../reports/group116_second_route_only_fixture_slice.md).
+- review [Second route-only fixture](../../examples/workloads/kora-representativeness-slice-v1.json).
+- review [Second slice route-only evaluator](../../scripts/evaluate_representativeness_slice_routes.py).
+- review [Second slice route-only evaluator tests](../../tests/test_representativeness_slice_route_only_evaluator.py).
+- rerun `python3 scripts/evaluate_representativeness_slice_routes.py` if reviewer wants to reproduce the aggregate route-only counters.
 - review [Group 115 source-install readiness check](../reports/group115_source_install_readiness_check.md).
-- review [Source-install readiness checker](../../scripts/check_source_install_readiness.py).
-- review [Source-install readiness tests](../../tests/test_source_install_readiness.py).
-- rerun `python3 scripts/check_source_install_readiness.py` if reviewer wants to reproduce the isolated local source-install check.
 - review [Group 114 first-run CLI smoke validation](../reports/group114_first_run_cli_smoke_validation.md).
 - review [Group 113 inner loop applied review and queue hardening](../reports/group113_inner_loop_applied_review_queue_hardening.md).
 - review [Codex medium-risk profile registry checklist](CODEX_MEDIUM_RISK_PROFILE_REGISTRY_CHECKLIST.md).
@@ -26,8 +28,8 @@ Suggested scope:
 - review [Group 110 Codex inner loop ownership](../reports/group110_codex_inner_loop_ownership.md).
 - review [Codex inner loop queue](CODEX_INNER_LOOP_QUEUE.md).
 - keep `CIL-003` deferred unless Albert explicitly approves the medium-risk profile-registry checklist.
-- confirm `CIL-005` remains local source-install readiness only, without PyPI checks, package publication, or a `getkora` published claim.
-- expect final classification `needs-cto-review` if user-facing install docs or onboarding language change.
+- confirm Group 116 remains route-only aggregate fixture evidence only, without output-quality, broader representativeness, production readiness, cost-reduction, provider-replacement, or GPU-serving-replacement claims.
+- expected final classification is `merge-ready` if CI passes and claim boundaries remain unchanged.
 - preserve the requirement that Codex pass is not merge-ready pass.
 - require final classification as `merge-ready`, `needs-r1`, `needs-cto-review`, or `blocked`.
 - do not add semantic judging, human grading, provider calls, H100/GPU/CUDA/server/remote execution, model inference, production validation, claim expansion, background automation, actual multi-agent execution, or merge automation without separate explicit approval.
@@ -44,7 +46,7 @@ Do not split a checker, tests, docs, report, and breadcrumbs into separate tasks
 
 ## Approved Alternatives Only After Explicit Prompt
 
-- A second route-only fixture slice.
+- Another bounded public-safe fixture/check slice.
 - A second public-safe fixture-check slice.
 - Documentation movement for one small bucket.
 - Larger bounded H100 or provider validation work.
@@ -89,3 +91,5 @@ Group 113 queue hardening does not implement `CIL-003`, change validation profil
 Group 114 first-run CLI smoke validation does not implement `CIL-003`, change validation profile registries, publish packages, call providers, require network access, run H100/GPU/CUDA/server/remote execution, run model inference, perform semantic judging or human grading, add production validation, prove output quality, prove broader workload representativeness, or claim that `getkora` is published.
 
 Group 115 source-install readiness checking does not implement `CIL-003`, change validation profile registries, change command profile registries, check PyPI installation, publish packages, create releases or tags, claim that `getkora` is published, claim install-from-PyPI support, call providers, run H100/GPU/CUDA/server/remote execution, run model inference, perform semantic judging or human grading, add production validation, prove output quality, or prove broader workload representativeness.
+
+Group 116 second route-only fixture slice does not implement `CIL-003`, change validation profile registries, change command profile registries, call providers, run H100/GPU/CUDA/server/remote execution, run model inference, perform semantic judging or human grading, add production validation, prove output quality, prove broader workload representativeness, prove production readiness, prove cost reduction, claim provider replacement, claim GPU-serving replacement, or expand claims.

--- a/docs/reports/group116_second_route_only_fixture_slice.md
+++ b/docs/reports/group116_second_route_only_fixture_slice.md
@@ -42,7 +42,7 @@ Albert action options: Merge / Request R1 / Stop.
 - base public HEAD: `49affdfb25bb7551e30255839a4816047971ced9`
 - branch: `codex/group116-route-only-fixture-slice`
 - worktree: `/Users/albertkim/02_PROJECTS/05_KORA_Project/worktrees/group116_route_only_fixture_slice`
-- PR: pending until PR open
+- PR: https://github.com/Krako-Labs/KORA/pull/268
 
 ## Subtasks
 

--- a/docs/reports/group116_second_route_only_fixture_slice.md
+++ b/docs/reports/group116_second_route_only_fixture_slice.md
@@ -1,0 +1,176 @@
+# Group 116 Second Route-Only Fixture Slice
+
+Status: implemented with local validation complete; PR open.
+
+## Objective
+
+Group 116 adds a second public-safe synthetic route-only fixture slice adjacent to, but distinct from, the Goal 102 representativeness seed and Goal 103 route-only evaluator.
+
+This group adds breadth to route-shape evidence only. It does not prove output quality, broader workload representativeness, production readiness, production validation, production cost reduction, customer savings, provider replacement, H100/GPU/CPU superiority, or GPU-serving replacement.
+
+## Approval Packet
+
+Decision needed: review and decide whether to merge Group 116 second route-only fixture slice.
+
+Risk level: low
+
+Final status classification: `merge-ready`
+
+Changed files: second synthetic route-only fixture, narrow validator schema generalization, route-only evaluator, focused tests, Group 116 report, docs index, queue, and breadcrumbs.
+
+Validation summary: focused slice tests, existing Goal 102/103 tests, real route-only evaluator run, markdown links, whitespace diff check, and full pytest passed.
+
+Repair attempts: 1.
+
+Failures encountered: initial focused test expectations used `category_count == 11`, `fallback == 5`, and `tool_needed == 5`; the real fixture/evaluator correctly reported 12 categories, `fallback == 4`, and `tool_needed == 6`. Tests were updated to match the implemented fixture design.
+
+Self-review summary: scope is fixture-only route-shape evidence, validation/evaluation tests, report, and breadcrumbs. `CIL-003` remains deferred. No validation profile registry or command profile registry was changed.
+
+Claim-boundary audit: Group 116 is route-only aggregate evidence over a synthetic public-safe fixture. It does not call providers, run model inference, run H100/GPU/CUDA/server/remote execution, perform semantic judging or human grading, publish packages, claim `getkora` is published, claim install-from-PyPI support, or make production/output-quality/broader-representativeness/cost-reduction/provider-replacement/GPU-serving-replacement claims.
+
+Forbidden-action audit: no `CIL-003` implementation, validation profile registry change, command profile registry change, provider call, model inference, H100/GPU/CUDA/server/remote execution, semantic judging, human grading, release, tag, GitHub Release, release asset, PyPI publication, package publication, issue, project board, repository settings change, collaborator change, file movement, file rename, file archive, file deletion, or local-only ChatGPT context change was added.
+
+Uncertainty notes: none. The fixture and evaluator are deterministic and route-only.
+
+Codex recommendation: Merge after normal review.
+
+Albert action options: Merge / Request R1 / Stop.
+
+## Base And Branch
+
+- public truth: `origin/main`
+- base public HEAD: `49affdfb25bb7551e30255839a4816047971ced9`
+- branch: `codex/group116-route-only-fixture-slice`
+- worktree: `/Users/albertkim/02_PROJECTS/05_KORA_Project/worktrees/group116_route_only_fixture_slice`
+- PR: pending until PR open
+
+## Subtasks
+
+- 116-1 Fixture scope and category design: designed a second synthetic route-only slice focused on practical workload-control surfaces that are adjacent to Goal 102 but not a mechanical copy.
+- 116-2 Second route-only fixture: added `examples/workloads/kora-representativeness-slice-v1.json` with 40 public-safe fixture-only items.
+- 116-3 Shape validator / reuse decision: reused the existing Goal 102 validator with narrow backward-compatible schema-version generalization.
+- 116-4 Route-only evaluator: added `scripts/evaluate_representativeness_slice_routes.py`, emitting aggregate counters only.
+- 116-5 Focused tests: added `tests/test_representativeness_slice_route_only_evaluator.py`.
+- 116-6 Real local route-only run: ran the new evaluator locally and recorded counters below.
+- 116-7 Report / breadcrumbs / queue update: added this report and updated `OPEN_THIS_FIRST.md`, `REVIEW_HUB.md`, `docs/README.md`, and `docs/context/NEXT_GOAL_QUEUE.md`.
+- 116-8 Validation / PR open: validation completed locally; PR opened after commit and push.
+
+## Fixture Design Summary
+
+The second slice emphasizes practical workload-control surfaces not fully stressed by the Goal 102 seed:
+
+- multi-step app workflow routing.
+- document intake and normalization.
+- local policy checks.
+- schema validation.
+- retry and fallback control.
+- cache-reuse candidates.
+- tool-needed local action candidates.
+- retrieval-needed candidates.
+- provider-needed ambiguous tasks.
+- GPU-candidate batch labels only, with no GPU execution.
+- CPU/local deterministic transforms.
+- report-generation control tasks.
+
+The fixture remains synthetic, public-safe, and fixture-only. It includes stable IDs, categories, explicit route labels, rationales, public-safety flags, and fixture-only claim scope. It avoids private data, real customer data, live provider examples, raw model outputs, secrets, restricted URLs, and infrastructure details.
+
+It is adjacent to Goal 102 because it uses the same public-safe shape and allowed route labels. It is distinct because it focuses more heavily on local app workflow control, schema/policy/retry surfaces, and operational report-control routing rather than the original support/issue/RAG/agent seed mix.
+
+## Real Route-Only Run Counters
+
+Command:
+
+```bash
+python3 scripts/evaluate_representativeness_slice_routes.py
+```
+
+Observed result:
+
+- total slice items: `40`
+- unsupported / unknown / missing route metadata count: `0`
+- route counts:
+  - `cache`: `7`
+  - `cpu`: `6`
+  - `deterministic`: `5`
+  - `fallback`: `4`
+  - `gpu`: `3`
+  - `provider_needed`: `4`
+  - `retrieval_needed`: `5`
+  - `tool_needed`: `6`
+- route group counts:
+  - `cache_reuse_candidates`: `7`
+  - `deterministic_local_route_candidates`: `22`
+  - `fallback_control_candidates`: `4`
+  - `provider_model_candidates`: `7`
+- workload category count: `12`
+
+This run emitted aggregate counters only. It did not call providers, run model inference, run H100/GPU/CUDA/server/remote execution, inspect output quality, perform semantic judging, or perform human grading.
+
+## Files Added
+
+- `examples/workloads/kora-representativeness-slice-v1.json`
+- `scripts/evaluate_representativeness_slice_routes.py`
+- `tests/test_representativeness_slice_route_only_evaluator.py`
+- `docs/reports/group116_second_route_only_fixture_slice.md`
+
+## Files Updated
+
+- `OPEN_THIS_FIRST.md`
+- `REVIEW_HUB.md`
+- `docs/README.md`
+- `docs/context/NEXT_GOAL_QUEUE.md`
+- `scripts/validate_representativeness_seed.py`
+
+## Validation Results
+
+Final validation before PR open:
+
+| Command | Result |
+| --- | --- |
+| `python3 -m pytest tests/test_representativeness_slice_route_only_evaluator.py tests/test_representativeness_seed.py tests/test_representativeness_route_only_evaluator.py` | passed, `12 passed` |
+| `python3 scripts/evaluate_representativeness_slice_routes.py` | passed; `40` items; unsupported/unknown/missing route metadata `0` |
+| `python3 scripts/check_markdown_links_goal082b.py` | passed |
+| `git diff --check` | passed |
+| `python3 -m pytest` | passed, `501 passed` |
+
+## Loop Count And Repairs
+
+- loop count: 1
+- repair attempts: 1
+- max loop count: 5
+- max repair attempts per failing subtask: 2
+
+## Risk And Final Classification
+
+- risk level: low
+- final status classification: `merge-ready`
+
+Rationale: this group adds a deterministic synthetic fixture, a route-only aggregate evaluator, focused tests, and narrow docs. It does not change command registries, validation profile registries, public positioning, package state, or claim boundaries.
+
+## Self-Review
+
+- changed files match the approved second route-only fixture slice scope.
+- fixture is synthetic, public-safe, and small enough for review.
+- evaluator emits aggregate route/category/group counters only.
+- unsupported / unknown / missing route metadata count is `0`.
+- `CIL-003` remains deferred and was not implemented.
+- no validation profile registry changed.
+- no command profile registry changed.
+- no provider calls were added or executed.
+- no model inference was added or executed.
+- no H100/GPU/CUDA/server/remote execution was added or executed.
+- no semantic judging or human grading was added.
+- no PyPI/package publication/release/tag action was added.
+- no `getkora` published or install-from-PyPI support claim was added.
+- no production readiness, production validation, output-quality proof, broader workload representativeness proof, cost-reduction proof, customer-savings claim, provider replacement claim, or GPU-serving replacement claim was added.
+- no local-only ChatGPT context changed.
+
+## Next Recommendation
+
+Recommended next action: review and merge Group 116 if the PR passes CI and the merge gate confirms the same boundaries.
+
+`CIL-003` remains deferred until Albert explicitly approves the medium-risk profile-registry checklist.
+
+## Claim Boundary Reminder
+
+Group 116 adds route-only aggregate counters over a synthetic fixture. It does not prove output quality, broader workload representativeness, production workload handling, production readiness, production validation, cost reduction, customer savings, H100/GPU/CPU superiority, provider replacement, or GPU-serving replacement.

--- a/examples/workloads/kora-representativeness-slice-v1.json
+++ b/examples/workloads/kora-representativeness-slice-v1.json
@@ -1,0 +1,368 @@
+{
+  "schema_version": "kora_representativeness_slice_v1",
+  "description": "Public-safe synthetic second route-only fixture slice for KORA workload-control route-shape evidence. This fixture is not output-quality proof, broader workload representativeness proof, production readiness proof, or provider/model execution evidence.",
+  "claim_scope": "fixture_only",
+  "public_safe": true,
+  "items": [
+    {
+      "id": "rep-slice-v1-001",
+      "category": "multi_step_app_workflow",
+      "input": "Synthetic app workflow: normalize a checkout event, classify retry eligibility, and prepare a local audit row.",
+      "expected_route": "cpu",
+      "rationale": "Structured multi-step local transforms can be represented as CPU-routed route-shape work.",
+      "public_safe": true,
+      "claim_scope": "fixture_only"
+    },
+    {
+      "id": "rep-slice-v1-002",
+      "category": "multi_step_app_workflow",
+      "input": "Synthetic app workflow: map a known onboarding status sequence to deterministic next-step labels.",
+      "expected_route": "deterministic",
+      "rationale": "Known status transitions fit deterministic route-shape handling.",
+      "public_safe": true,
+      "claim_scope": "fixture_only"
+    },
+    {
+      "id": "rep-slice-v1-003",
+      "category": "multi_step_app_workflow",
+      "input": "Synthetic app workflow: repeat a previously completed local route summary for the same fixture batch.",
+      "expected_route": "cache",
+      "rationale": "Repeated workflow summary work is represented as cache-routable.",
+      "public_safe": true,
+      "claim_scope": "fixture_only"
+    },
+    {
+      "id": "rep-slice-v1-004",
+      "category": "multi_step_app_workflow",
+      "input": "Synthetic app workflow: decide a novel roadmap sequence from ambiguous stakeholder notes.",
+      "expected_route": "provider_needed",
+      "rationale": "Ambiguous planning remains provider-needed in this route-only fixture.",
+      "public_safe": true,
+      "claim_scope": "fixture_only"
+    },
+    {
+      "id": "rep-slice-v1-005",
+      "category": "document_intake_normalization",
+      "input": "Synthetic document intake: normalize a public-safe changelog stub into title, section, and status fields.",
+      "expected_route": "cpu",
+      "rationale": "Local document parsing and normalization can be represented as CPU route-shape work.",
+      "public_safe": true,
+      "claim_scope": "fixture_only"
+    },
+    {
+      "id": "rep-slice-v1-006",
+      "category": "document_intake_normalization",
+      "input": "Synthetic document intake: classify a short note as report, runbook, checklist, or index.",
+      "expected_route": "deterministic",
+      "rationale": "Bounded document-type classification fits deterministic route-shape handling.",
+      "public_safe": true,
+      "claim_scope": "fixture_only"
+    },
+    {
+      "id": "rep-slice-v1-007",
+      "category": "document_intake_normalization",
+      "input": "Synthetic document intake: retrieve a referenced local section before assigning the control label.",
+      "expected_route": "retrieval_needed",
+      "rationale": "The route shape depends on local retrieval, not provider execution.",
+      "public_safe": true,
+      "claim_scope": "fixture_only"
+    },
+    {
+      "id": "rep-slice-v1-008",
+      "category": "document_intake_normalization",
+      "input": "Synthetic document intake: placeholder-restricted content requests external summarization.",
+      "expected_route": "fallback",
+      "rationale": "Restricted placeholder content plus external handling should fall back safely.",
+      "public_safe": true,
+      "claim_scope": "fixture_only"
+    },
+    {
+      "id": "rep-slice-v1-009",
+      "category": "local_policy_checks",
+      "input": "Synthetic policy check: no-provider mode is active and a request asks for external model use.",
+      "expected_route": "fallback",
+      "rationale": "A policy conflict is represented as fallback control work.",
+      "public_safe": true,
+      "claim_scope": "fixture_only"
+    },
+    {
+      "id": "rep-slice-v1-010",
+      "category": "local_policy_checks",
+      "input": "Synthetic policy check: route a known safe local transformation under a no-network policy.",
+      "expected_route": "deterministic",
+      "rationale": "Known policy-compliant local work can use deterministic routing.",
+      "public_safe": true,
+      "claim_scope": "fixture_only"
+    },
+    {
+      "id": "rep-slice-v1-011",
+      "category": "local_policy_checks",
+      "input": "Synthetic policy check: inspect local fixture metadata before allowing the next step.",
+      "expected_route": "tool_needed",
+      "rationale": "Local metadata inspection is represented as tool-needed route-shape work.",
+      "public_safe": true,
+      "claim_scope": "fixture_only"
+    },
+    {
+      "id": "rep-slice-v1-012",
+      "category": "local_policy_checks",
+      "input": "Synthetic policy check: repeated allow/deny decision for the same public-safe fixture request.",
+      "expected_route": "cache",
+      "rationale": "Repeated policy classification is represented as cache-routable.",
+      "public_safe": true,
+      "claim_scope": "fixture_only"
+    },
+    {
+      "id": "rep-slice-v1-013",
+      "category": "schema_validation",
+      "input": "Synthetic schema task: validate required keys and route labels in a local JSON fixture.",
+      "expected_route": "tool_needed",
+      "rationale": "Schema validation uses local tooling rather than provider execution.",
+      "public_safe": true,
+      "claim_scope": "fixture_only"
+    },
+    {
+      "id": "rep-slice-v1-014",
+      "category": "schema_validation",
+      "input": "Synthetic schema task: coerce simple scalar values into a known report schema.",
+      "expected_route": "cpu",
+      "rationale": "Local coercion and structural validation can be represented as CPU work.",
+      "public_safe": true,
+      "claim_scope": "fixture_only"
+    },
+    {
+      "id": "rep-slice-v1-015",
+      "category": "schema_validation",
+      "input": "Synthetic schema task: route a missing mandatory field to a safe invalid-input branch.",
+      "expected_route": "fallback",
+      "rationale": "Invalid shape should use fallback control rather than provider reasoning.",
+      "public_safe": true,
+      "claim_scope": "fixture_only"
+    },
+    {
+      "id": "rep-slice-v1-016",
+      "category": "schema_validation",
+      "input": "Synthetic schema task: repeated validation of an unchanged local fixture manifest.",
+      "expected_route": "cache",
+      "rationale": "Repeated validation result is represented as cache-routable route-shape work.",
+      "public_safe": true,
+      "claim_scope": "fixture_only"
+    },
+    {
+      "id": "rep-slice-v1-017",
+      "category": "retry_fallback_control",
+      "input": "Synthetic retry task: failed local parse should retry once then route to fallback.",
+      "expected_route": "fallback",
+      "rationale": "Retry exhaustion is represented as fallback control work.",
+      "public_safe": true,
+      "claim_scope": "fixture_only"
+    },
+    {
+      "id": "rep-slice-v1-018",
+      "category": "retry_fallback_control",
+      "input": "Synthetic retry task: deterministic retry policy maps known error code 2 to a usage hint.",
+      "expected_route": "deterministic",
+      "rationale": "Known error-code handling fits deterministic route-shape work.",
+      "public_safe": true,
+      "claim_scope": "fixture_only"
+    },
+    {
+      "id": "rep-slice-v1-019",
+      "category": "retry_fallback_control",
+      "input": "Synthetic retry task: inspect a local status file before deciding whether retry is allowed.",
+      "expected_route": "tool_needed",
+      "rationale": "The route shape requires local inspection via tooling.",
+      "public_safe": true,
+      "claim_scope": "fixture_only"
+    },
+    {
+      "id": "rep-slice-v1-020",
+      "category": "retry_fallback_control",
+      "input": "Synthetic retry task: repeated transient error already classified in this fixture batch.",
+      "expected_route": "cache",
+      "rationale": "Repeated error classification can be represented as cache-routable.",
+      "public_safe": true,
+      "claim_scope": "fixture_only"
+    },
+    {
+      "id": "rep-slice-v1-021",
+      "category": "cache_reuse_candidates",
+      "input": "Synthetic cache task: exact repeat of a public-safe document classification request.",
+      "expected_route": "cache",
+      "rationale": "Exact repeated work is represented as cache-routable.",
+      "public_safe": true,
+      "claim_scope": "fixture_only"
+    },
+    {
+      "id": "rep-slice-v1-022",
+      "category": "cache_reuse_candidates",
+      "input": "Synthetic cache task: semantically equivalent route summary already exists locally.",
+      "expected_route": "cache",
+      "rationale": "Equivalent repeated work is represented as cache reuse.",
+      "public_safe": true,
+      "claim_scope": "fixture_only"
+    },
+    {
+      "id": "rep-slice-v1-023",
+      "category": "cache_reuse_candidates",
+      "input": "Synthetic cache task: repeated route-only evaluator counter lookup.",
+      "expected_route": "cache",
+      "rationale": "Repeated aggregate counter lookup can be represented as cache-routable.",
+      "public_safe": true,
+      "claim_scope": "fixture_only"
+    },
+    {
+      "id": "rep-slice-v1-024",
+      "category": "tool_needed_local_actions",
+      "input": "Synthetic tool task: list local fixture files before choosing the route-only evaluator.",
+      "expected_route": "tool_needed",
+      "rationale": "Local file listing is represented as tool-needed work.",
+      "public_safe": true,
+      "claim_scope": "fixture_only"
+    },
+    {
+      "id": "rep-slice-v1-025",
+      "category": "tool_needed_local_actions",
+      "input": "Synthetic tool task: run a local markdown-link check after a report update.",
+      "expected_route": "tool_needed",
+      "rationale": "Local validation tooling is represented as tool-needed route-shape work.",
+      "public_safe": true,
+      "claim_scope": "fixture_only"
+    },
+    {
+      "id": "rep-slice-v1-026",
+      "category": "tool_needed_local_actions",
+      "input": "Synthetic tool task: inspect a generated JSON report before recording counters.",
+      "expected_route": "tool_needed",
+      "rationale": "Local report inspection requires tooling rather than provider execution.",
+      "public_safe": true,
+      "claim_scope": "fixture_only"
+    },
+    {
+      "id": "rep-slice-v1-027",
+      "category": "retrieval_needed_candidates",
+      "input": "Synthetic retrieval task: answer depends on a local README section about source install.",
+      "expected_route": "retrieval_needed",
+      "rationale": "The route shape requires local retrieval before any answer path.",
+      "public_safe": true,
+      "claim_scope": "fixture_only"
+    },
+    {
+      "id": "rep-slice-v1-028",
+      "category": "retrieval_needed_candidates",
+      "input": "Synthetic retrieval task: locate the report that describes the prior first-run smoke checker.",
+      "expected_route": "retrieval_needed",
+      "rationale": "The route shape depends on retrieving a local report reference.",
+      "public_safe": true,
+      "claim_scope": "fixture_only"
+    },
+    {
+      "id": "rep-slice-v1-029",
+      "category": "retrieval_needed_candidates",
+      "input": "Synthetic retrieval task: find the fixture route label from a local manifest excerpt.",
+      "expected_route": "retrieval_needed",
+      "rationale": "Local retrieval is required before route labeling.",
+      "public_safe": true,
+      "claim_scope": "fixture_only"
+    },
+    {
+      "id": "rep-slice-v1-030",
+      "category": "provider_needed_ambiguous_tasks",
+      "input": "Synthetic ambiguous task: write a persuasive customer-facing narrative from sparse notes.",
+      "expected_route": "provider_needed",
+      "rationale": "Ambiguous generative work is marked provider-needed in this route-only fixture.",
+      "public_safe": true,
+      "claim_scope": "fixture_only"
+    },
+    {
+      "id": "rep-slice-v1-031",
+      "category": "provider_needed_ambiguous_tasks",
+      "input": "Synthetic ambiguous task: infer unstated owner intent from a vague one-line request.",
+      "expected_route": "provider_needed",
+      "rationale": "Unstructured intent inference is provider-needed rather than deterministic.",
+      "public_safe": true,
+      "claim_scope": "fixture_only"
+    },
+    {
+      "id": "rep-slice-v1-032",
+      "category": "provider_needed_ambiguous_tasks",
+      "input": "Synthetic ambiguous task: choose tradeoffs for a new feature without enough constraints.",
+      "expected_route": "provider_needed",
+      "rationale": "Open-ended tradeoff selection is outside deterministic fixture-only routing.",
+      "public_safe": true,
+      "claim_scope": "fixture_only"
+    },
+    {
+      "id": "rep-slice-v1-033",
+      "category": "gpu_candidate_batch_labels",
+      "input": "Synthetic GPU-candidate label: large batch embedding refresh is marked as GPU-candidate only.",
+      "expected_route": "gpu",
+      "rationale": "This is a label-only GPU candidate with no GPU execution.",
+      "public_safe": true,
+      "claim_scope": "fixture_only"
+    },
+    {
+      "id": "rep-slice-v1-034",
+      "category": "gpu_candidate_batch_labels",
+      "input": "Synthetic GPU-candidate label: bulk local vector scoring is marked as GPU-candidate only.",
+      "expected_route": "gpu",
+      "rationale": "This records route-shape labeling only and does not execute GPU work.",
+      "public_safe": true,
+      "claim_scope": "fixture_only"
+    },
+    {
+      "id": "rep-slice-v1-035",
+      "category": "gpu_candidate_batch_labels",
+      "input": "Synthetic GPU-candidate label: batched image-like placeholder processing is marked as GPU-candidate only.",
+      "expected_route": "gpu",
+      "rationale": "The fixture records a GPU-candidate label without H100, CUDA, or server execution.",
+      "public_safe": true,
+      "claim_scope": "fixture_only"
+    },
+    {
+      "id": "rep-slice-v1-036",
+      "category": "cpu_local_transforms",
+      "input": "Synthetic CPU transform: normalize dates and status strings in a public-safe task list.",
+      "expected_route": "cpu",
+      "rationale": "Structured local normalization is represented as CPU-routed work.",
+      "public_safe": true,
+      "claim_scope": "fixture_only"
+    },
+    {
+      "id": "rep-slice-v1-037",
+      "category": "cpu_local_transforms",
+      "input": "Synthetic CPU transform: aggregate route labels into local counters for a report draft.",
+      "expected_route": "cpu",
+      "rationale": "Aggregate counting is local CPU route-shape work.",
+      "public_safe": true,
+      "claim_scope": "fixture_only"
+    },
+    {
+      "id": "rep-slice-v1-038",
+      "category": "cpu_local_transforms",
+      "input": "Synthetic CPU transform: sort fixture rows by route group and category.",
+      "expected_route": "cpu",
+      "rationale": "Sorting and grouping public-safe rows is represented as CPU-routed work.",
+      "public_safe": true,
+      "claim_scope": "fixture_only"
+    },
+    {
+      "id": "rep-slice-v1-039",
+      "category": "report_generation_control",
+      "input": "Synthetic report control: assemble route-only counters into a local evidence note.",
+      "expected_route": "deterministic",
+      "rationale": "Templated counter reporting can be represented as deterministic route-shape work.",
+      "public_safe": true,
+      "claim_scope": "fixture_only"
+    },
+    {
+      "id": "rep-slice-v1-040",
+      "category": "report_generation_control",
+      "input": "Synthetic report control: retrieve prior report context before recording next recommendations.",
+      "expected_route": "retrieval_needed",
+      "rationale": "The report-control route shape needs local retrieval before updating context.",
+      "public_safe": true,
+      "claim_scope": "fixture_only"
+    }
+  ]
+}

--- a/scripts/evaluate_representativeness_slice_routes.py
+++ b/scripts/evaluate_representativeness_slice_routes.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections import Counter
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from scripts.validate_representativeness_seed import ALLOWED_ROUTES, validate_seed
+
+
+DEFAULT_FIXTURE = Path("examples/workloads/kora-representativeness-slice-v1.json")
+
+LOCAL_ROUTE_CANDIDATES = ("cpu", "deterministic", "retrieval_needed", "tool_needed")
+PROVIDER_MODEL_CANDIDATES = ("gpu", "provider_needed")
+CACHE_REUSE_CANDIDATES = ("cache",)
+FALLBACK_CONTROL_CANDIDATES = ("fallback",)
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise ValueError("fixture root must be an object")
+    return data
+
+
+def evaluate_routes(path: Path = DEFAULT_FIXTURE) -> dict[str, Any]:
+    validation_summary = validate_seed(path)
+    data = _load_json(path)
+    items = data["items"]
+
+    route_counts = Counter(item.get("expected_route") for item in items)
+    category_counts = Counter(item.get("category") for item in items)
+    unsupported_or_missing = sum(
+        1 for item in items if item.get("expected_route") not in ALLOWED_ROUTES
+    )
+
+    def count_routes(routes: tuple[str, ...]) -> int:
+        return sum(route_counts[route] for route in routes)
+
+    return {
+        "ok": True,
+        "fixture": str(path),
+        "validation": {
+            "shape_validated": validation_summary["ok"],
+            "claim_scope": validation_summary["claim_scope"],
+            "public_safe": validation_summary["public_safe"],
+        },
+        "total_slice_items": len(items),
+        "route_counts": {
+            route: route_counts[route]
+            for route in sorted(ALLOWED_ROUTES)
+            if route_counts[route]
+        },
+        "route_group_counts": {
+            "cache_reuse_candidates": count_routes(CACHE_REUSE_CANDIDATES),
+            "deterministic_local_route_candidates": count_routes(LOCAL_ROUTE_CANDIDATES),
+            "fallback_control_candidates": count_routes(FALLBACK_CONTROL_CANDIDATES),
+            "provider_model_candidates": count_routes(PROVIDER_MODEL_CANDIDATES),
+        },
+        "workload_category_counts": {
+            category: category_counts[category] for category in sorted(category_counts)
+        },
+        "unsupported_unknown_missing_route_metadata_count": unsupported_or_missing,
+        "non_claims": [
+            "does_not_call_providers",
+            "does_not_execute_h100_gpu_cuda_server_or_remote_work",
+            "does_not_run_model_inference",
+            "does_not_perform_semantic_judging_or_human_grading",
+            "does_not_prove_output_quality",
+            "does_not_prove_broader_workload_representativeness",
+            "does_not_prove_production_readiness",
+            "does_not_prove_cost_reduction",
+        ],
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Evaluate aggregate route counters for the second KORA representativeness slice fixture."
+    )
+    parser.add_argument(
+        "--fixture",
+        type=Path,
+        default=DEFAULT_FIXTURE,
+        help="Path to the second representativeness slice fixture.",
+    )
+    args = parser.parse_args(argv)
+
+    summary = evaluate_routes(args.fixture)
+    print(json.dumps(summary, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/validate_representativeness_seed.py
+++ b/scripts/validate_representativeness_seed.py
@@ -7,6 +7,10 @@ from typing import Any
 
 
 DEFAULT_FIXTURE = Path("examples/workloads/kora-representativeness-seed-v0.json")
+ALLOWED_SCHEMA_VERSIONS = {
+    "kora_representativeness_seed_v0",
+    "kora_representativeness_slice_v1",
+}
 REQUIRED_ITEM_FIELDS = {
     "id",
     "category",
@@ -40,7 +44,7 @@ def _load_json(path: Path) -> dict[str, Any]:
 
 def validate_seed(path: Path = DEFAULT_FIXTURE) -> dict[str, Any]:
     data = _load_json(path)
-    if data.get("schema_version") != "kora_representativeness_seed_v0":
+    if data.get("schema_version") not in ALLOWED_SCHEMA_VERSIONS:
         raise ValueError("unsupported schema_version")
     if data.get("public_safe") is not True:
         raise ValueError("fixture public_safe must be true")

--- a/tests/test_representativeness_slice_route_only_evaluator.py
+++ b/tests/test_representativeness_slice_route_only_evaluator.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+
+from scripts.evaluate_representativeness_slice_routes import DEFAULT_FIXTURE, evaluate_routes
+from scripts.validate_representativeness_seed import ALLOWED_ROUTES, validate_seed
+
+
+def test_slice_fixture_loads_and_is_public_safe() -> None:
+    summary = validate_seed(DEFAULT_FIXTURE)
+
+    assert summary["ok"] is True
+    assert summary["item_count"] == 40
+    assert summary["category_count"] == 12
+    assert summary["public_safe"] is True
+    assert summary["claim_scope"] == "fixture_only"
+    assert set(summary["route_counts"]) == ALLOWED_ROUTES
+
+
+def test_slice_fixture_item_ids_are_unique_and_route_labels_are_accepted() -> None:
+    fixture = json.loads(DEFAULT_FIXTURE.read_text(encoding="utf-8"))
+
+    ids = [item["id"] for item in fixture["items"]]
+    routes = {item["expected_route"] for item in fixture["items"]}
+
+    assert len(ids) == len(set(ids))
+    assert routes == ALLOWED_ROUTES
+    assert all(item["id"].startswith("rep-slice-v1-") for item in fixture["items"])
+    assert all(item["public_safe"] is True for item in fixture["items"])
+    assert all(item["claim_scope"] == "fixture_only" for item in fixture["items"])
+
+
+def test_slice_route_only_evaluator_counters_are_stable() -> None:
+    summary = evaluate_routes(DEFAULT_FIXTURE)
+
+    assert summary["ok"] is True
+    assert summary["total_slice_items"] == 40
+    assert summary["route_counts"] == {
+        "cache": 7,
+        "cpu": 6,
+        "deterministic": 5,
+        "fallback": 4,
+        "gpu": 3,
+        "provider_needed": 4,
+        "retrieval_needed": 5,
+        "tool_needed": 6,
+    }
+    assert summary["route_group_counts"] == {
+        "cache_reuse_candidates": 7,
+        "deterministic_local_route_candidates": 22,
+        "fallback_control_candidates": 4,
+        "provider_model_candidates": 7,
+    }
+    assert summary["unsupported_unknown_missing_route_metadata_count"] == 0
+
+
+def test_slice_route_only_evaluator_counts_workload_categories() -> None:
+    summary = evaluate_routes(DEFAULT_FIXTURE)
+
+    assert summary["workload_category_counts"] == {
+        "cache_reuse_candidates": 3,
+        "cpu_local_transforms": 3,
+        "document_intake_normalization": 4,
+        "gpu_candidate_batch_labels": 3,
+        "local_policy_checks": 4,
+        "multi_step_app_workflow": 4,
+        "provider_needed_ambiguous_tasks": 3,
+        "report_generation_control": 2,
+        "retrieval_needed_candidates": 3,
+        "retry_fallback_control": 4,
+        "schema_validation": 4,
+        "tool_needed_local_actions": 3,
+    }
+
+
+def test_slice_evaluator_output_remains_route_only() -> None:
+    summary = evaluate_routes(DEFAULT_FIXTURE)
+
+    assert "does_not_call_providers" in summary["non_claims"]
+    assert "does_not_run_model_inference" in summary["non_claims"]
+    assert "does_not_prove_output_quality" in summary["non_claims"]
+    assert "does_not_prove_broader_workload_representativeness" in summary["non_claims"]
+    assert "does_not_prove_production_readiness" in summary["non_claims"]
+    assert "quality_score" not in summary
+    assert "semantic_judgment" not in summary
+    assert "human_grade" not in summary
+
+
+def test_slice_route_only_evaluator_cli_outputs_deterministic_json() -> None:
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "scripts/evaluate_representativeness_slice_routes.py",
+            "--fixture",
+            str(DEFAULT_FIXTURE),
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert completed.returncode == 0
+    summary = json.loads(completed.stdout)
+    assert summary["total_slice_items"] == 40
+    assert list(summary["route_counts"]) == [
+        "cache",
+        "cpu",
+        "deterministic",
+        "fallback",
+        "gpu",
+        "provider_needed",
+        "retrieval_needed",
+        "tool_needed",
+    ]
+    assert summary["unsupported_unknown_missing_route_metadata_count"] == 0


### PR DESCRIPTION
## Summary

Group 116 adds a second public-safe synthetic route-only fixture slice adjacent to Goal 102/103 without expanding claims.

Changes:

- adds `examples/workloads/kora-representativeness-slice-v1.json` with 40 synthetic fixture-only route-shape items
- adds `scripts/evaluate_representativeness_slice_routes.py` for aggregate counters only
- generalizes `scripts/validate_representativeness_seed.py` to accept the new slice schema while preserving the Goal 102 default fixture
- adds focused tests and Group 116 report/breadcrumb updates

## Real Route-Only Counters

`python3 scripts/evaluate_representativeness_slice_routes.py` passed with:

- total slice items: `40`
- unsupported / unknown / missing route metadata count: `0`
- route counts: `cache=7`, `cpu=6`, `deterministic=5`, `fallback=4`, `gpu=3`, `provider_needed=4`, `retrieval_needed=5`, `tool_needed=6`
- route group counts: `cache_reuse_candidates=7`, `deterministic_local_route_candidates=22`, `fallback_control_candidates=4`, `provider_model_candidates=7`

## Boundaries

This is route-only aggregate fixture evidence. It does not implement `CIL-003`, change validation profile registries, change command profile registries, call providers, run model inference, run H100/GPU/CUDA/server/remote execution, perform semantic judging or human grading, publish packages, claim `getkora` is published, claim install-from-PyPI support, prove output quality, prove broader workload representativeness, prove production readiness, prove cost reduction, claim provider replacement, or claim GPU-serving replacement.

## Validation

- `python3 -m pytest tests/test_representativeness_slice_route_only_evaluator.py tests/test_representativeness_seed.py tests/test_representativeness_route_only_evaluator.py` - passed, `12 passed`
- `python3 scripts/evaluate_representativeness_slice_routes.py` - passed
- `python3 scripts/check_markdown_links_goal082b.py` - passed
- `git diff --check` - passed
- `python3 -m pytest` - passed, `501 passed`

Final classification: `merge-ready`.

`CIL-003` remains deferred.
