### PR TITLE
docs: add model escalation glossary entry

### DIFF
--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -89,6 +89,18 @@ Architectural pattern where every request triggers a model invocation without ev
 
 ---
 
+## Model Escalation
+
+The path a task takes when deterministic handling is not safe or sufficient.
+
+In KORA, tasks first attempt deterministic routing — arithmetic, lookup, structural transformation. When those routes cannot satisfy the task's type or schema requirements, the task escalates to a model invocation.
+
+Model escalation is not a fallback. It is a deliberate routing decision made by the orchestrator based on task type, budget, and validation constraints.
+
+The ratio of deterministic routes to model escalations is a key architectural metric.
+
+---
+
 ## Model Task
 
 A task requiring probabilistic reasoning through a model invocation.


### PR DESCRIPTION
The glossary was missing a definition for model escalation — it is referenced in the workload spec and benchmark docs but never formally defined.

- Added `Model Escalation` entry to `docs/glossary.md`
- Positioned alphabetically between Inference Reflexivity and Model Task
- Covers: what escalation is, how it works in KORA, and why the deterministic-to-escalation ratio matters

Closes #200