### PR TITLE
Add routing robustness experiment (intent-preserving paraphrase, 0 LLM calls)

### DIFF
--- a/experiments/kora_target_workload/paraphrase.py
+++ b/experiments/kora_target_workload/paraphrase.py
@@ -1,0 +1,101 @@
+"""Deterministic, intent-preserving paraphrase transforms for KORA's routing
+robustness test.
+
+Goal: test the claim made in kb_match.py (Safety Guard #3) and implied by the
+strict FORMAT frame in dispatcher.py — that routing signals come from a query's
+*meaning*, not its exact surface wording. We do this WITHOUT any LLM call: each
+transform rewrites only the `text` surface in a way a real user might naturally
+phrase the same request, and leaves every label (`should_escalate`,
+`ground_truth`, `payload`, `meta`) untouched.
+
+Methodology guard (frozen before measuring anything): transforms are defined by
+"would a real user write it this way for the same intent?", NOT by whether they
+help or hurt the dispatcher. We report whatever happens — breaks are real
+weaknesses, non-breaks are real robustness. We never hand-craft a transform to
+force a trap into a valid frame, nor to dodge a known-fragile path.
+
+Each transform maps one case's text -> one new text (deterministic). Applying a
+transform to the full workload yields one paraphrased workload variant; routing
+metrics on it are compared against the original.
+"""
+
+from __future__ import annotations
+
+import re
+
+
+def t_whitespace(text: str) -> str:
+    """Insert benign double spaces between words and pad the ends, the kind of
+    sloppy spacing real users produce. A meaning-preserving no-op for a reader."""
+    collapsed = re.sub(r"\s+", " ", text.strip())
+    return "  " + collapsed.replace(" ", "  ") + " "
+
+
+def t_punct(text: str) -> str:
+    """Flip terminal punctuation: a question gets its '?' dropped, a
+    non-question gets a trailing '?' added. Users are inconsistent about this."""
+    s = text.rstrip()
+    if s.endswith("?"):
+        return s[:-1].rstrip()
+    if s.endswith("."):
+        return s[:-1].rstrip() + "?"
+    return s + "?"
+
+
+def t_case(text: str) -> str:
+    """Sentence-case the whole thing. The dispatcher lowercases internally, so
+    this is PREDICTED to be a true no-op for routing — it is included as a
+    sanity check: any flip here signals a bug in our own pipeline, not a real
+    sensitivity in the router."""
+    if not text:
+        return text
+    return text[0].upper() + text[1:].lower()
+
+
+def t_polite_prefix(text: str) -> str:
+    """Prepend a natural politeness lead-in. PREDICTED to break the strict
+    FORMAT frame (which anchors on '^is this a valid'), an honest cost-only
+    flip; FAQ/POLICY keep their substring keywords and should survive."""
+    return "Could you please tell me: " + text[0].lower() + text[1:] if text else text
+
+
+_SYNONYMS = [
+    (r"\bvalid\b", "correct"),
+    (r"\bopen\b", "available"),
+    (r"\bhours\b", "times"),
+    (r"\brefund\b", "money back"),
+    (r"\beligible\b", "qualified"),
+]
+
+
+def t_synonym(text: str) -> str:
+    """Apply conservative, user-plausible synonym swaps. Some of these are
+    PREDICTED to break routing (e.g. 'valid'->'correct' defeats the FORMAT
+    frame's literal; 'refund'->'money back' drops the policy topic keyword).
+    They are included precisely because a real user would say them — the breaks
+    they cause are honest measurements of keyword fragility."""
+    out = text
+    for pat, repl in _SYNONYMS:
+        out = re.sub(pat, repl, out, flags=re.IGNORECASE)
+    return out
+
+
+TRANSFORMS = {
+    "whitespace": t_whitespace,
+    "punct": t_punct,
+    "case": t_case,
+    "polite_prefix": t_polite_prefix,
+    "synonym": t_synonym,
+}
+
+
+def apply_transform(cases: list[dict], name: str) -> list[dict]:
+    """Return a copy of `cases` with `text` rewritten by transform `name`. Only
+    `text` changes; all labels are preserved."""
+    fn = TRANSFORMS[name]
+    out = []
+    for c in cases:
+        nc = dict(c)
+        nc["text"] = fn(c["text"])
+        out.append(nc)
+    return out

