### PR TITLE
Scrub private HF cache path + fix license inconsistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,4 +98,4 @@ See the [claim registry](docs/claims/kora-claim-registry.md) and [public languag
 
 ## License
 
-MIT License. See [LICENSE](LICENSE).
+Apache License 2.0. See [LICENSE](LICENSE).

--- a/experiments/clinc150_direct_vs_kora/MULTI_DATASET.md
+++ b/experiments/clinc150_direct_vs_kora/MULTI_DATASET.md
@@ -91,9 +91,9 @@ validated routing path.
 ```bash
 cd experiments/clinc150_direct_vs_kora
 # banking77 (parquet, downloaded once; no dataset script)
-HF_HOME=/data/tta/hf-cache python run_multi.py --dataset banking77 --n 500 --seed 0
+HF_HOME=~/.cache/huggingface python run_multi.py --dataset banking77 --n 500 --seed 0
 # CLINC150 (cached; offline)
-HF_HOME=/data/tta/hf-cache python run_multi.py --dataset clinc_oos --n 500 --seed 0
+HF_HOME=~/.cache/huggingface python run_multi.py --dataset clinc_oos --n 500 --seed 0
 ```
 
 Requires a local OpenAI-compatible endpoint (vLLM) serving the model at

--- a/experiments/clinc150_direct_vs_kora/README.md
+++ b/experiments/clinc150_direct_vs_kora/README.md
@@ -14,7 +14,7 @@ router deflects, and at what accuracy cost.
 
 - **venv:** `~/kora-ai-champion/envs/kora-benchmark` (vllm 0.6.6.post1, datasets 5.0.0, openai 2.44.0)
 - **model / server:** `Qwen/Qwen2.5-32B-Instruct` on `http://localhost:8000/v1` (api key `EMPTY`)
-- **dataset cache:** `HF_HOME=/data/tta/hf-cache` (CLINC150 `clinc_oos` / `plus` config, offline)
+- **dataset cache:** `HF_HOME=~/.cache/huggingface` (CLINC150 `clinc_oos` / `plus` config, offline)
 
 ### Starting the vLLM server
 
@@ -36,7 +36,7 @@ nohup ~/kora-ai-champion/envs/kora-benchmark/bin/python -m vllm.entrypoints.open
 ## Running
 
 ```bash
-HF_HOME=/data/tta/hf-cache \
+HF_HOME=~/.cache/huggingface \
 ~/kora-ai-champion/envs/kora-benchmark/bin/python \
 experiments/clinc150_direct_vs_kora/run.py --n 20 --seed 0
 ```

--- a/experiments/clinc150_direct_vs_kora/run.py
+++ b/experiments/clinc150_direct_vs_kora/run.py
@@ -11,7 +11,7 @@ We report accuracy, LLM-call count, token usage and latency for both arms so the
 routing economics (fewer LLM calls / tokens at comparable accuracy) are visible.
 
 Run:
-    HF_HOME=/data/tta/hf-cache \
+    HF_HOME=~/.cache/huggingface \
     ~/kora-ai-champion/envs/kora-benchmark/bin/python \
     experiments/clinc150_direct_vs_kora/run.py --n 20 --seed 0
 """

--- a/experiments/clinc150_direct_vs_kora/run_multi.py
+++ b/experiments/clinc150_direct_vs_kora/run_multi.py
@@ -23,7 +23,7 @@ Datasets:
                  intents, no out-of-scope label.
 
 Run:
-    HF_HOME=/data/tta/hf-cache \
+    HF_HOME=~/.cache/huggingface \
     ~/kora-ai-champion/envs/kora-benchmark/bin/python \
     experiments/clinc150_direct_vs_kora/run_multi.py \
         --dataset banking77 --n 20 --seed 0

--- a/experiments/clinc150_direct_vs_kora/sweep.py
+++ b/experiments/clinc150_direct_vs_kora/sweep.py
@@ -10,7 +10,7 @@ vs the direct (always-LLM) baseline. The keyword dictionary in router.py is used
 unchanged — only the confidence thresholds vary.
 
 Run:
-    HF_HOME=/data/tta/hf-cache \
+    HF_HOME=~/.cache/huggingface \
     ~/kora-ai-champion/envs/kora-benchmark/bin/python \
     experiments/clinc150_direct_vs_kora/sweep.py \
       --cached results/run_n500_seed0.json

--- a/experiments/kora_target_workload/results/REPORT.md
+++ b/experiments/kora_target_workload/results/REPORT.md
@@ -228,7 +228,7 @@ $PY generate.py --profile full --seed 0
 $PY -m kora.dispatcher workloads/full.json
 
 # 3. full run, both KB conditions, judge grader, k=3 (needs the vLLM server up)
-HF_HOME=/data/tta/hf-cache $PY run.py \
+HF_HOME=~/.cache/huggingface $PY run.py \
     --workload workloads/full.json --conditions both --k 3 \
     --faq-grader judge --out results/run_full.json
 

--- a/experiments/kora_target_workload/run.py
+++ b/experiments/kora_target_workload/run.py
@@ -22,7 +22,7 @@ precision/recall (deterministic, KB-independent), and optional consistency
 (K resamples of the LLM arm at a higher temperature -> answer variance).
 
 Run (smoke):
-    HF_HOME=/data/tta/hf-cache \
+    HF_HOME=~/.cache/huggingface \
     ~/kora-ai-champion/envs/kora-benchmark/bin/python \
         experiments/kora_target_workload/run.py --workload workloads/smoke.json
 """


### PR DESCRIPTION
## Summary
Repo hygiene for the public repo: replace the server-specific HF cache path
`/data/tta/hf-cache` with the portable default `~/.cache/huggingface` in all
reproduce snippets, and fix a license inconsistency (README said MIT; the
LICENSE file is Apache-2.0).

## Type of change
- [x] Docs only / repo hygiene
- [x] Security-sensitive (path scrub)

## Changes
- 3e0d469 — scrub HF cache path in PART A files (clinc run.py/sweep.py, northwind run.py, REPORT.md)
- bb8d03b — scrub HF cache path in the 3 multi-dataset files
- a6e533e — fix README license MIT → Apache-2.0 (matches the LICENSE file)

Verified: `git grep /data/tta/hf-cache` → 0 hits; README license line now
matches the LICENSE file.

## Left out of scope (PART C — boundary review pending)
These contain server paths or GPU evidence and need a public/private boundary
judgment, so they are intentionally untouched here:
- clinc150 README:22,28 — vLLM-launch working-dir + log path
- REPORT.md:194 — nvidia_smi log reference (path-reference only; file not committed)
- 7 GPU evidence/infra docs under docs/

## Scope check
- [x] No unrelated refactors
- [x] No public surface expansion
- [x] Deterministic-first behavior preserved
- [x] No hidden model calls introduced