--- a/experiments/kora_target_workload/results/robustness/ROBUSTNESS.md
+++ b/experiments/kora_target_workload/results/robustness/ROBUSTNESS.md
@@ -1,0 +1,167 @@
+# Routing Robustness Under Intent-Preserving Paraphrase
+
+**Question.** KORA's front door routes *answer-blind*: it sees only the user
+`text` (and an optional structured `payload`), then either answers
+deterministically or abstains so the query escalates to an LLM. `kb_match.py`
+states (Safety Guard #3) that its routing signals come from a query's *meaning*,
+not its exact wording. This experiment tests that claim empirically — and, more
+importantly, asks a safety question: **can a surface rephrasing of a query that
+*should* escalate cause the front door to deflect it instead?**
+
+A deflection that should have escalated is a *false deflection*: a hard query
+answered by a rule that was never meant to handle it. That is the only failure
+mode that matters for safety. A rephrasing that pushes an answerable query the
+other way — into the LLM — costs money but is harmless.
+
+**Result (preview).** Across 5 transforms × 330 cases, there were **0 dangerous
+flips**: no should-escalate case was ever paraphrased into a deflection. Every
+decision change went the safe direction (deflect → escalate). Surface ambiguity
+makes the front door *more* conservative, never less safe.
+
+---
+
+## Method
+
+All measurements are deterministic and use **zero LLM calls** — the same
+front-door code path as `run.py --routing-only` (`dispatcher.dispatch`, see
+`run.py` L485). No API key, no GPU.
+
+Each transform rewrites only a case's `text`. Every label
+(`should_escalate`, `ground_truth`, `payload`, `meta`) is left untouched, so the
+routing confusion matrix stays directly comparable to the original workload.
+
+### Methodology guard (frozen before measuring)
+
+Transforms were defined by a single criterion — *"would a real user write the
+same request this way?"* — and **not** by whether they help or hurt the
+dispatcher. We report whatever happens: breaks are real fragility, non-breaks
+are real robustness. No transform was hand-tuned to force a trap into a valid
+frame, nor to dodge a path we knew to be fragile.
+
+### Transforms
+
+| name | what it does | a priori prediction |
+|------|--------------|---------------------|
+| `whitespace`    | double the inter-word spaces, pad the ends | benign sloppiness |
+| `punct`         | flip terminal punctuation (`?` on/off)     | no-op |
+| `case`          | sentence-case the whole string             | **true no-op** (dispatcher lowercases internally) — a sanity check on our own pipeline |
+| `polite_prefix` | prepend "Could you please tell me: "       | breaks the strict FORMAT frame (cost-only) |
+| `synonym`       | conservative user-plausible swaps (`valid`→`correct`, `open`→`available`, `hours`→`times`, `refund`→`money back`, `eligible`→`qualified`) | breaks FORMAT literal + some policy/FAQ keywords |
+
+Positive class = `should_escalate`. A case is *escalated* when the front door
+abstains (`not routed`). Flips are bucketed as:
+
+- **dangerous**: should_escalate, original escalated, variant **deflected** → false deflection (safety failure). Target: 0.
+- **benign**: not should_escalate, original deflected, variant **escalated** → cost only.
+- **other**: any remaining change (reported for completeness).
+
+---
+
+## Results
+
+Original workload (full, 330 cases): deflection **0.767**, precision **0.883**,
+recall **0.971** (tp=68 fp=9 tn=251 fn=2). This matches the committed
+`results/routing_only.json`, confirming the harness shares the production
+routing path.
+
+| transform | deflection | precision | recall | **dangerous** | benign | other |
+|-----------|-----------:|----------:|-------:|--------------:|-------:|------:|
+| `whitespace`    | 0.388 | 0.337 | 0.971 | **0** | 126 | 1 |
+| `punct`         | 0.770 | 0.895 | 0.971 | **0** |   0 | 1 |
+| `case`          | 0.767 | 0.883 | 0.971 | **0** |   0 | 0 |
+| `polite_prefix` | 0.409 | 0.349 | 0.971 | **0** | 118 | 0 |
+| `synonym`       | 0.348 | 0.321 | 0.986 | **0** | 137 | 1 |
+
+**Dangerous flips: 0 across all transforms.** No should-escalate case was ever
+paraphrased into a deflection.
+
+### Where the deflection drops come from
+
+Benign flips, by category:
+
+| transform | format | faq | policy |
+|-----------|-------:|----:|-------:|
+| `whitespace`    | 118 | 8 | 0 |
+| `polite_prefix` | 118 | 0 | 0 |
+| `synonym`       | 118 | 3 | 16 |
+
+The drops are overwhelmingly **FORMAT** (118 of 120 FORMAT cases break under each
+of the three disruptive transforms). FORMAT routing relies on a strict regex
+frame (`^...is this a valid <type>: <candidate>...$`); any surface perturbation
+that disturbs the frame — a doubled space inside "email address", a polite
+prefix before "is this", or swapping the literal "valid" for "correct" — causes
+an abstain. FAQ and POLICY routing use substring keyword matching and are far
+more robust: FAQ breaks only on a handful of multi-word-keyword spacing/synonym
+cases (8 and 3), POLICY only when a synonym removes a topic/intent keyword
+(`refund`→`money back`, `eligible`→`qualified`; 16 cases).
+
+`punct` and `case` are true no-ops, exactly as predicted — `case` confirms our
+own pipeline introduces no spurious sensitivity (the dispatcher lowercases
+internally).
+
+---
+
+## Interpretation
+
+1. **The over-routing safety boundary is one-directional under paraphrase.**
+   Surface ambiguity can only make the front door abstain *more* (escalate to the
+   LLM), never deflect a hard query. This is a structural property of an
+   answer-blind front door whose default action is to abstain: when a learned or
+   literal signal is disturbed, the rule simply fails to fire, and a rule that
+   does not fire escalates. Failure is fail-safe by construction.
+
+2. **Robustness is path-dependent, and the regex path is the fragile one.**
+   Keyword-substring routing (FAQ, POLICY) tolerates most rephrasings; the strict
+   FORMAT regex does not. This is an honest design limitation: FORMAT trades
+   robustness for precision. It is also a clean lever for future work — a more
+   tolerant FORMAT frame would raise deflection on rephrased format questions
+   without touching the safety guarantee, since all FORMAT flips are benign.
+
+3. **Lower deflection here is a cost signal, not a safety signal.** The drop from
+   0.767 to ~0.39 under disruptive transforms means more queries reach the LLM —
+   it does not mean any query was mishandled.
+
+---
+
+## Honest limitations
+
+Two original false-negatives (should_escalate cases that the front door already
+routed *before* any paraphrase) surfaced during this experiment. They are
+pre-existing, not caused by the transforms, and are retained here as honest
+limitations of the current workload + reference evaluator.
+
+- **`rea-030` (reasoning, no payload).** Text: *"I got a damaged item as a gift
+  but I don't have the order number. Can you still help?"* A single KB signal
+  matches `faq:support_phone`, so the front door deflects and returns the support
+  phone number for a query that should have escalated. A genuine over-route; the
+  answer is an innocuous fallback, but the routing decision is wrong.
+
+- **`trp-030` (trap, payload present).** Text: *"Determine refund eligibility."*
+  with `payload={"days_since_delivery": -5, "item_category": "books",
+  "opened": false}`. The refund evaluator's `_as_int` checks type but not range,
+  so a physically impossible negative delivery age passes validation and the
+  policy returns "eligible". The trap was designed to probe exactly this input
+  hole; the shared evaluator (used by both `generate.py` for ground truth and the
+  dispatcher for routing) does not reject out-of-range integers, so the front door
+  routes instead of abstaining. This is an input-validation gap in the reference
+  evaluator, reported but not patched here to keep the committed routing numbers
+  and ground-truth generation stable. Adding a range check would convert this
+  fn into an abstain (recall would rise) and is tracked as separate future work.
+
+Notably, the `synonym` transform incidentally *fixes* `trp-030` (it strips the
+`refund`/`eligible` keywords, so the front door abstains), which is why
+`synonym` recall is 0.986 vs 0.971 elsewhere. We report this as an artifact, not
+as a robustness benefit.
+
+---
+
+## Reproduce
+
+```bash
+cd experiments/kora_target_workload
+python run_robustness.py --workload workloads/full.json \
+    --out results/robustness/robustness.json
+```
+
+Zero LLM calls, no key, no GPU. The per-case flip lists (including the two
+false-negatives above) are written to the output JSON.

--- a/experiments/kora_target_workload/results/robustness/robustness.json
+++ b/experiments/kora_target_workload/results/robustness/robustness.json
@@ -1,0 +1,3200 @@
+{
+  "workload": "workloads/full.json",
+  "n_cases": 330,
+  "original": {
+    "n": 330,
+    "routed": 253,
+    "deflection_rate": 0.7666666666666667,
+    "tp": 68,
+    "fp": 9,
+    "tn": 251,
+    "fn": 2,
+    "precision": 0.8831168831168831,
+    "recall": 0.9714285714285714
+  },
+  "variants": {
+    "whitespace": {
+      "metrics": {
+        "n": 330,
+        "routed": 128,
+        "deflection_rate": 0.3878787878787879,
+        "tp": 68,
+        "fp": 134,
+        "tn": 126,
+        "fn": 2,
+        "precision": 0.33663366336633666,
+        "recall": 0.9714285714285714
+      },
+      "n_dangerous": 0,
+      "n_benign": 126,
+      "n_other": 1,
+      "flips": {
+        "dangerous": [],
+        "benign": [
+          {
+            "id": "fmt-email-001",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid email address: user@example.com"
+          },
+          {
+            "id": "fmt-email-002",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid email address: jane.doe@example.org"
+          },
+          {
+            "id": "fmt-email-003",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid email address: user+promo@example.com"
+          },
+          {
+            "id": "fmt-email-004",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid email address: first.last@sub.example.co.uk"
+          },
+          {
+            "id": "fmt-email-005",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid email address: john_doe@example.com"
+          },
+          {
+            "id": "fmt-email-006",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid email address: a.b.c@example.io"
+          },
+          {
+            "id": "fmt-email-008",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid email address: sales@mail.example.net"
+          },
+          {
+            "id": "fmt-email-009",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid email address: r2d2@example.com"
+          },
+          {
+            "id": "fmt-email-010",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid email address: hello@example.travel"
+          },
+          {
+            "id": "fmt-email-011",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid email address: customer123@shop.example.com"
+          },
+          {
+            "id": "fmt-email-012",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid email address: q@example.com"
+          },
+          {
+            "id": "fmt-email-013",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid email address: a1@example.com"
+          },
+          {
+            "id": "fmt-email-014",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid email address: b2@example.net"
+          },
+          {
+            "id": "fmt-email-015",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid email address: c.d@example.org"
+          },
+          {
+            "id": "fmt-email-016",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid email address: e_f@example.io"
+          },
+          {
+            "id": "fmt-email-017",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid email address: g+h@example.com"
+          },
+          {
+            "id": "fmt-email-018",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid email address: ian@mail.example.com"
+          },
+          {
+            "id": "fmt-email-019",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid email address: jkl@example.co"
+          },
+          {
+            "id": "fmt-email-020",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid email address: mno@example.us"
+          },
+          {
+            "id": "fmt-email-021",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid email address: foo.example.com"
+          },
+          {
+            "id": "fmt-email-022",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid email address: a@@b.com"
+          },
+          {
+            "id": "fmt-email-023",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid email address: .leading@example.com"
+          },
+          {
+            "id": "fmt-email-024",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid email address: trailing.@example.com"
+          },
+          {
+            "id": "fmt-email-025",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid email address: @nodomain.com"
+          },
+          {
+            "id": "fmt-email-026",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid email address: noatdomain@"
+          },
+          {
+            "id": "fmt-email-027",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid email address: has space@example.com"
+          },
+          {
+            "id": "fmt-email-028",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid email address: user@exam ple.com"
+          },
+          {
+            "id": "fmt-email-029",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid email address: user@@@example.com"
+          },
+          {
+            "id": "fmt-email-030",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid email address: plaintext"
+          },
+          {
+            "id": "fmt-email-031",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid email address: user@.com"
+          },
+          {
+            "id": "fmt-email-032",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid email address: user@domain..com"
+          },
+          {
+            "id": "fmt-email-033",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid email address: a@localhost"
+          },
+          {
+            "id": "fmt-email-034",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid email address: user@example.com."
+          },
+          {
+            "id": "fmt-email-035",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid email address: abc@"
+          },
+          {
+            "id": "fmt-email-036",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid email address: @def.com"
+          },
+          {
+            "id": "fmt-email-037",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid email address: ghi@"
+          },
+          {
+            "id": "fmt-email-038",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid email address: mno@@pqr.com"
+          },
+          {
+            "id": "fmt-email-039",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid email address: stu vwx@example.com"
+          },
+          {
+            "id": "fmt-email-040",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid email address: a@b@c.com"
+          },
+          {
+            "id": "fmt-phone-001",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid phone number: (212) 736-5000"
+          },
+          {
+            "id": "fmt-phone-002",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid phone number: +1 212 736 5000"
+          },
+          {
+            "id": "fmt-phone-003",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid phone number: (415) 362-0788"
+          },
+          {
+            "id": "fmt-phone-004",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid phone number: +14153620788"
+          },
+          {
+            "id": "fmt-phone-005",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid phone number: +44 20 7183 8750"
+          },
+          {
+            "id": "fmt-phone-006",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid phone number: +61 2 9374 4000"
+          },
+          {
+            "id": "fmt-phone-007",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid phone number: (202) 456-1111"
+          },
+          {
+            "id": "fmt-phone-008",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid phone number: +12024561111"
+          },
+          {
+            "id": "fmt-phone-009",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid phone number: (312) 726-7000"
+          },
+          {
+            "id": "fmt-phone-010",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid phone number: +13127267000"
+          },
+          {
+            "id": "fmt-phone-011",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid phone number: (305) 358-5900"
+          },
+          {
+            "id": "fmt-phone-012",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid phone number: (404) 521-5000"
+          },
+          {
+            "id": "fmt-phone-013",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid phone number: +14045215000"
+          },
+          {
+            "id": "fmt-phone-014",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid phone number: (312) 744-5000"
+          },
+          {
+            "id": "fmt-phone-015",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid phone number: +1 312 744 5000"
+          },
+          {
+            "id": "fmt-phone-016",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid phone number: (617) 267-9300"
+          },
+          {
+            "id": "fmt-phone-017",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid phone number: +1 617 267 9300"
+          },
+          {
+            "id": "fmt-phone-018",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid phone number: (206) 684-4000"
+          },
+          {
+            "id": "fmt-phone-019",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid phone number: +1 206 684 4000"
+          },
+          {
+            "id": "fmt-phone-020",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid phone number: (702) 731-7110"
+          },
+          {
+            "id": "fmt-phone-021",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid phone number: 415-555"
+          },
+          {
+            "id": "fmt-phone-022",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid phone number: 123"
+          },
+          {
+            "id": "fmt-phone-023",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid phone number: +1 415 555 2671 999"
+          },
+          {
+            "id": "fmt-phone-024",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid phone number: 555-ABCD"
+          },
+          {
+            "id": "fmt-phone-025",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid phone number: (000) 000-0000"
+          },
+          {
+            "id": "fmt-phone-026",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid phone number: +1 000 000 0000"
+          },
+          {
+            "id": "fmt-phone-027",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid phone number: abcdefghij"
+          },
+          {
+            "id": "fmt-phone-028",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid phone number: +999 99 999"
+          },
+          {
+            "id": "fmt-phone-029",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid phone number: 12"
+          },
+          {
+            "id": "fmt-phone-031",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid phone number: +1-23"
+          },
+          {
+            "id": "fmt-phone-032",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid phone number: 00000"
+          },
+          {
+            "id": "fmt-phone-033",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid phone number: 1"
+          },
+          {
+            "id": "fmt-phone-034",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid phone number: +1 1"
+          },
+          {
+            "id": "fmt-phone-035",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid phone number: (999) 999-99999"
+          },
+          {
+            "id": "fmt-phone-036",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid phone number: phone"
+          },
+          {
+            "id": "fmt-phone-037",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid phone number: ++1234"
+          },
+          {
+            "id": "fmt-phone-038",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid phone number: +1 555 555 5555 5555"
+          },
+          {
+            "id": "fmt-phone-039",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid phone number: 123-45-6789"
+          },
+          {
+            "id": "fmt-phone-040",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid phone number: (12) 34"
+          },
+          {
+            "id": "fmt-date-001",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid calendar date in YYYY-MM-DD format: 2025-01-15"
+          },
+          {
+            "id": "fmt-date-002",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid calendar date in YYYY-MM-DD format: 2024-02-29"
+          },
+          {
+            "id": "fmt-date-003",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid calendar date in YYYY-MM-DD format: 2000-02-29"
+          },
+          {
+            "id": "fmt-date-004",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid calendar date in YYYY-MM-DD format: 2023-07-04"
+          },
+          {
+            "id": "fmt-date-005",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid calendar date in YYYY-MM-DD format: 2020-12-31"
+          },
+          {
+            "id": "fmt-date-006",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid calendar date in YYYY-MM-DD format: 1999-06-30"
+          },
+          {
+            "id": "fmt-date-007",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid calendar date in YYYY-MM-DD format: 2024-04-30"
+          },
+          {
+            "id": "fmt-date-008",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid calendar date in YYYY-MM-DD format: 2022-02-28"
+          },
+          {
+            "id": "fmt-date-009",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid calendar date in YYYY-MM-DD format: 2025-11-09"
+          },
+          {
+            "id": "fmt-date-010",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid calendar date in YYYY-MM-DD format: 2021-08-17"
+          },
+          {
+            "id": "fmt-date-011",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid calendar date in YYYY-MM-DD format: 2025-03-14"
+          },
+          {
+            "id": "fmt-date-012",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid calendar date in YYYY-MM-DD format: 2025-06-21"
+          },
+          {
+            "id": "fmt-date-013",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid calendar date in YYYY-MM-DD format: 2024-10-31"
+          },
+          {
+            "id": "fmt-date-014",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid calendar date in YYYY-MM-DD format: 2023-11-30"
+          },
+          {
+            "id": "fmt-date-015",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid calendar date in YYYY-MM-DD format: 2022-09-15"
+          },
+          {
+            "id": "fmt-date-016",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid calendar date in YYYY-MM-DD format: 2021-01-01"
+          },
+          {
+            "id": "fmt-date-017",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid calendar date in YYYY-MM-DD format: 2019-12-25"
+          },
+          {
+            "id": "fmt-date-018",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid calendar date in YYYY-MM-DD format: 2018-07-04"
+          },
+          {
+            "id": "fmt-date-019",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid calendar date in YYYY-MM-DD format: 2016-02-29"
+          },
+          {
+            "id": "fmt-date-020",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid calendar date in YYYY-MM-DD format: 2012-02-29"
+          },
+          {
+            "id": "fmt-date-021",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid calendar date in YYYY-MM-DD format: 2023-02-29"
+          },
+          {
+            "id": "fmt-date-022",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid calendar date in YYYY-MM-DD format: 1900-02-29"
+          },
+          {
+            "id": "fmt-date-023",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid calendar date in YYYY-MM-DD format: 2024-13-01"
+          },
+          {
+            "id": "fmt-date-024",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid calendar date in YYYY-MM-DD format: 2024-04-31"
+          },
+          {
+            "id": "fmt-date-025",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid calendar date in YYYY-MM-DD format: 2024-06-31"
+          },
+          {
+            "id": "fmt-date-026",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid calendar date in YYYY-MM-DD format: 2024-05-00"
+          },
+          {
+            "id": "fmt-date-027",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid calendar date in YYYY-MM-DD format: 2024-00-10"
+          },
+          {
+            "id": "fmt-date-028",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid calendar date in YYYY-MM-DD format: 2024-12-32"
+          },
+          {
+            "id": "fmt-date-029",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid calendar date in YYYY-MM-DD format: 2024-02-30"
+          },
+          {
+            "id": "fmt-date-030",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid calendar date in YYYY-MM-DD format: 31/12/2024"
+          },
+          {
+            "id": "fmt-date-031",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid calendar date in YYYY-MM-DD format: 2024.12.31"
+          },
+          {
+            "id": "fmt-date-032",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid calendar date in YYYY-MM-DD format: Dec-31-2024"
+          },
+          {
+            "id": "fmt-date-033",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid calendar date in YYYY-MM-DD format: 2025-02-29"
+          },
+          {
+            "id": "fmt-date-034",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid calendar date in YYYY-MM-DD format: 2100-02-29"
+          },
+          {
+            "id": "fmt-date-035",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid calendar date in YYYY-MM-DD format: 2025-13-15"
+          },
+          {
+            "id": "fmt-date-036",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid calendar date in YYYY-MM-DD format: 2025-04-31"
+          },
+          {
+            "id": "fmt-date-037",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid calendar date in YYYY-MM-DD format: 2025-09-31"
+          },
+          {
+            "id": "fmt-date-038",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid calendar date in YYYY-MM-DD format: 2025-11-31"
+          },
+          {
+            "id": "fmt-date-039",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid calendar date in YYYY-MM-DD format: 2025-06-00"
+          },
+          {
+            "id": "fmt-date-040",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid calendar date in YYYY-MM-DD format: 2025-01-32"
+          },
+          {
+            "id": "faq-001",
+            "category": "faq",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "When are you open during the week?"
+          },
+          {
+            "id": "faq-010",
+            "category": "faq",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "What's the time limit on getting my money back?"
+          },
+          {
+            "id": "faq-012",
+            "category": "faq",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "How long after delivery can I still request a refund?"
+          },
+          {
+            "id": "faq-018",
+            "category": "faq",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "How fast is delivery within the country?"
+          },
+          {
+            "id": "faq-020",
+            "category": "faq",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "How long does standard local delivery take?"
+          },
+          {
+            "id": "faq-030",
+            "category": "faq",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "How can I phone customer service?"
+          },
+          {
+            "id": "faq-053",
+            "category": "faq",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Do your gift cards expire?"
+          },
+          {
+            "id": "faq-054",
+            "category": "faq",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is there an expiration date on gift cards?"
+          }
+        ],
+        "other": [
+          {
+            "id": "faq-055",
+            "category": "faq",
+            "should_escalate": false,
+            "orig": "escalate",
+            "variant": "deflect",
+            "text": "How long is a gift card valid for?"
+          }
+        ]
+      }
+    },
+    "punct": {
+      "metrics": {
+        "n": 330,
+        "routed": 254,
+        "deflection_rate": 0.7696969696969697,
+        "tp": 68,
+        "fp": 8,
+        "tn": 252,
+        "fn": 2,
+        "precision": 0.8947368421052632,
+        "recall": 0.9714285714285714
+      },
+      "n_dangerous": 0,
+      "n_benign": 0,
+      "n_other": 1,
+      "flips": {
+        "dangerous": [],
+        "benign": [],
+        "other": [
+          {
+            "id": "fmt-phone-030",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "escalate",
+            "variant": "deflect",
+            "text": "Is this a valid phone number:    "
+          }
+        ]
+      }
+    },
+    "case": {
+      "metrics": {
+        "n": 330,
+        "routed": 253,
+        "deflection_rate": 0.7666666666666667,
+        "tp": 68,
+        "fp": 9,
+        "tn": 251,
+        "fn": 2,
+        "precision": 0.8831168831168831,
+        "recall": 0.9714285714285714
+      },
+      "n_dangerous": 0,
+      "n_benign": 0,
+      "n_other": 0,
+      "flips": {
+        "dangerous": [],
+        "benign": [],
+        "other": []
+      }
+    },
+    "polite_prefix": {
+      "metrics": {
+        "n": 330,
+        "routed": 135,
+        "deflection_rate": 0.4090909090909091,
+        "tp": 68,
+        "fp": 127,
+        "tn": 133,
+        "fn": 2,
+        "precision": 0.3487179487179487,
+        "recall": 0.9714285714285714
+      },
+      "n_dangerous": 0,
+      "n_benign": 118,
+      "n_other": 0,
+      "flips": {
+        "dangerous": [],
+        "benign": [
+          {
+            "id": "fmt-email-001",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid email address: user@example.com"
+          },
+          {
+            "id": "fmt-email-002",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid email address: jane.doe@example.org"
+          },
+          {
+            "id": "fmt-email-003",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid email address: user+promo@example.com"
+          },
+          {
+            "id": "fmt-email-004",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid email address: first.last@sub.example.co.uk"
+          },
+          {
+            "id": "fmt-email-005",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid email address: john_doe@example.com"
+          },
+          {
+            "id": "fmt-email-006",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid email address: a.b.c@example.io"
+          },
+          {
+            "id": "fmt-email-008",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid email address: sales@mail.example.net"
+          },
+          {
+            "id": "fmt-email-009",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid email address: r2d2@example.com"
+          },
+          {
+            "id": "fmt-email-010",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid email address: hello@example.travel"
+          },
+          {
+            "id": "fmt-email-011",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid email address: customer123@shop.example.com"
+          },
+          {
+            "id": "fmt-email-012",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid email address: q@example.com"
+          },
+          {
+            "id": "fmt-email-013",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid email address: a1@example.com"
+          },
+          {
+            "id": "fmt-email-014",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid email address: b2@example.net"
+          },
+          {
+            "id": "fmt-email-015",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid email address: c.d@example.org"
+          },
+          {
+            "id": "fmt-email-016",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid email address: e_f@example.io"
+          },
+          {
+            "id": "fmt-email-017",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid email address: g+h@example.com"
+          },
+          {
+            "id": "fmt-email-018",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid email address: ian@mail.example.com"
+          },
+          {
+            "id": "fmt-email-019",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid email address: jkl@example.co"
+          },
+          {
+            "id": "fmt-email-020",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid email address: mno@example.us"
+          },
+          {
+            "id": "fmt-email-021",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid email address: foo.example.com"
+          },
+          {
+            "id": "fmt-email-022",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid email address: a@@b.com"
+          },
+          {
+            "id": "fmt-email-023",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid email address: .leading@example.com"
+          },
+          {
+            "id": "fmt-email-024",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid email address: trailing.@example.com"
+          },
+          {
+            "id": "fmt-email-025",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid email address: @nodomain.com"
+          },
+          {
+            "id": "fmt-email-026",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid email address: noatdomain@"
+          },
+          {
+            "id": "fmt-email-027",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid email address: has space@example.com"
+          },
+          {
+            "id": "fmt-email-028",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid email address: user@exam ple.com"
+          },
+          {
+            "id": "fmt-email-029",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid email address: user@@@example.com"
+          },
+          {
+            "id": "fmt-email-030",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid email address: plaintext"
+          },
+          {
+            "id": "fmt-email-031",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid email address: user@.com"
+          },
+          {
+            "id": "fmt-email-032",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid email address: user@domain..com"
+          },
+          {
+            "id": "fmt-email-033",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid email address: a@localhost"
+          },
+          {
+            "id": "fmt-email-034",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid email address: user@example.com."
+          },
+          {
+            "id": "fmt-email-035",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid email address: abc@"
+          },
+          {
+            "id": "fmt-email-036",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid email address: @def.com"
+          },
+          {
+            "id": "fmt-email-037",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid email address: ghi@"
+          },
+          {
+            "id": "fmt-email-038",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid email address: mno@@pqr.com"
+          },
+          {
+            "id": "fmt-email-039",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid email address: stu vwx@example.com"
+          },
+          {
+            "id": "fmt-email-040",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid email address: a@b@c.com"
+          },
+          {
+            "id": "fmt-phone-001",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid phone number: (212) 736-5000"
+          },
+          {
+            "id": "fmt-phone-002",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid phone number: +1 212 736 5000"
+          },
+          {
+            "id": "fmt-phone-003",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid phone number: (415) 362-0788"
+          },
+          {
+            "id": "fmt-phone-004",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid phone number: +14153620788"
+          },
+          {
+            "id": "fmt-phone-005",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid phone number: +44 20 7183 8750"
+          },
+          {
+            "id": "fmt-phone-006",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid phone number: +61 2 9374 4000"
+          },
+          {
+            "id": "fmt-phone-007",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid phone number: (202) 456-1111"
+          },
+          {
+            "id": "fmt-phone-008",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid phone number: +12024561111"
+          },
+          {
+            "id": "fmt-phone-009",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid phone number: (312) 726-7000"
+          },
+          {
+            "id": "fmt-phone-010",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid phone number: +13127267000"
+          },
+          {
+            "id": "fmt-phone-011",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid phone number: (305) 358-5900"
+          },
+          {
+            "id": "fmt-phone-012",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid phone number: (404) 521-5000"
+          },
+          {
+            "id": "fmt-phone-013",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid phone number: +14045215000"
+          },
+          {
+            "id": "fmt-phone-014",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid phone number: (312) 744-5000"
+          },
+          {
+            "id": "fmt-phone-015",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid phone number: +1 312 744 5000"
+          },
+          {
+            "id": "fmt-phone-016",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid phone number: (617) 267-9300"
+          },
+          {
+            "id": "fmt-phone-017",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid phone number: +1 617 267 9300"
+          },
+          {
+            "id": "fmt-phone-018",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid phone number: (206) 684-4000"
+          },
+          {
+            "id": "fmt-phone-019",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid phone number: +1 206 684 4000"
+          },
+          {
+            "id": "fmt-phone-020",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid phone number: (702) 731-7110"
+          },
+          {
+            "id": "fmt-phone-021",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid phone number: 415-555"
+          },
+          {
+            "id": "fmt-phone-022",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid phone number: 123"
+          },
+          {
+            "id": "fmt-phone-023",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid phone number: +1 415 555 2671 999"
+          },
+          {
+            "id": "fmt-phone-024",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid phone number: 555-ABCD"
+          },
+          {
+            "id": "fmt-phone-025",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid phone number: (000) 000-0000"
+          },
+          {
+            "id": "fmt-phone-026",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid phone number: +1 000 000 0000"
+          },
+          {
+            "id": "fmt-phone-027",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid phone number: abcdefghij"
+          },
+          {
+            "id": "fmt-phone-028",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid phone number: +999 99 999"
+          },
+          {
+            "id": "fmt-phone-029",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid phone number: 12"
+          },
+          {
+            "id": "fmt-phone-031",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid phone number: +1-23"
+          },
+          {
+            "id": "fmt-phone-032",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid phone number: 00000"
+          },
+          {
+            "id": "fmt-phone-033",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid phone number: 1"
+          },
+          {
+            "id": "fmt-phone-034",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid phone number: +1 1"
+          },
+          {
+            "id": "fmt-phone-035",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid phone number: (999) 999-99999"
+          },
+          {
+            "id": "fmt-phone-036",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid phone number: phone"
+          },
+          {
+            "id": "fmt-phone-037",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid phone number: ++1234"
+          },
+          {
+            "id": "fmt-phone-038",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid phone number: +1 555 555 5555 5555"
+          },
+          {
+            "id": "fmt-phone-039",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid phone number: 123-45-6789"
+          },
+          {
+            "id": "fmt-phone-040",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid phone number: (12) 34"
+          },
+          {
+            "id": "fmt-date-001",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid calendar date in YYYY-MM-DD format: 2025-01-15"
+          },
+          {
+            "id": "fmt-date-002",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid calendar date in YYYY-MM-DD format: 2024-02-29"
+          },
+          {
+            "id": "fmt-date-003",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid calendar date in YYYY-MM-DD format: 2000-02-29"
+          },
+          {
+            "id": "fmt-date-004",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid calendar date in YYYY-MM-DD format: 2023-07-04"
+          },
+          {
+            "id": "fmt-date-005",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid calendar date in YYYY-MM-DD format: 2020-12-31"
+          },
+          {
+            "id": "fmt-date-006",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid calendar date in YYYY-MM-DD format: 1999-06-30"
+          },
+          {
+            "id": "fmt-date-007",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid calendar date in YYYY-MM-DD format: 2024-04-30"
+          },
+          {
+            "id": "fmt-date-008",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid calendar date in YYYY-MM-DD format: 2022-02-28"
+          },
+          {
+            "id": "fmt-date-009",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid calendar date in YYYY-MM-DD format: 2025-11-09"
+          },
+          {
+            "id": "fmt-date-010",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid calendar date in YYYY-MM-DD format: 2021-08-17"
+          },
+          {
+            "id": "fmt-date-011",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid calendar date in YYYY-MM-DD format: 2025-03-14"
+          },
+          {
+            "id": "fmt-date-012",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid calendar date in YYYY-MM-DD format: 2025-06-21"
+          },
+          {
+            "id": "fmt-date-013",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid calendar date in YYYY-MM-DD format: 2024-10-31"
+          },
+          {
+            "id": "fmt-date-014",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid calendar date in YYYY-MM-DD format: 2023-11-30"
+          },
+          {
+            "id": "fmt-date-015",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid calendar date in YYYY-MM-DD format: 2022-09-15"
+          },
+          {
+            "id": "fmt-date-016",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid calendar date in YYYY-MM-DD format: 2021-01-01"
+          },
+          {
+            "id": "fmt-date-017",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid calendar date in YYYY-MM-DD format: 2019-12-25"
+          },
+          {
+            "id": "fmt-date-018",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid calendar date in YYYY-MM-DD format: 2018-07-04"
+          },
+          {
+            "id": "fmt-date-019",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid calendar date in YYYY-MM-DD format: 2016-02-29"
+          },
+          {
+            "id": "fmt-date-020",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid calendar date in YYYY-MM-DD format: 2012-02-29"
+          },
+          {
+            "id": "fmt-date-021",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid calendar date in YYYY-MM-DD format: 2023-02-29"
+          },
+          {
+            "id": "fmt-date-022",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid calendar date in YYYY-MM-DD format: 1900-02-29"
+          },
+          {
+            "id": "fmt-date-023",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid calendar date in YYYY-MM-DD format: 2024-13-01"
+          },
+          {
+            "id": "fmt-date-024",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid calendar date in YYYY-MM-DD format: 2024-04-31"
+          },
+          {
+            "id": "fmt-date-025",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid calendar date in YYYY-MM-DD format: 2024-06-31"
+          },
+          {
+            "id": "fmt-date-026",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid calendar date in YYYY-MM-DD format: 2024-05-00"
+          },
+          {
+            "id": "fmt-date-027",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid calendar date in YYYY-MM-DD format: 2024-00-10"
+          },
+          {
+            "id": "fmt-date-028",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid calendar date in YYYY-MM-DD format: 2024-12-32"
+          },
+          {
+            "id": "fmt-date-029",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid calendar date in YYYY-MM-DD format: 2024-02-30"
+          },
+          {
+            "id": "fmt-date-030",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid calendar date in YYYY-MM-DD format: 31/12/2024"
+          },
+          {
+            "id": "fmt-date-031",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid calendar date in YYYY-MM-DD format: 2024.12.31"
+          },
+          {
+            "id": "fmt-date-032",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid calendar date in YYYY-MM-DD format: Dec-31-2024"
+          },
+          {
+            "id": "fmt-date-033",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid calendar date in YYYY-MM-DD format: 2025-02-29"
+          },
+          {
+            "id": "fmt-date-034",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid calendar date in YYYY-MM-DD format: 2100-02-29"
+          },
+          {
+            "id": "fmt-date-035",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid calendar date in YYYY-MM-DD format: 2025-13-15"
+          },
+          {
+            "id": "fmt-date-036",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid calendar date in YYYY-MM-DD format: 2025-04-31"
+          },
+          {
+            "id": "fmt-date-037",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid calendar date in YYYY-MM-DD format: 2025-09-31"
+          },
+          {
+            "id": "fmt-date-038",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid calendar date in YYYY-MM-DD format: 2025-11-31"
+          },
+          {
+            "id": "fmt-date-039",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid calendar date in YYYY-MM-DD format: 2025-06-00"
+          },
+          {
+            "id": "fmt-date-040",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid calendar date in YYYY-MM-DD format: 2025-01-32"
+          }
+        ],
+        "other": []
+      }
+    },
+    "synonym": {
+      "metrics": {
+        "n": 330,
+        "routed": 115,
+        "deflection_rate": 0.3484848484848485,
+        "tp": 69,
+        "fp": 146,
+        "tn": 114,
+        "fn": 1,
+        "precision": 0.3209302325581395,
+        "recall": 0.9857142857142858
+      },
+      "n_dangerous": 0,
+      "n_benign": 137,
+      "n_other": 1,
+      "flips": {
+        "dangerous": [],
+        "benign": [
+          {
+            "id": "fmt-email-001",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid email address: user@example.com"
+          },
+          {
+            "id": "fmt-email-002",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid email address: jane.doe@example.org"
+          },
+          {
+            "id": "fmt-email-003",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid email address: user+promo@example.com"
+          },
+          {
+            "id": "fmt-email-004",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid email address: first.last@sub.example.co.uk"
+          },
+          {
+            "id": "fmt-email-005",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid email address: john_doe@example.com"
+          },
+          {
+            "id": "fmt-email-006",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid email address: a.b.c@example.io"
+          },
+          {
+            "id": "fmt-email-008",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid email address: sales@mail.example.net"
+          },
+          {
+            "id": "fmt-email-009",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid email address: r2d2@example.com"
+          },
+          {
+            "id": "fmt-email-010",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid email address: hello@example.travel"
+          },
+          {
+            "id": "fmt-email-011",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid email address: customer123@shop.example.com"
+          },
+          {
+            "id": "fmt-email-012",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid email address: q@example.com"
+          },
+          {
+            "id": "fmt-email-013",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid email address: a1@example.com"
+          },
+          {
+            "id": "fmt-email-014",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid email address: b2@example.net"
+          },
+          {
+            "id": "fmt-email-015",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid email address: c.d@example.org"
+          },
+          {
+            "id": "fmt-email-016",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid email address: e_f@example.io"
+          },
+          {
+            "id": "fmt-email-017",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid email address: g+h@example.com"
+          },
+          {
+            "id": "fmt-email-018",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid email address: ian@mail.example.com"
+          },
+          {
+            "id": "fmt-email-019",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid email address: jkl@example.co"
+          },
+          {
+            "id": "fmt-email-020",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid email address: mno@example.us"
+          },
+          {
+            "id": "fmt-email-021",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid email address: foo.example.com"
+          },
+          {
+            "id": "fmt-email-022",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid email address: a@@b.com"
+          },
+          {
+            "id": "fmt-email-023",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid email address: .leading@example.com"
+          },
+          {
+            "id": "fmt-email-024",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid email address: trailing.@example.com"
+          },
+          {
+            "id": "fmt-email-025",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid email address: @nodomain.com"
+          },
+          {
+            "id": "fmt-email-026",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid email address: noatdomain@"
+          },
+          {
+            "id": "fmt-email-027",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid email address: has space@example.com"
+          },
+          {
+            "id": "fmt-email-028",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid email address: user@exam ple.com"
+          },
+          {
+            "id": "fmt-email-029",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid email address: user@@@example.com"
+          },
+          {
+            "id": "fmt-email-030",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid email address: plaintext"
+          },
+          {
+            "id": "fmt-email-031",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid email address: user@.com"
+          },
+          {
+            "id": "fmt-email-032",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid email address: user@domain..com"
+          },
+          {
+            "id": "fmt-email-033",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid email address: a@localhost"
+          },
+          {
+            "id": "fmt-email-034",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid email address: user@example.com."
+          },
+          {
+            "id": "fmt-email-035",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid email address: abc@"
+          },
+          {
+            "id": "fmt-email-036",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid email address: @def.com"
+          },
+          {
+            "id": "fmt-email-037",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid email address: ghi@"
+          },
+          {
+            "id": "fmt-email-038",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid email address: mno@@pqr.com"
+          },
+          {
+            "id": "fmt-email-039",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid email address: stu vwx@example.com"
+          },
+          {
+            "id": "fmt-email-040",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid email address: a@b@c.com"
+          },
+          {
+            "id": "fmt-phone-001",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid phone number: (212) 736-5000"
+          },
+          {
+            "id": "fmt-phone-002",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid phone number: +1 212 736 5000"
+          },
+          {
+            "id": "fmt-phone-003",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid phone number: (415) 362-0788"
+          },
+          {
+            "id": "fmt-phone-004",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid phone number: +14153620788"
+          },
+          {
+            "id": "fmt-phone-005",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid phone number: +44 20 7183 8750"
+          },
+          {
+            "id": "fmt-phone-006",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid phone number: +61 2 9374 4000"
+          },
+          {
+            "id": "fmt-phone-007",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid phone number: (202) 456-1111"
+          },
+          {
+            "id": "fmt-phone-008",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid phone number: +12024561111"
+          },
+          {
+            "id": "fmt-phone-009",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid phone number: (312) 726-7000"
+          },
+          {
+            "id": "fmt-phone-010",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid phone number: +13127267000"
+          },
+          {
+            "id": "fmt-phone-011",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid phone number: (305) 358-5900"
+          },
+          {
+            "id": "fmt-phone-012",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid phone number: (404) 521-5000"
+          },
+          {
+            "id": "fmt-phone-013",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid phone number: +14045215000"
+          },
+          {
+            "id": "fmt-phone-014",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid phone number: (312) 744-5000"
+          },
+          {
+            "id": "fmt-phone-015",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid phone number: +1 312 744 5000"
+          },
+          {
+            "id": "fmt-phone-016",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid phone number: (617) 267-9300"
+          },
+          {
+            "id": "fmt-phone-017",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid phone number: +1 617 267 9300"
+          },
+          {
+            "id": "fmt-phone-018",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid phone number: (206) 684-4000"
+          },
+          {
+            "id": "fmt-phone-019",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid phone number: +1 206 684 4000"
+          },
+          {
+            "id": "fmt-phone-020",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid phone number: (702) 731-7110"
+          },
+          {
+            "id": "fmt-phone-021",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid phone number: 415-555"
+          },
+          {
+            "id": "fmt-phone-022",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid phone number: 123"
+          },
+          {
+            "id": "fmt-phone-023",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid phone number: +1 415 555 2671 999"
+          },
+          {
+            "id": "fmt-phone-024",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid phone number: 555-ABCD"
+          },
+          {
+            "id": "fmt-phone-025",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid phone number: (000) 000-0000"
+          },
+          {
+            "id": "fmt-phone-026",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid phone number: +1 000 000 0000"
+          },
+          {
+            "id": "fmt-phone-027",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid phone number: abcdefghij"
+          },
+          {
+            "id": "fmt-phone-028",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid phone number: +999 99 999"
+          },
+          {
+            "id": "fmt-phone-029",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid phone number: 12"
+          },
+          {
+            "id": "fmt-phone-031",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid phone number: +1-23"
+          },
+          {
+            "id": "fmt-phone-032",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid phone number: 00000"
+          },
+          {
+            "id": "fmt-phone-033",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid phone number: 1"
+          },
+          {
+            "id": "fmt-phone-034",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid phone number: +1 1"
+          },
+          {
+            "id": "fmt-phone-035",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid phone number: (999) 999-99999"
+          },
+          {
+            "id": "fmt-phone-036",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid phone number: phone"
+          },
+          {
+            "id": "fmt-phone-037",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid phone number: ++1234"
+          },
+          {
+            "id": "fmt-phone-038",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid phone number: +1 555 555 5555 5555"
+          },
+          {
+            "id": "fmt-phone-039",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid phone number: 123-45-6789"
+          },
+          {
+            "id": "fmt-phone-040",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid phone number: (12) 34"
+          },
+          {
+            "id": "fmt-date-001",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid calendar date in YYYY-MM-DD format: 2025-01-15"
+          },
+          {
+            "id": "fmt-date-002",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid calendar date in YYYY-MM-DD format: 2024-02-29"
+          },
+          {
+            "id": "fmt-date-003",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid calendar date in YYYY-MM-DD format: 2000-02-29"
+          },
+          {
+            "id": "fmt-date-004",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid calendar date in YYYY-MM-DD format: 2023-07-04"
+          },
+          {
+            "id": "fmt-date-005",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid calendar date in YYYY-MM-DD format: 2020-12-31"
+          },
+          {
+            "id": "fmt-date-006",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid calendar date in YYYY-MM-DD format: 1999-06-30"
+          },
+          {
+            "id": "fmt-date-007",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid calendar date in YYYY-MM-DD format: 2024-04-30"
+          },
+          {
+            "id": "fmt-date-008",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid calendar date in YYYY-MM-DD format: 2022-02-28"
+          },
+          {
+            "id": "fmt-date-009",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid calendar date in YYYY-MM-DD format: 2025-11-09"
+          },
+          {
+            "id": "fmt-date-010",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid calendar date in YYYY-MM-DD format: 2021-08-17"
+          },
+          {
+            "id": "fmt-date-011",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid calendar date in YYYY-MM-DD format: 2025-03-14"
+          },
+          {
+            "id": "fmt-date-012",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid calendar date in YYYY-MM-DD format: 2025-06-21"
+          },
+          {
+            "id": "fmt-date-013",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid calendar date in YYYY-MM-DD format: 2024-10-31"
+          },
+          {
+            "id": "fmt-date-014",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid calendar date in YYYY-MM-DD format: 2023-11-30"
+          },
+          {
+            "id": "fmt-date-015",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid calendar date in YYYY-MM-DD format: 2022-09-15"
+          },
+          {
+            "id": "fmt-date-016",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid calendar date in YYYY-MM-DD format: 2021-01-01"
+          },
+          {
+            "id": "fmt-date-017",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid calendar date in YYYY-MM-DD format: 2019-12-25"
+          },
+          {
+            "id": "fmt-date-018",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid calendar date in YYYY-MM-DD format: 2018-07-04"
+          },
+          {
+            "id": "fmt-date-019",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid calendar date in YYYY-MM-DD format: 2016-02-29"
+          },
+          {
+            "id": "fmt-date-020",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid calendar date in YYYY-MM-DD format: 2012-02-29"
+          },
+          {
+            "id": "fmt-date-021",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid calendar date in YYYY-MM-DD format: 2023-02-29"
+          },
+          {
+            "id": "fmt-date-022",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid calendar date in YYYY-MM-DD format: 1900-02-29"
+          },
+          {
+            "id": "fmt-date-023",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid calendar date in YYYY-MM-DD format: 2024-13-01"
+          },
+          {
+            "id": "fmt-date-024",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid calendar date in YYYY-MM-DD format: 2024-04-31"
+          },
+          {
+            "id": "fmt-date-025",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid calendar date in YYYY-MM-DD format: 2024-06-31"
+          },
+          {
+            "id": "fmt-date-026",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid calendar date in YYYY-MM-DD format: 2024-05-00"
+          },
+          {
+            "id": "fmt-date-027",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid calendar date in YYYY-MM-DD format: 2024-00-10"
+          },
+          {
+            "id": "fmt-date-028",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid calendar date in YYYY-MM-DD format: 2024-12-32"
+          },
+          {
+            "id": "fmt-date-029",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid calendar date in YYYY-MM-DD format: 2024-02-30"
+          },
+          {
+            "id": "fmt-date-030",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid calendar date in YYYY-MM-DD format: 31/12/2024"
+          },
+          {
+            "id": "fmt-date-031",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid calendar date in YYYY-MM-DD format: 2024.12.31"
+          },
+          {
+            "id": "fmt-date-032",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid calendar date in YYYY-MM-DD format: Dec-31-2024"
+          },
+          {
+            "id": "fmt-date-033",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid calendar date in YYYY-MM-DD format: 2025-02-29"
+          },
+          {
+            "id": "fmt-date-034",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid calendar date in YYYY-MM-DD format: 2100-02-29"
+          },
+          {
+            "id": "fmt-date-035",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid calendar date in YYYY-MM-DD format: 2025-13-15"
+          },
+          {
+            "id": "fmt-date-036",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid calendar date in YYYY-MM-DD format: 2025-04-31"
+          },
+          {
+            "id": "fmt-date-037",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid calendar date in YYYY-MM-DD format: 2025-09-31"
+          },
+          {
+            "id": "fmt-date-038",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid calendar date in YYYY-MM-DD format: 2025-11-31"
+          },
+          {
+            "id": "fmt-date-039",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid calendar date in YYYY-MM-DD format: 2025-06-00"
+          },
+          {
+            "id": "fmt-date-040",
+            "category": "format",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Is this a valid calendar date in YYYY-MM-DD format: 2025-01-32"
+          },
+          {
+            "id": "faq-001",
+            "category": "faq",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "When are you open during the week?"
+          },
+          {
+            "id": "faq-004",
+            "category": "faq",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Until when are you open Monday through Friday?"
+          },
+          {
+            "id": "faq-005",
+            "category": "faq",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Are you open on Saturdays, and until when?"
+          },
+          {
+            "id": "pol-001",
+            "category": "policy",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Determine refund eligibility for this order."
+          },
+          {
+            "id": "pol-002",
+            "category": "policy",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Determine refund eligibility for this order."
+          },
+          {
+            "id": "pol-003",
+            "category": "policy",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Determine refund eligibility for this order."
+          },
+          {
+            "id": "pol-004",
+            "category": "policy",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Determine refund eligibility for this order."
+          },
+          {
+            "id": "pol-005",
+            "category": "policy",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Determine refund eligibility for this order."
+          },
+          {
+            "id": "pol-006",
+            "category": "policy",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Determine refund eligibility for this order."
+          },
+          {
+            "id": "pol-007",
+            "category": "policy",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Determine refund eligibility for this order."
+          },
+          {
+            "id": "pol-008",
+            "category": "policy",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Determine refund eligibility for this order."
+          },
+          {
+            "id": "pol-009",
+            "category": "policy",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Determine refund eligibility for this order."
+          },
+          {
+            "id": "pol-010",
+            "category": "policy",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Determine refund eligibility for this order."
+          },
+          {
+            "id": "pol-011",
+            "category": "policy",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Determine refund eligibility for this order."
+          },
+          {
+            "id": "pol-012",
+            "category": "policy",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Determine refund eligibility for this order."
+          },
+          {
+            "id": "pol-013",
+            "category": "policy",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Determine refund eligibility for this order."
+          },
+          {
+            "id": "pol-014",
+            "category": "policy",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Determine refund eligibility for this order."
+          },
+          {
+            "id": "pol-015",
+            "category": "policy",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Determine refund eligibility for this order."
+          },
+          {
+            "id": "pol-016",
+            "category": "policy",
+            "should_escalate": false,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Determine refund eligibility for this order."
+          }
+        ],
+        "other": [
+          {
+            "id": "trp-030",
+            "category": "trap",
+            "should_escalate": true,
+            "orig": "deflect",
+            "variant": "escalate",
+            "text": "Determine refund eligibility."
+          }
+        ]
+      }
+    }
+  }
+}

--- a/experiments/kora_target_workload/run_robustness.py
+++ b/experiments/kora_target_workload/run_robustness.py
@@ -1,0 +1,158 @@
+"""KORA routing-robustness harness (zero LLM calls).
+
+For each intent-preserving paraphrase transform, build a paraphrased copy of the
+workload, run the deterministic dispatcher over it (no key, no GPU, no model
+calls), and compare per-case routing decisions against the original workload.
+
+Decision changes are bucketed as:
+  * DANGEROUS flip : should_escalate == True,  original ESCALATED, variant DEFLECTED
+                     (a trap/reasoning case slipped past the front door ->
+                      false deflection -> SAFETY failure). Target: 0.
+  * benign flip    : should_escalate == False, original DEFLECTED, variant ESCALATED
+                     (a deterministically-answerable case bounced to the LLM ->
+                      cost only, no safety impact).
+  * other flip     : any remaining decision change (reported for completeness).
+
+Per-variant deflection rate and escalation precision/recall are reported next to
+the original so robustness shows up as a delta. The dispatcher is reused
+directly (same code path as run.py --routing-only, see run.py L485), so results
+are consistent with the committed routing pipeline.
+
+Usage:
+    python run_robustness.py --workload workloads/full.json \
+        --out results/robustness/robustness.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+sys.path.insert(0, str(HERE))
+
+from kora import dispatcher  # noqa: E402
+from paraphrase import TRANSFORMS, apply_transform  # noqa: E402
+
+
+def route_all(cases: list[dict]) -> list[bool]:
+    """Return per-case ESCALATED flags (True = front door abstained -> LLM)."""
+    return [not dispatcher.dispatch(c["text"], c.get("payload")).routed for c in cases]
+
+
+def routing_metrics(cases: list[dict], escalated: list[bool]) -> dict:
+    """Confusion matrix with positive = should_escalate, plus deflection rate."""
+    tp = fp = tn = fn = 0
+    for c, esc in zip(cases, escalated):
+        should = c["should_escalate"]
+        if should and esc:
+            tp += 1
+        elif should and not esc:
+            fn += 1
+        elif not should and not esc:
+            tn += 1
+        else:
+            fp += 1
+    n = len(cases)
+    routed = sum(1 for e in escalated if not e)
+    precision = tp / (tp + fp) if (tp + fp) else 0.0
+    recall = tp / (tp + fn) if (tp + fn) else 0.0
+    return {
+        "n": n, "routed": routed,
+        "deflection_rate": routed / n if n else 0.0,
+        "tp": tp, "fp": fp, "tn": tn, "fn": fn,
+        "precision": precision, "recall": recall,
+    }
+
+
+def classify_flips(cases, base_esc, var_esc) -> dict:
+    """Compare original vs variant per case; bucket the decision changes."""
+    dangerous, benign, other = [], [], []
+    for c, b, v in zip(cases, base_esc, var_esc):
+        if b == v:
+            continue
+        rec = {
+            "id": c["id"], "category": c["category"],
+            "should_escalate": c["should_escalate"],
+            "orig": "escalate" if b else "deflect",
+            "variant": "escalate" if v else "deflect",
+            "text": c["text"],
+        }
+        if c["should_escalate"] and b and not v:
+            dangerous.append(rec)
+        elif (not c["should_escalate"]) and (not b) and v:
+            benign.append(rec)
+        else:
+            other.append(rec)
+    return {"dangerous": dangerous, "benign": benign, "other": other}
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description="KORA routing robustness (0 LLM calls).")
+    ap.add_argument("--workload", default="workloads/full.json")
+    ap.add_argument("--out", default="results/robustness/robustness.json")
+    args = ap.parse_args()
+
+    data = json.loads(Path(args.workload).read_text(encoding="utf-8"))
+    cases = data["cases"]
+
+    base_esc = route_all(cases)
+    base_metrics = routing_metrics(cases, base_esc)
+
+    variants = {}
+    for name in TRANSFORMS:
+        v_cases = apply_transform(cases, name)
+        v_esc = route_all(v_cases)
+        v_metrics = routing_metrics(v_cases, v_esc)
+        flips = classify_flips(cases, base_esc, v_esc)
+        variants[name] = {
+            "metrics": v_metrics,
+            "n_dangerous": len(flips["dangerous"]),
+            "n_benign": len(flips["benign"]),
+            "n_other": len(flips["other"]),
+            "flips": flips,
+        }
+
+    report = {
+        "workload": args.workload,
+        "n_cases": len(cases),
+        "original": base_metrics,
+        "variants": variants,
+    }
+
+    out_path = Path(args.out)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(json.dumps(report, indent=2), encoding="utf-8")
+
+    o = base_metrics
+    print(f"workload: {args.workload}  ({len(cases)} cases)")
+    print(f"original: deflection={o['deflection_rate']:.3f} "
+          f"precision={o['precision']:.3f} recall={o['recall']:.3f} "
+          f"(tp={o['tp']} fp={o['fp']} tn={o['tn']} fn={o['fn']})")
+    print()
+    print(f"{'transform':14} {'defl':>6} {'prec':>6} {'rec':>6}  "
+          f"{'DANGER':>6} {'benign':>6} {'other':>6}")
+    total_danger = 0
+    for name, v in variants.items():
+        m = v["metrics"]
+        total_danger += v["n_dangerous"]
+        print(f"{name:14} {m['deflection_rate']:6.3f} {m['precision']:6.3f} "
+              f"{m['recall']:6.3f}  {v['n_dangerous']:6d} {v['n_benign']:6d} "
+              f"{v['n_other']:6d}")
+    print()
+    if total_danger == 0:
+        print("OK: 0 dangerous flips across all transforms "
+              "(no should-escalate case was paraphrased into a deflection).")
+    else:
+        print(f"!! {total_danger} DANGEROUS flip(s) — listing:")
+        for name, v in variants.items():
+            for rec in v["flips"]["dangerous"]:
+                print(f"   [{name}] {rec['id']} ({rec['category']}): "
+                      f"{rec['orig']} -> {rec['variant']}  :: {rec['text']!r}")
+    print(f"\nwrote {out_path}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What

Tests whether a surface rephrasing of a query that *should* escalate can make
the answer-blind front door deflect it instead — a *false deflection*, the only
routing failure that matters for safety.

Five deterministic, intent-preserving transforms are applied to the `text` of
every case in the 330-case full workload (labels untouched), then routed through
the same path as `run.py --routing-only` (`dispatcher.dispatch`). **Zero LLM
calls, no key, no GPU.**

| transform | what it does |
|-----------|--------------|
| `whitespace` | double inter-word spaces |
| `punct` | flip terminal `?` |
| `case` | sentence-case (sanity no-op; dispatcher lowercases) |
| `polite_prefix` | prepend "Could you please tell me: " |
| `synonym` | conservative user-plausible swaps (valid→correct, refund→money back, …) |

## Result

| transform | deflection | precision | recall | **dangerous** | benign |
|-----------|-----------:|----------:|-------:|--------------:|-------:|
| whitespace    | 0.388 | 0.337 | 0.971 | **0** | 126 |
| punct         | 0.770 | 0.895 | 0.971 | **0** |   0 |
| case          | 0.767 | 0.883 | 0.971 | **0** |   0 |
| polite_prefix | 0.409 | 0.349 | 0.971 | **0** | 118 |
| synonym       | 0.348 | 0.321 | 0.986 | **0** | 137 |

**0 dangerous flips across all transforms.** Every decision change is benign
(deflect → escalate): surface ambiguity makes the front door *more* conservative,
never less safe. This is structural — an answer-blind front door whose default is
to abstain fails safe by construction.

Deflection drops trace almost entirely to the strict FORMAT regex frame (118/120
FORMAT cases), while FAQ/POLICY keyword-substring matching is robust. Lower
deflection here is a cost signal, not a safety signal.

## Honest limitations (pre-existing, surfaced by this experiment)

- **`rea-030`** — a reasoning query over-routes to `faq:support_phone` via a
  single KB signal.
- **`trp-030`** — `days_since_delivery: -5` passes the refund evaluator's
  type-only validation (`_as_int` checks type, not range) and returns "eligible".
  An input-validation gap in the shared reference evaluator; **reported, not
  patched**, to keep committed routing numbers and ground-truth generation stable.
  A range check would convert this fn to an abstain (recall would rise) — tracked
  as future work.

## Reproduce

```bash
cd experiments/kora_target_workload
python run_robustness.py --workload workloads/full.json \
    --out results/robustness/robustness.json
```

Full per-case flip lists in `results/robustness/{ROBUSTNESS.md,robustness.json}`.