### PR TITLE
Align benchmark numbers with the current dispatcher (canonical routing)

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ The included examples are offline and make zero provider calls.
 
 ## Evidence Boundaries
 
-KORA ships offline sample workloads (simulated provider/model invocation avoidance) **and** one real, measured benchmark on a single synthetic domain: deterministic front-door routing across 5 models (Qwen2.5-32B, Claude Sonnet 4.6, Claude Haiku 4.5, Llama 3.3 70B, Llama 3.1 8B), giving an identical **76.7% deflection** (LLM calls 330 → 77). The routing result reproduces with no API key, no GPU, and zero LLM calls. See [experiments/kora_target_workload](experiments/kora_target_workload/README.md).
+KORA ships offline sample workloads (simulated provider/model invocation avoidance) **and** one real, measured benchmark on a single synthetic domain: deterministic front-door routing across 5 models (Qwen2.5-32B, Claude Sonnet 4.6, Claude Haiku 4.5, Llama 3.3 70B, Llama 3.1 8B), giving an identical **76.06% deflection** (LLM calls 330 → 79). The routing result reproduces with no API key, no GPU, and zero LLM calls. See [experiments/kora_target_workload](experiments/kora_target_workload/README.md).
 
 The repository does **not** claim:
 

--- a/experiments/clinc150_direct_vs_kora/MULTI_DATASET.md
+++ b/experiments/clinc150_direct_vs_kora/MULTI_DATASET.md
@@ -45,10 +45,14 @@ validated routing path.
 
 2. **Routing on pure intent classification trades a little accuracy for fewer
    calls.** Both datasets show ~20–24% fewer LLM calls and tokens at a 1–3 point
-   accuracy cost. This is KORA's *weak* setting: pure judgment tasks where there
+   accuracy cost. This ~20-24% is the conservative per-domain band measured on
+   these two intent domains (CLINC150 20.8%, banking77 23.8%), not a
+   domain-agnostic constant: per-domain deflection tracks how much the label
+   vocabulary overlaps the query text, and varies widely across domains.
+   This is KORA's *weak* setting: pure judgment tasks where there
    is no deterministic, rule-answerable structure to exploit. It contrasts with
    the rule-rich single-domain workload (northwindgoods), where the front door
-   deflects 76.7% with no accuracy loss because the deflected queries have
+   deflects 76.06% with no accuracy loss because the deflected queries have
    deterministic answers (format/FAQ/policy). The honest summary: KORA pays off
    most where queries have deterministic answers, and least on pure
    classification.

--- a/experiments/kora_target_workload/README.md
+++ b/experiments/kora_target_workload/README.md
@@ -24,17 +24,17 @@ cost and accuracy, independent of which model you pay for?*
 ## TL;DR
 
 Deterministic routing is decided by the dispatcher, not the model, so the
-deflection rate is **identical across all five models**: KORA makes **76.7% fewer
-LLM calls** (330 → 77) on this workload. The accuracy effect, however, depends on
+deflection rate is **identical across all five models**: KORA makes **76.06% fewer
+LLM calls** (330 → 79) on this workload. The accuracy effect, however, depends on
 the served model — and it grows as the model gets weaker.
 
 | Served model | tier | deflection | LLM calls saved | with-KB Δacc | without-KB Δacc |
 |---|---|---|---|---|---|
-| Llama 3.1 8B | tiny | 76.7% | 76.7% | +0.123 | **+0.335** |
-| Llama 3.3 70B | large | 76.7% | 76.7% | +0.050 | +0.319 |
-| Claude Haiku 4.5 | small | 76.7% | 76.7% | +0.019 | +0.300 |
-| Nova Pro | mid | 76.7% | 76.7% | +0.031 | +0.265 |
-| Claude Sonnet 4.6 | frontier | 76.7% | 76.7% | +0.012 | +0.223 |
+| Llama 3.1 8B | tiny | 76.06% | 76.06% | +0.123 | **+0.335** |
+| Llama 3.3 70B | large | 76.06% | 76.06% | +0.050 | +0.319 |
+| Claude Haiku 4.5 | small | 76.06% | 76.06% | +0.019 | +0.300 |
+| Nova Pro | mid | 76.06% | 76.06% | +0.031 | +0.265 |
+| Claude Sonnet 4.6 | frontier | 76.06% | 76.06% | +0.012 | +0.223 |
 
 Absolute accuracy (direct → KORA):
 
@@ -49,7 +49,7 @@ Absolute accuracy (direct → KORA):
 Setup: N=330, k=1, FAQ semantic grader **held fixed at Claude Sonnet 4.6 across
 all arms** (so grading never varies with the served model). Models served via AWS
 Bedrock Converse. A local **Qwen2.5-32B** run (vLLM, 2× H100) reproduces the same
-**deflection = 76.7%** (deflection is independent of the judge and of k, since
+**deflection = 76.06%** (deflection is independent of the judge and of k, since
 it is fixed by the deterministic router), confirming the routing result is not
 specific to hosted APIs.
 
@@ -60,7 +60,7 @@ dispatcher — **zero LLM calls, no API key, no GPU**. Anyone can reproduce them
 
 ```bash
 python run.py --routing-only --workload workloads/full.json --out /tmp/routing.json
-# -> precision=0.883 recall=0.971  (deflection 76.7%)
+# -> precision=0.886 recall=1.000  (deflection 76.06%)
 ```
 
 This is the heart of KORA's claim, and it is fully reproducible offline.
@@ -92,9 +92,10 @@ python run.py \
 python aggregate_results.py
 ```
 
-The committed `results/full_*.json` let you verify every number above without
-running anything: each file lists per-category accuracy and **every** wrong
-answer and routing miss for both arms.
+The committed `results/routing_only.json` reproduces the routing numbers
+(precision, recall, deflection) with no credentials, and each committed
+`results/full_*.json` lists per-category accuracy and **every** wrong answer for
+both arms, so you can inspect the underlying data without running anything.
 
 ## What "without-KB" actually means
 
@@ -116,10 +117,10 @@ that genuinely need one.
   330-case set.
 - **Answer-blind router.** The dispatcher never sees the case category or the
   ground truth — only what a real front door sees (user text + optional payload).
-- **Errors are public.** Each `results/full_*.json` enumerates every wrong answer
-  and every routing miss, including KORA's own (e.g. over-routed cases where the
-  deterministic path answered something it should have escalated — 2 such cases
-  here, surfaced in the routing report).
+- **Errors are public.** Each `results/full_*.json` enumerates every wrong answer,
+  and the routing report enumerates every routing miss, including KORA's own
+  over-routing. The 2 cases that originally over-routed (rea-030, trp-030) are now
+  escalated by a versioned guardrail, so the canonical routing report shows 0.
 - **Fixed judge.** The FAQ semantic grader is held at one model (Sonnet 4.6)
   across all arms, so accuracy differences reflect the served model, not the
   grader.
@@ -141,7 +142,8 @@ Roadmap toward promoting this into the root package as a first-class
 1. **Generalize** the dispatcher to arbitrary domains (user-supplied KB/rules)
    rather than one hard-coded domain.
 2. **Quantify over-routing safety** — formal bounds on when deterministic
-   answering is safe (the 2 over-routed cases here are the starting point).
+   answering is safe (the 2 over-routed cases here have since been guarded to 0 and
+   kept as named regression tests; formal bounds remain future work).
 3. **Integrate** with the root task-graph engine as its deterministic-path stage.
 
 Until those land, this stays an independent, reproducible benchmark rather than a

--- a/experiments/kora_target_workload/README.md
+++ b/experiments/kora_target_workload/README.md
@@ -30,10 +30,10 @@ the served model — and it grows as the model gets weaker.
 
 | Served model | tier | deflection | LLM calls saved | with-KB Δacc | without-KB Δacc |
 |---|---|---|---|---|---|
-| Llama 3.1 8B | tiny | 76.06% | 76.06% | +0.123 | **+0.335** |
+| Llama 3.1 8B | tiny | 76.06% | 76.06% | +0.123 | **+0.342** |
 | Llama 3.3 70B | large | 76.06% | 76.06% | +0.050 | +0.319 |
 | Claude Haiku 4.5 | small | 76.06% | 76.06% | +0.019 | +0.300 |
-| Nova Pro | mid | 76.06% | 76.06% | +0.031 | +0.265 |
+| Nova Pro | mid | 76.06% | 76.06% | +0.027 | +0.277 |
 | Claude Sonnet 4.6 | frontier | 76.06% | 76.06% | +0.012 | +0.223 |
 
 Absolute accuracy (direct → KORA):
@@ -41,10 +41,10 @@ Absolute accuracy (direct → KORA):
 | Served model | with-KB direct → KORA | without-KB direct → KORA |
 |---|---|---|
 | Claude Sonnet 4.6 | 0.988 → 1.000 | 0.765 → 0.988 |
-| Nova Pro | 0.969 → 1.000 | 0.715 → 0.981 |
+| Nova Pro | 0.973 → 1.000 | 0.704 → 0.981 |
 | Claude Haiku 4.5 | 0.981 → 1.000 | 0.677 → 0.977 |
 | Llama 3.3 70B | 0.950 → 1.000 | 0.658 → 0.977 |
-| Llama 3.1 8B | 0.877 → 1.000 | 0.646 → 0.981 |
+| Llama 3.1 8B | 0.877 → 1.000 | 0.638 → 0.981 |
 
 Setup: N=330, k=1, FAQ semantic grader **held fixed at Claude Sonnet 4.6 across
 all arms** (so grading never varies with the served model). Models served via AWS

--- a/experiments/kora_target_workload/reproduce.sh
+++ b/experiments/kora_target_workload/reproduce.sh
@@ -35,7 +35,7 @@ print("    committed : precision=%.3f recall=%.3f (tp=%d fp=%d tn=%d fn=%d)" %
 print("    reproduced: precision=%.3f recall=%.3f (tp=%d fp=%d tn=%d fn=%d)" %
       (got["precision"],got["recall"],got["tp"],got["fp"],got["tn"],got["fn"]))
 if ok:
-    print("\n✅ REPRODUCED: routing metrics match exactly (deflection 76.7%, no LLM, no key).")
+    print("\n✅ REPRODUCED: routing metrics match exactly (deflection 76.06%, no LLM, no key).")
     sys.exit(0)
 else:
     print("\n❌ MISMATCH: routing metrics differ from the committed result.")

--- a/experiments/kora_target_workload/results/REPORT.md
+++ b/experiments/kora_target_workload/results/REPORT.md
@@ -181,41 +181,6 @@ became newly mis-routed. The genuine `support_phone` FAQ cases (`faq-029`–`faq
 and every well-formed policy case are unaffected. Deflection drops only by the two
 now-escalated cases (2 / 330).
 
-### 5c-guardrail. Fixing the two over-routing cases (versioned change)
-
-The two cases above were left in the frozen full-benchmark run on purpose, so the
-headline numbers in §5a–§5b are reported against unpatched rules. As a *separate,
-versioned* change, both cases were then registered as named regression tests and
-the underlying rules were guarded. The benchmark numbers above are not edited; the
-system was changed and re-measured, and both results are reported side by side.
-
-- **Named tests first.** `experiments/kora_target_workload/tests/test_over_routing_guardrails.py`
-  loads `rea-030` and `trp-030` from the canonical workload and asserts each
-  escalates (`Decision.routed is False`, the same criterion `run.py` uses). At the
-  test commit these fail on purpose, fixing the gap as a record before any fix.
-- **Guard 1 — input range-check (`policy_rules`).** Negative elapsed-time / count
-  fields (`days_since_delivery`, `months_since_purchase`, `account_age_days`,
-  `prior_orders`) now raise `PolicyInputError`, so a malformed payload abstains
-  instead of producing a verdict. Fixes `trp-030` (`days_since_delivery = -5`).
-- **Guard 2 — FAQ signal (`spec/kb.yaml`).** `"number"` was dropped from the
-  `support_phone` `all_of` signal. Genuine phone requests match on
-  `phone` / `call` / `telephone`; `"number"` only produced false matches on
-  order / tracking / account numbers. Fixes `rea-030`.
-
-Full 330-case routing (`run.py --routing-only`, 0 LLM calls), before → after:
-
-| metric | before (frozen rules) | after (guards) |
-|---|---|---|
-| over-routing (should-escalate but handled) | 2 (`rea-030`, `trp-030`) | **0** |
-| recall | 0.971 | **1.000** |
-| precision | 0.883 | 0.886 |
-| deflection | 0.767 | 0.761 |
-
-Routing changed for exactly these two cases — no other case flipped, and no case
-became newly mis-routed. The genuine `support_phone` FAQ cases (`faq-029`–`faq-032`)
-and every well-formed policy case are unaffected. Deflection drops only by the two
-now-escalated cases (2 / 330).
-
 ### 5d. Other honest caveats
 - **Synthetic KB/policies.** "Northwind Goods" facts and policy thresholds are
   invented for the demo; the point is the *mechanism*, not these specific values.

--- a/experiments/kora_target_workload/results/SUMMARY_model_diversity.md
+++ b/experiments/kora_target_workload/results/SUMMARY_model_diversity.md
@@ -2,10 +2,10 @@
 
 | Model | tier | deflection | LLM calls saved | with-KB d-acc | without-KB d-acc |
 |---|---|---|---|---|---|
-| Llama 3.1 8B | tiny | 76.06% | 76.06% | +0.123 | +0.335 |
+| Llama 3.1 8B | tiny | 76.06% | 76.06% | +0.123 | +0.342 |
 | Llama 3.3 70B | large | 76.06% | 76.06% | +0.050 | +0.319 |
 | Claude Haiku 4.5 | small | 76.06% | 76.06% | +0.019 | +0.300 |
-| Nova Pro | mid | 76.06% | 76.06% | +0.031 | +0.265 |
+| Nova Pro | mid | 76.06% | 76.06% | +0.027 | +0.277 |
 | Claude Sonnet 4.6 | frontier | 76.06% | 76.06% | +0.012 | +0.223 |
 
 - **deflection 76.06% identical across all models** (set by the deterministic router, model-independent)

--- a/experiments/kora_target_workload/results/SUMMARY_model_diversity.md
+++ b/experiments/kora_target_workload/results/SUMMARY_model_diversity.md
@@ -2,12 +2,12 @@
 
 | Model | tier | deflection | LLM calls saved | with-KB d-acc | without-KB d-acc |
 |---|---|---|---|---|---|
-| Llama 3.1 8B | tiny | 76.7% | 76.7% | +0.123 | +0.335 |
-| Llama 3.3 70B | large | 76.7% | 76.7% | +0.050 | +0.319 |
-| Claude Haiku 4.5 | small | 76.7% | 76.7% | +0.019 | +0.300 |
-| Nova Pro | mid | 76.7% | 76.7% | +0.031 | +0.265 |
-| Claude Sonnet 4.6 | frontier | 76.7% | 76.7% | +0.012 | +0.223 |
+| Llama 3.1 8B | tiny | 76.06% | 76.06% | +0.123 | +0.335 |
+| Llama 3.3 70B | large | 76.06% | 76.06% | +0.050 | +0.319 |
+| Claude Haiku 4.5 | small | 76.06% | 76.06% | +0.019 | +0.300 |
+| Nova Pro | mid | 76.06% | 76.06% | +0.031 | +0.265 |
+| Claude Sonnet 4.6 | frontier | 76.06% | 76.06% | +0.012 | +0.223 |
 
-- **deflection 76.7% identical across all models** (set by the deterministic router, model-independent)
+- **deflection 76.06% identical across all models** (set by the deterministic router, model-independent)
 - **without-KB**: direct varies with model strength; KORA stays ~0.98 -> larger gain for weaker models
-- over-routed: 2 cases (routing precision=0.883) — later guarded to 0 (recall 1.000); see REPORT.md §5c-guardrail
+- over-routed: 0 cases (routing precision 0.886, recall 1.000); a versioned guardrail escalates the 2 originally over-routed cases (rea-030, trp-030). See REPORT.md §5c-guardrail

--- a/experiments/kora_target_workload/results/full_haiku45.json
+++ b/experiments/kora_target_workload/results/full_haiku45.json
@@ -24,12 +24,12 @@
   },
   "routing": {
     "positive_class": "should_escalate",
-    "tp": 68,
+    "tp": 70,
     "fp": 9,
     "tn": 251,
-    "fn": 2,
-    "precision": 0.8831168831168831,
-    "recall": 0.9714285714285714,
+    "fn": 0,
+    "precision": 0.8860759493670886,
+    "recall": 1.0,
     "by_category": {
       "format": {
         "n": 120,
@@ -48,29 +48,16 @@
       },
       "reasoning": {
         "n": 40,
-        "routed": 1,
-        "abstain": 39
+        "routed": 0,
+        "abstain": 40
       },
       "trap": {
         "n": 30,
-        "routed": 1,
-        "abstain": 29
+        "routed": 0,
+        "abstain": 30
       }
     },
-    "over_routed_cases": [
-      {
-        "id": "rea-030",
-        "category": "reasoning",
-        "handler": "faq:support_phone",
-        "answer": "Our support line is +1-800-555-0100."
-      },
-      {
-        "id": "trp-030",
-        "category": "trap",
-        "handler": "policy:refund_eligibility",
-        "answer": "eligible"
-      }
-    ]
+    "over_routed_cases": []
   },
   "conditions": {
     "with_kb": {
@@ -103,9 +90,9 @@
         "tokens_in": 362883,
         "tokens_out": 19329,
         "estimated_cost_usd": 0.0,
-        "latency_s_total": 663.6056416034698,
-        "latency_p50_s": 1.8748736381530762,
-        "latency_p95_s": 2.9560765624046326
+        "latency_s_total": 739.7753622531891,
+        "latency_p50_s": 2.140468955039978,
+        "latency_p95_s": 3.0125031590461733
       },
       "kora": {
         "arm": "kora",
@@ -130,24 +117,24 @@
             "accuracy": 1.0
           }
         },
-        "llm_calls": 77,
-        "deterministic_answers": 253,
-        "deflection_rate": 0.7666666666666667,
-        "tokens_in": 84304,
-        "tokens_out": 7219,
+        "llm_calls": 79,
+        "deterministic_answers": 251,
+        "deflection_rate": 0.7606060606060606,
+        "tokens_in": 86519,
+        "tokens_out": 7403,
         "estimated_cost_usd": 0.0,
-        "latency_s_total": 188.58727431297302,
+        "latency_s_total": 203.43286395072937,
         "latency_p50_s": 0.0,
-        "latency_p95_s": 2.851854836940766
+        "latency_p95_s": 2.911456334590912
       },
       "comparison": {
         "accuracy_delta_kora_minus_direct": 0.019230769230769273,
-        "llm_calls_saved": 253,
-        "llm_calls_saved_pct": 0.7666666666666667,
-        "tokens_in_saved": 278579,
-        "tokens_out_saved": 12110,
+        "llm_calls_saved": 251,
+        "llm_calls_saved_pct": 0.7606060606060606,
+        "tokens_in_saved": 276364,
+        "tokens_out_saved": 11926,
         "cost_saved_usd": 0.0,
-        "latency_s_saved": 475.0183672904968
+        "latency_s_saved": 536.3424983024597
       },
       "consistency_direct": {
         "k": 1,
@@ -259,9 +246,9 @@
         "tokens_in": 59613,
         "tokens_out": 22999,
         "estimated_cost_usd": 0.0,
-        "latency_s_total": 687.9555213451385,
-        "latency_p50_s": 2.0137503147125244,
-        "latency_p95_s": 2.94883793592453
+        "latency_s_total": 755.298332452774,
+        "latency_p50_s": 2.256555438041687,
+        "latency_p95_s": 2.898733174800873
       },
       "kora": {
         "arm": "kora",
@@ -286,24 +273,24 @@
             "accuracy": 1.0
           }
         },
-        "llm_calls": 77,
-        "deterministic_answers": 253,
-        "deflection_rate": 0.7666666666666667,
-        "tokens_in": 13541,
-        "tokens_out": 7051,
+        "llm_calls": 79,
+        "deterministic_answers": 251,
+        "deflection_rate": 0.7606060606060606,
+        "tokens_in": 13918,
+        "tokens_out": 7199,
         "estimated_cost_usd": 0.0,
-        "latency_s_total": 178.16726732254028,
+        "latency_s_total": 202.96333146095276,
         "latency_p50_s": 0.0,
-        "latency_p95_s": 2.5903663635253906
+        "latency_p95_s": 2.8344682693481444
       },
       "comparison": {
         "accuracy_delta_kora_minus_direct": 0.29999999999999993,
-        "llm_calls_saved": 253,
-        "llm_calls_saved_pct": 0.7666666666666667,
-        "tokens_in_saved": 46072,
-        "tokens_out_saved": 15948,
+        "llm_calls_saved": 251,
+        "llm_calls_saved_pct": 0.7606060606060606,
+        "tokens_in_saved": 45695,
+        "tokens_out_saved": 15800,
         "cost_saved_usd": 0.0,
-        "latency_s_saved": 509.78825402259827
+        "latency_s_saved": 552.3350009918213
       },
       "consistency_direct": {
         "k": 1,

--- a/experiments/kora_target_workload/results/full_llama1_8b.json
+++ b/experiments/kora_target_workload/results/full_llama1_8b.json
@@ -24,12 +24,12 @@
   },
   "routing": {
     "positive_class": "should_escalate",
-    "tp": 68,
+    "tp": 70,
     "fp": 9,
     "tn": 251,
-    "fn": 2,
-    "precision": 0.8831168831168831,
-    "recall": 0.9714285714285714,
+    "fn": 0,
+    "precision": 0.8860759493670886,
+    "recall": 1.0,
     "by_category": {
       "format": {
         "n": 120,
@@ -48,29 +48,16 @@
       },
       "reasoning": {
         "n": 40,
-        "routed": 1,
-        "abstain": 39
+        "routed": 0,
+        "abstain": 40
       },
       "trap": {
         "n": 30,
-        "routed": 1,
-        "abstain": 29
+        "routed": 0,
+        "abstain": 30
       }
     },
-    "over_routed_cases": [
-      {
-        "id": "rea-030",
-        "category": "reasoning",
-        "handler": "faq:support_phone",
-        "answer": "Our support line is +1-800-555-0100."
-      },
-      {
-        "id": "trp-030",
-        "category": "trap",
-        "handler": "policy:refund_eligibility",
-        "answer": "eligible"
-      }
-    ]
+    "over_routed_cases": []
   },
   "conditions": {
     "with_kb": {
@@ -101,11 +88,11 @@
         "deterministic_answers": 0,
         "deflection_rate": 0.0,
         "tokens_in": 322467,
-        "tokens_out": 9256,
+        "tokens_out": 9279,
         "estimated_cost_usd": 0.0,
-        "latency_s_total": 348.6860601902008,
-        "latency_p50_s": 1.0779924392700195,
-        "latency_p95_s": 1.2038342356681824
+        "latency_s_total": 352.3945560455322,
+        "latency_p50_s": 1.0915807485580444,
+        "latency_p95_s": 1.2158610463142396
       },
       "kora": {
         "arm": "kora",
@@ -130,24 +117,24 @@
             "accuracy": 1.0
           }
         },
-        "llm_calls": 77,
-        "deterministic_answers": 253,
-        "deflection_rate": 0.7666666666666667,
-        "tokens_in": 74994,
-        "tokens_out": 3167,
+        "llm_calls": 79,
+        "deterministic_answers": 251,
+        "deflection_rate": 0.7606060606060606,
+        "tokens_in": 76962,
+        "tokens_out": 3235,
         "estimated_cost_usd": 0.0,
-        "latency_s_total": 85.07781434059143,
+        "latency_s_total": 86.806236743927,
         "latency_p50_s": 0.0,
-        "latency_p95_s": 1.186715304851532
+        "latency_p95_s": 1.1933847069740295
       },
       "comparison": {
         "accuracy_delta_kora_minus_direct": 0.12307692307692308,
-        "llm_calls_saved": 253,
-        "llm_calls_saved_pct": 0.7666666666666667,
-        "tokens_in_saved": 247473,
-        "tokens_out_saved": 6089,
+        "llm_calls_saved": 251,
+        "llm_calls_saved_pct": 0.7606060606060606,
+        "tokens_in_saved": 245505,
+        "tokens_out_saved": 6044,
         "cost_saved_usd": 0.0,
-        "latency_s_saved": 263.6082458496094
+        "latency_s_saved": 265.5883193016052
       },
       "consistency_direct": {
         "k": 1,
@@ -160,7 +147,7 @@
           "gt_kind": "valid_invalid",
           "ground_truth": "valid",
           "verdict": "invalid",
-          "answer": "The domain name is incorrect. Email addresses should end in .com, .net, .org, etc.",
+          "answer": "The domain is not a valid top-level domain.",
           "llm_called": true,
           "handler": null,
           "text": "Is this a valid email address: hello@example.travel",
@@ -256,7 +243,7 @@
           "gt_kind": "valid_invalid",
           "ground_truth": "valid",
           "verdict": "invalid",
-          "answer": "June only has 30 days, so the date is invalid.",
+          "answer": "June only has 30 days, so the 30th is not a valid day in this date.",
           "llm_called": true,
           "handler": null,
           "text": "Is this a valid calendar date in YYYY-MM-DD format: 1999-06-30",
@@ -268,7 +255,7 @@
           "gt_kind": "valid_invalid",
           "ground_truth": "valid",
           "verdict": "invalid",
-          "answer": "April only has 30 days, so this date is not valid.",
+          "answer": "April only has 30 days, so the 30th is valid, but the 31st is not.",
           "llm_called": true,
           "handler": null,
           "text": "Is this a valid calendar date in YYYY-MM-DD format: 2024-04-30",
@@ -506,7 +493,7 @@
           "gt_kind": "eligibility",
           "ground_truth": "ineligible",
           "verdict": "eligible",
-          "answer": "",
+          "answer": "You are eligible for the WELCOME10 coupon.",
           "llm_called": true,
           "handler": null,
           "text": "Determine whether the WELCOME10 coupon is valid here.",
@@ -554,7 +541,7 @@
           "gt_kind": "eligibility",
           "ground_truth": "eligible",
           "verdict": "ineligible",
-          "answer": "The warranty period for appliances is 24 months, but the product was purchased 24 months ago, which is exactly the maximum allowed time. However, the defect type is manufacturing, which is covered.",
+          "answer": "The warranty period for appliances is 24 months, but the product was purchased 24 months ago, which is the maximum allowed time.",
           "llm_called": true,
           "handler": null,
           "text": "Determine whether this warranty claim is covered.",
@@ -619,18 +606,18 @@
         "arm": "direct",
         "n_total": 330,
         "n_scorable": 260,
-        "accuracy": 0.6461538461538462,
-        "correct": 168,
+        "accuracy": 0.6384615384615384,
+        "correct": 166,
         "accuracy_by_category": {
           "format": {
             "n": 120,
-            "correct": 107,
-            "accuracy": 0.8916666666666667
+            "correct": 106,
+            "accuracy": 0.8833333333333333
           },
           "faq": {
             "n": 60,
-            "correct": 14,
-            "accuracy": 0.23333333333333334
+            "correct": 13,
+            "accuracy": 0.21666666666666667
           },
           "policy": {
             "n": 80,
@@ -642,11 +629,11 @@
         "deterministic_answers": 0,
         "deflection_rate": 0.0,
         "tokens_in": 58137,
-        "tokens_out": 11795,
+        "tokens_out": 11992,
         "estimated_cost_usd": 0.0,
-        "latency_s_total": 356.8360071182251,
-        "latency_p50_s": 1.1018733978271484,
-        "latency_p95_s": 1.2516185879707338
+        "latency_s_total": 363.17064356803894,
+        "latency_p50_s": 1.119618535041809,
+        "latency_p95_s": 1.2421834230422975
       },
       "kora": {
         "arm": "kora",
@@ -671,24 +658,24 @@
             "accuracy": 1.0
           }
         },
-        "llm_calls": 77,
-        "deterministic_answers": 253,
-        "deflection_rate": 0.7666666666666667,
-        "tokens_in": 13317,
-        "tokens_out": 3448,
+        "llm_calls": 79,
+        "deterministic_answers": 251,
+        "deflection_rate": 0.7606060606060606,
+        "tokens_in": 13683,
+        "tokens_out": 3513,
         "estimated_cost_usd": 0.0,
-        "latency_s_total": 85.715496301651,
+        "latency_s_total": 87.82976126670837,
         "latency_p50_s": 0.0,
-        "latency_p95_s": 1.193427848815918
+        "latency_p95_s": 1.1999699592590334
       },
       "comparison": {
-        "accuracy_delta_kora_minus_direct": 0.33461538461538454,
-        "llm_calls_saved": 253,
-        "llm_calls_saved_pct": 0.7666666666666667,
-        "tokens_in_saved": 44820,
-        "tokens_out_saved": 8347,
+        "accuracy_delta_kora_minus_direct": 0.3423076923076923,
+        "llm_calls_saved": 251,
+        "llm_calls_saved_pct": 0.7606060606060606,
+        "tokens_in_saved": 44454,
+        "tokens_out_saved": 8479,
         "cost_saved_usd": 0.0,
-        "latency_s_saved": 271.1205108165741
+        "latency_s_saved": 275.34088230133057
       },
       "consistency_direct": {
         "k": 1,
@@ -700,8 +687,8 @@
           "category": "format",
           "gt_kind": "valid_invalid",
           "ground_truth": "valid",
-          "verdict": "invalid",
-          "answer": "The domain should be .com, .net, .org, etc. instead of .travel.",
+          "verdict": null,
+          "answer": "{\"verdict\": \"invalid\", \"answer\": \"The domain should be .com, .net, .io, .co, .me, .biz, .info, .org, .edu, .gov, .mil, .name, .pro, .tel, .mobi, .asia, .cat, .jobs, .travel, .xxx, .aero, .biz, .coop, ",
           "llm_called": true,
           "handler": null,
           "text": "Is this a valid email address: hello@example.travel",
@@ -725,7 +712,7 @@
           "gt_kind": "valid_invalid",
           "ground_truth": "valid",
           "verdict": "invalid",
-          "answer": "Please check the domain extension, it should be .com, .org, .net, etc.",
+          "answer": "The domain should be .com, .org, .net, etc.",
           "llm_called": true,
           "handler": null,
           "text": "Is this a valid email address: jkl@example.co",
@@ -797,7 +784,7 @@
           "gt_kind": "valid_invalid",
           "ground_truth": "valid",
           "verdict": "invalid",
-          "answer": "June only has 30 days in 1999, so this date is invalid.",
+          "answer": "June only has 30 days, so this date is invalid.",
           "llm_called": true,
           "handler": null,
           "text": "Is this a valid calendar date in YYYY-MM-DD format: 1999-06-30",
@@ -821,10 +808,22 @@
           "gt_kind": "valid_invalid",
           "ground_truth": "valid",
           "verdict": "invalid",
-          "answer": "October only has 31 days in some years, but 2024 is a leap year, so October has 31 days. However, the 31st of October is a valid date in 2024.",
+          "answer": "October only has 31 days in some years, but 2024 is a leap year, so October has 31 days. However, the date is invalid because it is after the last day of October 2024.",
           "llm_called": true,
           "handler": null,
           "text": "Is this a valid calendar date in YYYY-MM-DD format: 2024-10-31",
+          "payload": null
+        },
+        {
+          "id": "fmt-date-014",
+          "category": "format",
+          "gt_kind": "valid_invalid",
+          "ground_truth": "valid",
+          "verdict": "invalid",
+          "answer": "The month of November only has 30 days, so this date is not valid.",
+          "llm_called": true,
+          "handler": null,
+          "text": "Is this a valid calendar date in YYYY-MM-DD format: 2023-11-30",
           "payload": null
         },
         {
@@ -852,6 +851,21 @@
           "payload": null
         },
         {
+          "id": "faq-001",
+          "category": "faq",
+          "gt_kind": "kb_answer",
+          "ground_truth": [
+            "monday",
+            "friday"
+          ],
+          "verdict": null,
+          "answer": "We are open Monday to Friday, 9am to 5pm EST. We are closed on weekends and holidays.",
+          "llm_called": true,
+          "handler": null,
+          "text": "When are you open during the week?",
+          "payload": null
+        },
+        {
           "id": "faq-003",
           "category": "faq",
           "gt_kind": "kb_answer",
@@ -875,7 +889,7 @@
             "friday"
           ],
           "verdict": null,
-          "answer": "We are open from 9am to 5pm, Monday through Friday.",
+          "answer": "We are open from 9am to 5pm Monday through Friday.",
           "llm_called": true,
           "handler": null,
           "text": "Until when are you open Monday through Friday?",
@@ -903,7 +917,7 @@
             "saturday"
           ],
           "verdict": null,
-          "answer": "Our store is open from 10am to 6pm on Saturdays and 12pm to 5pm on Sundays. You can also shop online 24/7.",
+          "answer": "Our store is open from 10am to 6pm on Saturday and Sunday. We're closed on Monday to Friday.",
           "llm_called": true,
           "handler": null,
           "text": "What are your hours over the weekend?",
@@ -917,7 +931,7 @@
             "saturday"
           ],
           "verdict": null,
-          "answer": "Our store is open Monday to Friday, 10am to 6pm. We're closed on weekends.",
+          "answer": "Our store is open Monday to Friday, 10am to 6pm. We are closed on weekends.",
           "llm_called": true,
           "handler": null,
           "text": "Can I come by on a Saturday or Sunday?",
@@ -931,7 +945,7 @@
             "saturday"
           ],
           "verdict": null,
-          "answer": "Our store is open 7 days a week from 9am to 6pm. You can shop with us online 24/7.",
+          "answer": "Our store is open 7 days a week, from 9am to 9pm EST. We're always here to help you!",
           "llm_called": true,
           "handler": null,
           "text": "What time do you close on the weekend?",
@@ -976,7 +990,7 @@
             "50"
           ],
           "verdict": null,
-          "answer": "Shipping fees vary depending on your location and the items in your order. You can check the shipping options and costs during checkout.",
+          "answer": "Shipping fees vary depending on your location and the items in your order. You can check the shipping rates during checkout.",
           "llm_called": true,
           "handler": null,
           "text": "Do I have to pay a shipping fee, and how much?",
@@ -1036,7 +1050,7 @@
             "5"
           ],
           "verdict": null,
-          "answer": "Please check your order status in your account or contact our customer service for more information on shipping and delivery times.",
+          "answer": "Please check your order status in your account or contact us for more information on shipping and delivery times.",
           "llm_called": true,
           "handler": null,
           "text": "When will my order ship and get here domestically?",
@@ -1066,7 +1080,7 @@
             "14"
           ],
           "verdict": null,
-          "answer": "Please note that delivery times vary depending on your location and the shipping method chosen. You can check the estimated delivery times for your area on our website or contact our customer service ",
+          "answer": "Please check your order confirmation email for estimated delivery times, which depend on your location and shipping method.",
           "llm_called": true,
           "handler": null,
           "text": "When will an overseas order arrive?",
@@ -1081,7 +1095,7 @@
             "14"
           ],
           "verdict": null,
-          "answer": "Please check our shipping policy page for estimated delivery times for international orders.",
+          "answer": "Delivery times vary by destination. Please check our shipping page for estimated delivery times to your location.",
           "llm_called": true,
           "handler": null,
           "text": "What's the delivery time for international orders?",
@@ -1166,7 +1180,7 @@
             "555-0100"
           ],
           "verdict": null,
-          "answer": "You can contact our support team at 1-800-NORTHWIND (1-800-667-4846) or email us at support@northwindgoods.com.",
+          "answer": "You can contact our support team at 1-800-NORTHWIND (1-800-668-4746) or email us at support@northwindgoods.com.",
           "llm_called": true,
           "handler": null,
           "text": "What number do I call for support?",
@@ -1309,7 +1323,7 @@
             "100"
           ],
           "verdict": null,
-          "answer": "You can earn rewards by making purchases and completing specific actions on our website. Rewards can be redeemed for discounts, free products, or other perks. Check our rewards page for details on cur",
+          "answer": "You can earn rewards by making purchases and completing certain actions on our website. Rewards can be redeemed for discounts, free products, or other perks. Check our rewards program page for details",
           "llm_called": true,
           "handler": null,
           "text": "How does earning and redeeming rewards work?",
@@ -1351,7 +1365,7 @@
             "security"
           ],
           "verdict": null,
-          "answer": "You can reset your password by going to the 'Account' section of your profile and clicking on 'Forgot Password'. Follow the instructions to receive a password reset link via email.",
+          "answer": "You can reset your password by going to the 'Account' section of your Northwind Goods account dashboard and clicking on 'Forgot Password'. Follow the instructions to receive a password reset link via ",
           "llm_called": true,
           "handler": null,
           "text": "Where do I go to reset my account password?",
@@ -1407,7 +1421,7 @@
             "orders"
           ],
           "verdict": null,
-          "answer": "You can track your package by logging into your account on our website and clicking on 'Order History' or by contacting our customer service team for assistance.",
+          "answer": "You can track your package by logging into your account on our website and clicking on the 'Order History' tab. You can also contact our customer service team for assistance.",
           "llm_called": true,
           "handler": null,
           "text": "How can I follow where my package is?",
@@ -1449,7 +1463,7 @@
             "never"
           ],
           "verdict": null,
-          "answer": "Our gift cards are valid for 12 months from the date of purchase. If you have any questions or concerns, please contact our customer support team.",
+          "answer": "Our gift cards are valid for 12 months from the date of purchase.",
           "llm_called": true,
           "handler": null,
           "text": "How long is a gift card valid for?",
@@ -1463,7 +1477,7 @@
             "columbus"
           ],
           "verdict": null,
-          "answer": "Please visit our Return Policy page for detailed instructions on how to initiate a return and the address to send it to.",
+          "answer": "Please visit our Return Policy page for detailed instructions on how to initiate a return and the correct return address.",
           "llm_called": true,
           "handler": null,
           "text": "Where should I mail my returns?",
@@ -1477,7 +1491,7 @@
             "columbus"
           ],
           "verdict": null,
-          "answer": "Please visit our Return Policy page for detailed instructions on how to initiate a return and the address to send your item to.",
+          "answer": "Please visit our Returns page for detailed return shipping instructions.",
           "llm_called": true,
           "handler": null,
           "text": "What address do I send returned items to?",
@@ -1549,7 +1563,7 @@
           "gt_kind": "eligibility",
           "ground_truth": "eligible",
           "verdict": "ineligible",
-          "answer": "Refunds are only eligible for items that are not of category 'other' and have been delivered for at least 30 days.",
+          "answer": "Refunds are only eligible for items in categories 'electronics', 'clothing', and 'home goods' within 30 days of delivery.",
           "llm_called": true,
           "handler": null,
           "text": "Determine refund eligibility for this order.",
@@ -1565,7 +1579,7 @@
           "gt_kind": "eligibility",
           "ground_truth": "eligible",
           "verdict": "ineligible",
-          "answer": "You are ineligible for a refund because the order is more than 15 days old and the item has been opened.",
+          "answer": "You are ineligible for a refund because the order is more than 14 days old and the item has been opened.",
           "llm_called": true,
           "handler": null,
           "text": "Determine refund eligibility for this order.",
@@ -1597,7 +1611,7 @@
           "gt_kind": "eligibility",
           "ground_truth": "eligible",
           "verdict": "ineligible",
-          "answer": "Since 30 days have passed since delivery and the item has not been opened, you are not eligible for a refund.",
+          "answer": "Refunds are only eligible within 15 days of delivery for electronics items that have not been opened.",
           "llm_called": true,
           "handler": null,
           "text": "Determine refund eligibility for this order.",
@@ -1629,7 +1643,7 @@
           "gt_kind": "eligibility",
           "ground_truth": "eligible",
           "verdict": "ineligible",
-          "answer": "Refunds are only eligible within 15 days of delivery for non-book items.",
+          "answer": "Refunds for books are only eligible within 15 days of delivery.",
           "llm_called": true,
           "handler": null,
           "text": "Determine refund eligibility for this order.",
@@ -1677,7 +1691,7 @@
           "gt_kind": "eligibility",
           "ground_truth": "eligible",
           "verdict": "ineligible",
-          "answer": "Free shipping is available for orders over $200 or for members with a valid membership plan.",
+          "answer": "Free shipping is only available for orders over $200 or for premium members.",
           "llm_called": true,
           "handler": null,
           "text": "Determine whether this order qualifies for free shipping.",
@@ -1709,7 +1723,7 @@
           "gt_kind": "eligibility",
           "ground_truth": "eligible",
           "verdict": "ineligible",
-          "answer": "You need to have at least one prior order to use the WELCOME10 coupon.",
+          "answer": "You need to have at least one prior order to use this coupon.",
           "llm_called": true,
           "handler": null,
           "text": "Determine whether the WELCOME10 coupon is valid here.",
@@ -1837,7 +1851,7 @@
           "gt_kind": "eligibility",
           "ground_truth": "eligible",
           "verdict": "ineligible",
-          "answer": "The warranty for appliances is valid for 12 months from the date of purchase. The product has been out of warranty for 24 months.",
+          "answer": "The warranty for appliances is 12 months from the date of purchase. The product has been out of warranty for 24 months.",
           "llm_called": true,
           "handler": null,
           "text": "Determine whether this warranty claim is covered.",
@@ -1885,7 +1899,7 @@
           "gt_kind": "eligibility",
           "ground_truth": "eligible",
           "verdict": "ineligible",
-          "answer": "The warranty for appliances has a 12-month duration. Since the product was purchased only 1 month ago, it is not yet eligible for a warranty claim.",
+          "answer": "The warranty for appliances has a 12-month duration. The product has been purchased for only 1 month, so it is still under warranty.",
           "llm_called": true,
           "handler": null,
           "text": "Determine whether this warranty claim is covered.",
@@ -1901,7 +1915,7 @@
           "gt_kind": "eligibility",
           "ground_truth": "eligible",
           "verdict": "ineligible",
-          "answer": "Our warranty covers manufacturing defects for products purchased within 1 year. You are 5 months past the 1-year mark.",
+          "answer": "Our warranty covers manufacturing defects for products purchased within 1 year. You've had your accessory for 5 months, so unfortunately, this claim is not eligible.",
           "llm_called": true,
           "handler": null,
           "text": "Determine whether this warranty claim is covered.",
@@ -1964,7 +1978,7 @@
           "gt_kind": "eligibility",
           "ground_truth": "ineligible",
           "verdict": "eligible",
-          "answer": "You are eligible for a free prepaid return label since you changed your mind within 5 days of delivery.",
+          "answer": "You are eligible for a free prepaid return label since you have changed your mind and it has been 5 days since delivery.",
           "llm_called": true,
           "handler": null,
           "text": "Determine free prepaid return-label eligibility.",
@@ -1994,7 +2008,7 @@
           "gt_kind": "eligibility",
           "ground_truth": "ineligible",
           "verdict": "eligible",
-          "answer": "You are eligible for a free prepaid return label since you have just received the order.",
+          "answer": "You are eligible for a free prepaid return label since you have just received your order.",
           "llm_called": true,
           "handler": null,
           "text": "Determine free prepaid return-label eligibility.",
@@ -2009,7 +2023,7 @@
           "gt_kind": "eligibility",
           "ground_truth": "ineligible",
           "verdict": "eligible",
-          "answer": "You are eligible for a free prepaid return label since you returned the item within 30 days of delivery due to a change of mind.",
+          "answer": "You are eligible for a free prepaid return label since you have returned the item within 30 days of delivery due to a change of mind.",
           "llm_called": true,
           "handler": null,
           "text": "Determine free prepaid return-label eligibility.",
@@ -2043,7 +2057,7 @@
             "saturday"
           ],
           "verdict": null,
-          "answer": "Our store is open Monday to Friday, 10am to 6pm. We're closed on weekends.",
+          "answer": "Our store is open Monday to Friday, 10am to 6pm. We are closed on weekends.",
           "llm_called": true,
           "handler": null,
           "text": "Can I come by on a Saturday or Sunday?",
@@ -2058,7 +2072,7 @@
             "50"
           ],
           "verdict": null,
-          "answer": "Shipping fees vary depending on your location and the items in your order. You can check the shipping options and costs during checkout.",
+          "answer": "Shipping fees vary depending on your location and the items in your order. You can check the shipping rates during checkout.",
           "llm_called": true,
           "handler": null,
           "text": "Do I have to pay a shipping fee, and how much?",
@@ -2087,7 +2101,7 @@
             "orders"
           ],
           "verdict": null,
-          "answer": "You can track your package by logging into your account on our website and clicking on 'Order History' or by contacting our customer service team for assistance.",
+          "answer": "You can track your package by logging into your account on our website and clicking on the 'Order History' tab. You can also contact our customer service team for assistance.",
           "llm_called": true,
           "handler": null,
           "text": "How can I follow where my package is?",
@@ -2101,7 +2115,7 @@
             "never"
           ],
           "verdict": null,
-          "answer": "Our gift cards are valid for 12 months from the date of purchase. If you have any questions or concerns, please contact our customer support team.",
+          "answer": "Our gift cards are valid for 12 months from the date of purchase.",
           "llm_called": true,
           "handler": null,
           "text": "How long is a gift card valid for?",

--- a/experiments/kora_target_workload/results/full_llama3_70b.json
+++ b/experiments/kora_target_workload/results/full_llama3_70b.json
@@ -24,12 +24,12 @@
   },
   "routing": {
     "positive_class": "should_escalate",
-    "tp": 68,
+    "tp": 70,
     "fp": 9,
     "tn": 251,
-    "fn": 2,
-    "precision": 0.8831168831168831,
-    "recall": 0.9714285714285714,
+    "fn": 0,
+    "precision": 0.8860759493670886,
+    "recall": 1.0,
     "by_category": {
       "format": {
         "n": 120,
@@ -48,29 +48,16 @@
       },
       "reasoning": {
         "n": 40,
-        "routed": 1,
-        "abstain": 39
+        "routed": 0,
+        "abstain": 40
       },
       "trap": {
         "n": 30,
-        "routed": 1,
-        "abstain": 29
+        "routed": 0,
+        "abstain": 30
       }
     },
-    "over_routed_cases": [
-      {
-        "id": "rea-030",
-        "category": "reasoning",
-        "handler": "faq:support_phone",
-        "answer": "Our support line is +1-800-555-0100."
-      },
-      {
-        "id": "trp-030",
-        "category": "trap",
-        "handler": "policy:refund_eligibility",
-        "answer": "eligible"
-      }
-    ]
+    "over_routed_cases": []
   },
   "conditions": {
     "with_kb": {
@@ -101,11 +88,11 @@
         "deterministic_answers": 0,
         "deflection_rate": 0.0,
         "tokens_in": 329067,
-        "tokens_out": 9110,
+        "tokens_out": 8727,
         "estimated_cost_usd": 0.0,
-        "latency_s_total": 382.717280626297,
-        "latency_p50_s": 1.086154818534851,
-        "latency_p95_s": 1.6086236596107486
+        "latency_s_total": 387.6004989147186,
+        "latency_p50_s": 1.1271754503250122,
+        "latency_p95_s": 1.6498385310173038
       },
       "kora": {
         "arm": "kora",
@@ -130,24 +117,24 @@
             "accuracy": 1.0
           }
         },
-        "llm_calls": 77,
-        "deterministic_answers": 253,
-        "deflection_rate": 0.7666666666666667,
-        "tokens_in": 76534,
-        "tokens_out": 3972,
+        "llm_calls": 79,
+        "deterministic_answers": 251,
+        "deflection_rate": 0.7606060606060606,
+        "tokens_in": 78542,
+        "tokens_out": 3916,
         "estimated_cost_usd": 0.0,
-        "latency_s_total": 103.03662252426147,
+        "latency_s_total": 104.45572757720947,
         "latency_p50_s": 0.0,
-        "latency_p95_s": 1.4779364228248597
+        "latency_p95_s": 1.5201613903045654
       },
       "comparison": {
         "accuracy_delta_kora_minus_direct": 0.050000000000000044,
-        "llm_calls_saved": 253,
-        "llm_calls_saved_pct": 0.7666666666666667,
-        "tokens_in_saved": 252533,
-        "tokens_out_saved": 5138,
+        "llm_calls_saved": 251,
+        "llm_calls_saved_pct": 0.7606060606060606,
+        "tokens_in_saved": 250525,
+        "tokens_out_saved": 4811,
         "cost_saved_usd": 0.0,
-        "latency_s_saved": 279.6806581020355
+        "latency_s_saved": 283.14477133750916
       },
       "consistency_direct": {
         "k": 1,
@@ -219,8 +206,8 @@
           "category": "policy",
           "gt_kind": "eligibility",
           "ground_truth": "eligible",
-          "verdict": null,
-          "answer": "{\"verdict\": \"ineligible\", \"answer\": \"The item is not eligible for a refund because it is opened and falls under the electronics rule, however since the item category is 'other', the general 30-day rul",
+          "verdict": "ineligible",
+          "answer": "The item is not eligible for a refund because it has been opened and is in the 'other' category, which is subject to the standard 30-day return window but is not eligible due to being opened, similar ",
           "llm_called": true,
           "handler": null,
           "text": "Determine refund eligibility for this order.",
@@ -236,7 +223,7 @@
           "gt_kind": "eligibility",
           "ground_truth": "eligible",
           "verdict": "ineligible",
-          "answer": "The item is not eligible for a refund because it was opened and the refund request is at the 30-day limit.",
+          "answer": "The item is outside the 30-day return window or is an opened non-electronic item, which is still eligible for return but since it is opened and not electronics, the 30-day window applies and has been ",
           "llm_called": true,
           "handler": null,
           "text": "Determine refund eligibility for this order.",
@@ -252,7 +239,7 @@
           "gt_kind": "eligibility",
           "ground_truth": "eligible",
           "verdict": "ineligible",
-          "answer": "The warranty period for electronics is 12 months, and since it has been 12 months since purchase, the claim is ineligible.",
+          "answer": "The warranty claim is not covered because the electronics warranty period is 12 months and the claim is being made after this period.",
           "llm_called": true,
           "handler": null,
           "text": "Determine whether this warranty claim is covered.",
@@ -268,7 +255,7 @@
           "gt_kind": "eligibility",
           "ground_truth": "eligible",
           "verdict": "ineligible",
-          "answer": "The warranty period for appliances is 24 months, and since the defect is manufacturing-related, the claim would normally be eligible. However, given the claim is exactly at the 24-month mark, it is ri",
+          "answer": "The warranty period for appliances is 24 months, and since the defect is manufacturing-related, the claim would normally be eligible. However, since the months since purchase equals the warranty perio",
           "llm_called": true,
           "handler": null,
           "text": "Determine whether this warranty claim is covered.",
@@ -353,29 +340,29 @@
         "accuracy_by_category": {
           "format": {
             "n": 120,
-            "correct": 114,
-            "accuracy": 0.95
+            "correct": 115,
+            "accuracy": 0.9583333333333334
           },
           "faq": {
             "n": 60,
-            "correct": 14,
-            "accuracy": 0.23333333333333334
+            "correct": 15,
+            "accuracy": 0.25
           },
           "policy": {
             "n": 80,
-            "correct": 43,
-            "accuracy": 0.5375
+            "correct": 41,
+            "accuracy": 0.5125
           }
         },
         "llm_calls": 330,
         "deterministic_answers": 0,
         "deflection_rate": 0.0,
         "tokens_in": 64737,
-        "tokens_out": 10157,
+        "tokens_out": 9971,
         "estimated_cost_usd": 0.0,
-        "latency_s_total": 376.55631923675537,
-        "latency_p50_s": 1.1242525577545166,
-        "latency_p95_s": 1.428698515892029
+        "latency_s_total": 433.6472132205963,
+        "latency_p50_s": 1.2553330659866333,
+        "latency_p95_s": 1.8065745115280156
       },
       "kora": {
         "arm": "kora",
@@ -400,24 +387,24 @@
             "accuracy": 1.0
           }
         },
-        "llm_calls": 77,
-        "deterministic_answers": 253,
-        "deflection_rate": 0.7666666666666667,
-        "tokens_in": 14857,
-        "tokens_out": 3278,
+        "llm_calls": 79,
+        "deterministic_answers": 251,
+        "deflection_rate": 0.7606060606060606,
+        "tokens_in": 15263,
+        "tokens_out": 3325,
         "estimated_cost_usd": 0.0,
-        "latency_s_total": 96.93669700622559,
+        "latency_s_total": 120.01074814796448,
         "latency_p50_s": 0.0,
-        "latency_p95_s": 1.3809044718742371
+        "latency_p95_s": 1.5820069432258614
       },
       "comparison": {
         "accuracy_delta_kora_minus_direct": 0.3192307692307692,
-        "llm_calls_saved": 253,
-        "llm_calls_saved_pct": 0.7666666666666667,
-        "tokens_in_saved": 49880,
-        "tokens_out_saved": 6879,
+        "llm_calls_saved": 251,
+        "llm_calls_saved_pct": 0.7606060606060606,
+        "tokens_in_saved": 49474,
+        "tokens_out_saved": 6646,
         "cost_saved_usd": 0.0,
-        "latency_s_saved": 279.6196222305298
+        "latency_s_saved": 313.63646507263184
       },
       "consistency_direct": {
         "k": 1,
@@ -473,24 +460,12 @@
           "payload": null
         },
         {
-          "id": "fmt-date-006",
-          "category": "format",
-          "gt_kind": "valid_invalid",
-          "ground_truth": "valid",
-          "verdict": "invalid",
-          "answer": "June only has 30 days in some years, but 1999 is not a leap year and June has 30 days, however, June has 30 days every year, so the date is valid, actually, the date is valid.",
-          "llm_called": true,
-          "handler": null,
-          "text": "Is this a valid calendar date in YYYY-MM-DD format: 1999-06-30",
-          "payload": null
-        },
-        {
           "id": "fmt-date-020",
           "category": "format",
           "gt_kind": "valid_invalid",
           "ground_truth": "valid",
           "verdict": "invalid",
-          "answer": "2012 is not a leap year, so February does not have 29 days in this year.",
+          "answer": "",
           "llm_called": true,
           "handler": null,
           "text": "Is this a valid calendar date in YYYY-MM-DD format: 2012-02-29",
@@ -505,7 +480,7 @@
             "friday"
           ],
           "verdict": null,
-          "answer": "Our customer support is available Monday through Friday, 9am to 5pm. Please note that hours may vary on holidays.",
+          "answer": "Our customer support is available Monday through Friday, 9am to 5pm EST. You can also check our website for holiday hours and other important notices.",
           "llm_called": true,
           "handler": null,
           "text": "When are you open during the week?",
@@ -520,7 +495,7 @@
             "friday"
           ],
           "verdict": null,
-          "answer": "Our customer support is available Monday through Friday from 9 AM to 5 PM EST.",
+          "answer": "Our customer support is available Monday through Friday from 9am to 5pm EST.",
           "llm_called": true,
           "handler": null,
           "text": "Until when are you open Monday through Friday?",
@@ -534,7 +509,7 @@
             "saturday"
           ],
           "verdict": null,
-          "answer": "Our customer service is available 7 days a week. For specific store hours, please check our website or contact your local Northwind Goods store for their Saturday hours.",
+          "answer": "Our customer support is available 24/7, but for store hours, please check our website's contact page or call us for specific Saturday hours at your local Northwind Goods store.",
           "llm_called": true,
           "handler": null,
           "text": "Are you open on Saturdays, and until when?",
@@ -548,7 +523,7 @@
             "saturday"
           ],
           "verdict": null,
-          "answer": "Our customer support hours over the weekend are Saturday 9am-5pm and Sunday 10am-4pm. Please note that these hours may be subject to change on holidays.",
+          "answer": "Our customer support hours over the weekend are Saturday 9am-5pm and Sunday 10am-4pm. You can also contact us via email or our website's contact form for assistance outside of these hours.",
           "llm_called": true,
           "handler": null,
           "text": "What are your hours over the weekend?",
@@ -562,7 +537,7 @@
             "saturday"
           ],
           "verdict": null,
-          "answer": "Our store hours are Monday through Friday. Please check our website for specific hours and consider visiting us on a weekday.",
+          "answer": "Our store hours are Monday to Friday. Please check our website for specific hours and consider visiting us on a weekday.",
           "llm_called": true,
           "handler": null,
           "text": "Can I come by on a Saturday or Sunday?",
@@ -576,7 +551,7 @@
             "saturday"
           ],
           "verdict": null,
-          "answer": "Our weekend hours are from 9am to 6pm. Please note that hours may vary on holidays or special events. You can check our website for the most up-to-date information.",
+          "answer": "Our weekend hours are Saturday 9am-6pm and Sunday 10am-5pm. Please note that hours may vary on holidays.",
           "llm_called": true,
           "handler": null,
           "text": "What time do you close on the weekend?",
@@ -621,7 +596,7 @@
             "50"
           ],
           "verdict": null,
-          "answer": "Shipping fees vary depending on your location and order total. Please check our website for more information or contact us with your order details for a quote.",
+          "answer": "Shipping fees vary depending on your location and order total. Please add items to your cart and enter your shipping address to see the estimated shipping cost.",
           "llm_called": true,
           "handler": null,
           "text": "Do I have to pay a shipping fee, and how much?",
@@ -636,7 +611,7 @@
             "50"
           ],
           "verdict": null,
-          "answer": "Delivery charges vary depending on the order and location. For more information, please check our shipping policy or contact us with your order details.",
+          "answer": "Delivery charges vary depending on the order and location. You can check the shipping costs on our website during checkout or contact us for more information.",
           "llm_called": true,
           "handler": null,
           "text": "Is there a postage charge, or is delivery free?",
@@ -655,21 +630,6 @@
           "llm_called": true,
           "handler": null,
           "text": "How many days until my domestic order arrives?",
-          "payload": null
-        },
-        {
-          "id": "faq-018",
-          "category": "faq",
-          "gt_kind": "kb_answer",
-          "ground_truth": [
-            "3",
-            "5"
-          ],
-          "verdict": null,
-          "answer": "Delivery within the country typically takes 2-5 business days, but please note that this may vary depending on your location and the shipping method chosen at checkout.",
-          "llm_called": true,
-          "handler": null,
-          "text": "How fast is delivery within the country?",
           "payload": null
         },
         {
@@ -696,7 +656,7 @@
             "14"
           ],
           "verdict": null,
-          "answer": "Shipping times abroad vary depending on the destination. For more accurate information, please check our shipping policy or contact us with your specific order details.",
+          "answer": "Shipping times abroad vary depending on the destination. For more information, please check our shipping policy or contact us with your specific order details.",
           "llm_called": true,
           "handler": null,
           "text": "How long does shipping abroad take?",
@@ -726,7 +686,7 @@
             "14"
           ],
           "verdict": null,
-          "answer": "For international orders, delivery time typically ranges from 7 to 21 business days, depending on the destination and shipping method chosen. You can track your order for more precise updates.",
+          "answer": "For international orders, delivery time typically ranges from 7-21 business days, depending on the destination and shipping method chosen. You can track your order for more accurate updates.",
           "llm_called": true,
           "handler": null,
           "text": "What's the delivery time for international orders?",
@@ -797,7 +757,7 @@
             "support@northwindgoods.example"
           ],
           "verdict": null,
-          "answer": "You can reach us at support@northwindgoods.com for any questions or concerns.",
+          "answer": "Yes, you can reach us at support@northwindgoods.com for assistance with your inquiries or concerns.",
           "llm_called": true,
           "handler": null,
           "text": "Is there a support email I can reach you at?",
@@ -825,7 +785,7 @@
             "555-0100"
           ],
           "verdict": null,
-          "answer": "You can find our customer service phone number at the bottom of our website or by clicking 'Contact Us' on the Northwind Goods homepage.",
+          "answer": "You can find our customer service phone number at the bottom of the Northwind Goods website or by clicking 'Contact Us' in the main menu.",
           "llm_called": true,
           "handler": null,
           "text": "How can I phone customer service?",
@@ -839,7 +799,7 @@
             "555-0100"
           ],
           "verdict": null,
-          "answer": "Yes, you can call us at 1-800-NORTH-01 (1-800-667-8401) for assistance.",
+          "answer": "Yes, you can call us at 1-800-NORTH-01 (1-800-667-8401) for assistance with your order or any questions you may have.",
           "llm_called": true,
           "handler": null,
           "text": "Is there a support telephone number I can call?",
@@ -853,7 +813,7 @@
             "555-0100"
           ],
           "verdict": null,
-          "answer": "You can reach our help line at 1-800-555-5555. Our customer support team is available 24/7 to assist you with any questions or concerns.",
+          "answer": "You can reach our help line at 1-800-555-5555. Our customer support team is available to assist you Monday through Friday, 9am to 5pm EST.",
           "llm_called": true,
           "handler": null,
           "text": "What's the phone number to reach your help line?",
@@ -954,7 +914,7 @@
             "100"
           ],
           "verdict": null,
-          "answer": "To determine your points and their value, could you please provide more details about the type of points you're referring to, such as rewards points from a specific purchase or loyalty program?",
+          "answer": "To determine your points and their value, could you please provide more information about the rewards program or promotion you're referring to? This will help me give you a more accurate answer.",
           "llm_called": true,
           "handler": null,
           "text": "How many points do I get and what are they worth?",
@@ -968,7 +928,7 @@
             "100"
           ],
           "verdict": null,
-          "answer": "Earning and redeeming rewards at Northwind Goods typically involves creating an account, making purchases to accumulate points, and then using those points for discounts or free items on future purcha",
+          "answer": "Earning and redeeming rewards at Northwind Goods is based on our loyalty program. For every dollar spent, you earn points. These points can be redeemed for discounts on future purchases. You can find ",
           "llm_called": true,
           "handler": null,
           "text": "How does earning and redeeming rewards work?",
@@ -1010,7 +970,7 @@
             "security"
           ],
           "verdict": null,
-          "answer": "To reset your account password, please go to the Northwind Goods website, click on 'Login' and then 'Forgot Password', and follow the prompts to reset your password.",
+          "answer": "To reset your account password, please click on 'Forgot Password' on the Northwind Goods login page and follow the prompts.",
           "llm_called": true,
           "handler": null,
           "text": "Where do I go to reset my account password?",
@@ -1038,7 +998,7 @@
             "orders"
           ],
           "verdict": null,
-          "answer": "To track your order, please log in to your account, go to the 'My Orders' section, and click on the order number you'd like to track. You can also contact our customer support team for assistance.",
+          "answer": "To track your order, please log in to your Northwind Goods account, go to the 'My Orders' section, and click on the order number you'd like to track. You can also contact our customer support team wit",
           "llm_called": true,
           "handler": null,
           "text": "How do I track my order?",
@@ -1052,7 +1012,7 @@
             "orders"
           ],
           "verdict": null,
-          "answer": "You can view your shipment's tracking status by logging into your account, going to the 'Order History' section, and clicking on the 'Track' button next to your order.",
+          "answer": "You can view your shipment's tracking status by logging into your account on our website and navigating to the 'Order History' or 'Track Orders' section.",
           "llm_called": true,
           "handler": null,
           "text": "Where can I see my shipment's tracking status?",
@@ -1066,7 +1026,7 @@
             "orders"
           ],
           "verdict": null,
-          "answer": "You can track your package by logging into your Northwind Goods account, going to 'Order History', and clicking on 'Track Package' next to your order. You will need your order number and the email add",
+          "answer": "You can track your package by logging into your Northwind Goods account, going to 'Order History', and clicking on 'Track Package' next to your order. You will also receive email updates with tracking",
           "llm_called": true,
           "handler": null,
           "text": "How can I follow where my package is?",
@@ -1094,7 +1054,7 @@
             "never"
           ],
           "verdict": null,
-          "answer": "Northwind Goods gift cards are valid for 2 years from the date of purchase.",
+          "answer": "Northwind Goods gift cards are valid for 12 months from the date of purchase.",
           "llm_called": true,
           "handler": null,
           "text": "How long is a gift card valid for?",
@@ -1108,7 +1068,7 @@
             "columbus"
           ],
           "verdict": null,
-          "answer": "Please mail your returns to the address listed on our website under 'Contact Us' or on the packing slip included with your order. If you can't find it, you can also contact us for assistance.",
+          "answer": "Please mail your returns to the address listed on our website's return policy page or on the packing slip included with your order. If you can't find it, contact us for assistance.",
           "llm_called": true,
           "handler": null,
           "text": "Where should I mail my returns?",
@@ -1136,7 +1096,7 @@
             "columbus"
           ],
           "verdict": null,
-          "answer": "Returns should be shipped to our warehouse at the address listed on our website under the 'Returns and Refunds' section. Please contact us for the most up-to-date information.",
+          "answer": "Returns should be shipped to the address listed on our website under 'Return Policy' or on the packing slip included with your order. If you can't find it, please contact us for assistance.",
           "llm_called": true,
           "handler": null,
           "text": "Where do returns need to be shipped?",
@@ -1178,7 +1138,7 @@
           "gt_kind": "eligibility",
           "ground_truth": "eligible",
           "verdict": "ineligible",
-          "answer": "Refund window has closed",
+          "answer": "Refunds are typically only available within 15-20 days of delivery, depending on the item category.",
           "llm_called": true,
           "handler": null,
           "text": "Determine refund eligibility for this order.",
@@ -1189,12 +1149,28 @@
           }
         },
         {
+          "id": "pol-006",
+          "category": "policy",
+          "gt_kind": "eligibility",
+          "ground_truth": "ineligible",
+          "verdict": "eligible",
+          "answer": "You are eligible for a refund.",
+          "llm_called": true,
+          "handler": null,
+          "text": "Determine refund eligibility for this order.",
+          "payload": {
+            "days_since_delivery": 2,
+            "item_category": "food",
+            "opened": false
+          }
+        },
+        {
           "id": "pol-008",
           "category": "policy",
           "gt_kind": "eligibility",
           "ground_truth": "eligible",
           "verdict": "ineligible",
-          "answer": "Most items must be returned in their original packaging to be eligible for a refund.",
+          "answer": "Opened items are generally not eligible for refunds.",
           "llm_called": true,
           "handler": null,
           "text": "Determine refund eligibility for this order.",
@@ -1210,7 +1186,7 @@
           "gt_kind": "eligibility",
           "ground_truth": "eligible",
           "verdict": "ineligible",
-          "answer": "Most clothing items must be returned within 15 days and in their original packaging to be eligible for a refund.",
+          "answer": "According to our policy, clothing items that have been opened are not eligible for refunds after 14 days.",
           "llm_called": true,
           "handler": null,
           "text": "Determine refund eligibility for this order.",
@@ -1242,7 +1218,7 @@
           "gt_kind": "eligibility",
           "ground_truth": "eligible",
           "verdict": "ineligible",
-          "answer": "Most items in electronics category can be returned within 15 days.",
+          "answer": "Most electronics have a 15-day return window.",
           "llm_called": true,
           "handler": null,
           "text": "Determine refund eligibility for this order.",
@@ -1338,7 +1314,7 @@
           "gt_kind": "eligibility",
           "ground_truth": "eligible",
           "verdict": "ineligible",
-          "answer": "Order total must be at least $25 for free shipping, or $10 for Plus members, to qualify.",
+          "answer": "Order total must be at least $25 for free shipping, or $10 for Plus members with domestic destinations.",
           "llm_called": true,
           "handler": null,
           "text": "Determine whether this order qualifies for free shipping.",
@@ -1370,7 +1346,7 @@
           "gt_kind": "eligibility",
           "ground_truth": "eligible",
           "verdict": "ineligible",
-          "answer": "Orders to remote zones require a minimum of $100 for free shipping, even with a plus membership.",
+          "answer": "Free shipping typically requires an order total of $100 or more for remote zones, or $75 or more for plus members in non-remote zones.",
           "llm_called": true,
           "handler": null,
           "text": "Determine whether this order qualifies for free shipping.",
@@ -1386,7 +1362,7 @@
           "gt_kind": "eligibility",
           "ground_truth": "eligible",
           "verdict": "ineligible",
-          "answer": "Order total must be $50 or more for free shipping.",
+          "answer": "Order total must be $50 or more for free shipping",
           "llm_called": true,
           "handler": null,
           "text": "Determine whether this order qualifies for free shipping.",
@@ -1466,7 +1442,7 @@
           "gt_kind": "eligibility",
           "ground_truth": "ineligible",
           "verdict": null,
-          "answer": "The coupon you're trying to use is WELCOME10, but the details provided are for SAVE20. Please check the coupon code and try again.",
+          "answer": "The coupon you're trying to use is WELCOME10, but the details provided mention a different coupon code, SAVE20. Please check the coupon code and try again.",
           "llm_called": true,
           "handler": null,
           "text": "Determine whether the WELCOME10 coupon is valid here.",
@@ -1482,7 +1458,7 @@
           "gt_kind": "eligibility",
           "ground_truth": "eligible",
           "verdict": "ineligible",
-          "answer": "Account age is 0 days and there are no prior orders, so the WELCOME10 coupon is not applicable.",
+          "answer": "The WELCOME10 coupon is typically for new customers with some prior activity, but your account is too new.",
           "llm_called": true,
           "handler": null,
           "text": "Determine whether the WELCOME10 coupon is valid here.",
@@ -1546,7 +1522,7 @@
           "gt_kind": "eligibility",
           "ground_truth": "ineligible",
           "verdict": "eligible",
-          "answer": "You are eligible for the WELCOME10 coupon as it is typically offered to new customers with no prior orders.",
+          "answer": "The WELCOME10 coupon is valid for new customers with no prior orders.",
           "llm_called": true,
           "handler": null,
           "text": "Determine whether the WELCOME10 coupon is valid here.",
@@ -1626,7 +1602,7 @@
           "gt_kind": "eligibility",
           "ground_truth": "eligible",
           "verdict": "ineligible",
-          "answer": "Warranty claims for electronics are only covered up to 12 months after purchase, and since this claim is for 11 months, it is still within the timeframe, but the answer is based on the assumption that",
+          "answer": "Warranty claims for electronics are only covered up to 12 months after purchase, but since the defect is manufacturing-related, you may want to contact our support team for further assistance.",
           "llm_called": true,
           "handler": null,
           "text": "Determine whether this warranty claim is covered.",
@@ -1642,7 +1618,7 @@
           "gt_kind": "eligibility",
           "ground_truth": "ineligible",
           "verdict": "eligible",
-          "answer": "Most accessories have a 6-12 month warranty covering manufacturing defects, so this claim is likely covered.",
+          "answer": "Based on the provided details, the warranty claim is covered.",
           "llm_called": true,
           "handler": null,
           "text": "Determine whether this warranty claim is covered.",
@@ -1696,6 +1672,21 @@
           "payload": {
             "reason": "changed_mind",
             "days_since_delivery": 5
+          }
+        },
+        {
+          "id": "pol-073",
+          "category": "policy",
+          "gt_kind": "eligibility",
+          "ground_truth": "eligible",
+          "verdict": "ineligible",
+          "answer": "Prepaid return labels are only available within 15 days of delivery for defective items.",
+          "llm_called": true,
+          "handler": null,
+          "text": "Determine free prepaid return-label eligibility.",
+          "payload": {
+            "reason": "defective",
+            "days_since_delivery": 20
           }
         },
         {
@@ -1765,7 +1756,7 @@
             "saturday"
           ],
           "verdict": null,
-          "answer": "Our store hours are Monday through Friday. Please check our website for specific hours and consider visiting us on a weekday.",
+          "answer": "Our store hours are Monday to Friday. Please check our website for specific hours and consider visiting us on a weekday.",
           "llm_called": true,
           "handler": null,
           "text": "Can I come by on a Saturday or Sunday?",
@@ -1780,7 +1771,7 @@
             "50"
           ],
           "verdict": null,
-          "answer": "Shipping fees vary depending on your location and order total. Please check our website for more information or contact us with your order details for a quote.",
+          "answer": "Shipping fees vary depending on your location and order total. Please add items to your cart and enter your shipping address to see the estimated shipping cost.",
           "llm_called": true,
           "handler": null,
           "text": "Do I have to pay a shipping fee, and how much?",
@@ -1809,7 +1800,7 @@
             "orders"
           ],
           "verdict": null,
-          "answer": "You can track your package by logging into your Northwind Goods account, going to 'Order History', and clicking on 'Track Package' next to your order. You will need your order number and the email add",
+          "answer": "You can track your package by logging into your Northwind Goods account, going to 'Order History', and clicking on 'Track Package' next to your order. You will also receive email updates with tracking",
           "llm_called": true,
           "handler": null,
           "text": "How can I follow where my package is?",
@@ -1823,7 +1814,7 @@
             "never"
           ],
           "verdict": null,
-          "answer": "Northwind Goods gift cards are valid for 2 years from the date of purchase.",
+          "answer": "Northwind Goods gift cards are valid for 12 months from the date of purchase.",
           "llm_called": true,
           "handler": null,
           "text": "How long is a gift card valid for?",

--- a/experiments/kora_target_workload/results/full_novapro.json
+++ b/experiments/kora_target_workload/results/full_novapro.json
@@ -24,12 +24,12 @@
   },
   "routing": {
     "positive_class": "should_escalate",
-    "tp": 68,
+    "tp": 70,
     "fp": 9,
     "tn": 251,
-    "fn": 2,
-    "precision": 0.8831168831168831,
-    "recall": 0.9714285714285714,
+    "fn": 0,
+    "precision": 0.8860759493670886,
+    "recall": 1.0,
     "by_category": {
       "format": {
         "n": 120,
@@ -48,29 +48,16 @@
       },
       "reasoning": {
         "n": 40,
-        "routed": 1,
-        "abstain": 39
+        "routed": 0,
+        "abstain": 40
       },
       "trap": {
         "n": 30,
-        "routed": 1,
-        "abstain": 29
+        "routed": 0,
+        "abstain": 30
       }
     },
-    "over_routed_cases": [
-      {
-        "id": "rea-030",
-        "category": "reasoning",
-        "handler": "faq:support_phone",
-        "answer": "Our support line is +1-800-555-0100."
-      },
-      {
-        "id": "trp-030",
-        "category": "trap",
-        "handler": "policy:refund_eligibility",
-        "answer": "eligible"
-      }
-    ]
+    "over_routed_cases": []
   },
   "conditions": {
     "with_kb": {
@@ -78,8 +65,8 @@
         "arm": "direct",
         "n_total": 330,
         "n_scorable": 260,
-        "accuracy": 0.9692307692307692,
-        "correct": 252,
+        "accuracy": 0.9730769230769231,
+        "correct": 253,
         "accuracy_by_category": {
           "format": {
             "n": 120,
@@ -88,8 +75,8 @@
           },
           "faq": {
             "n": 60,
-            "correct": 59,
-            "accuracy": 0.9833333333333333
+            "correct": 60,
+            "accuracy": 1.0
           },
           "policy": {
             "n": 80,
@@ -101,11 +88,11 @@
         "deterministic_answers": 0,
         "deflection_rate": 0.0,
         "tokens_in": 361391,
-        "tokens_out": 13231,
+        "tokens_out": 12547,
         "estimated_cost_usd": 0.0,
-        "latency_s_total": 436.5557508468628,
-        "latency_p50_s": 1.3007687330245972,
-        "latency_p95_s": 1.6784626841545105
+        "latency_s_total": 450.49545907974243,
+        "latency_p50_s": 1.3492830991744995,
+        "latency_p95_s": 1.7122800469398498
       },
       "kora": {
         "arm": "kora",
@@ -130,24 +117,24 @@
             "accuracy": 1.0
           }
         },
-        "llm_calls": 77,
-        "deterministic_answers": 253,
-        "deflection_rate": 0.7666666666666667,
-        "tokens_in": 83938,
-        "tokens_out": 4431,
+        "llm_calls": 79,
+        "deterministic_answers": 251,
+        "deflection_rate": 0.7606060606060606,
+        "tokens_in": 86140,
+        "tokens_out": 4106,
         "estimated_cost_usd": 0.0,
-        "latency_s_total": 110.51468539237976,
+        "latency_s_total": 115.45294547080994,
         "latency_p50_s": 0.0,
-        "latency_p95_s": 1.5900098443031312
+        "latency_p95_s": 1.6129996776580813
       },
       "comparison": {
-        "accuracy_delta_kora_minus_direct": 0.03076923076923077,
-        "llm_calls_saved": 253,
-        "llm_calls_saved_pct": 0.7666666666666667,
-        "tokens_in_saved": 277453,
-        "tokens_out_saved": 8800,
+        "accuracy_delta_kora_minus_direct": 0.02692307692307694,
+        "llm_calls_saved": 251,
+        "llm_calls_saved_pct": 0.7606060606060606,
+        "tokens_in_saved": 275251,
+        "tokens_out_saved": 8441,
         "cost_saved_usd": 0.0,
-        "latency_s_saved": 326.04106545448303
+        "latency_s_saved": 335.0425136089325
       },
       "consistency_direct": {
         "k": 1,
@@ -160,7 +147,7 @@
           "gt_kind": "valid_invalid",
           "ground_truth": "invalid",
           "verdict": "valid",
-          "answer": "Yes, 'a@localhost' is a valid email address format.",
+          "answer": "Yes, 'a@localhost' is a valid email address.",
           "llm_called": true,
           "handler": null,
           "text": "Is this a valid email address: a@localhost",
@@ -172,7 +159,7 @@
           "gt_kind": "valid_invalid",
           "ground_truth": "invalid",
           "verdict": "valid",
-          "answer": "Yes, user@example.com is a valid email address.",
+          "answer": "The email address user@example.com is valid.",
           "llm_called": true,
           "handler": null,
           "text": "Is this a valid email address: user@example.com.",
@@ -184,25 +171,27 @@
           "gt_kind": "valid_invalid",
           "ground_truth": "valid",
           "verdict": "invalid",
-          "answer": "The date 2024-02-29 is invalid because 2024 is a leap year, but February only has 28 days in non-leap years and 29 days in leap years. The correct date should be 2024-02-29.",
+          "answer": "The date 2024-02-29 is invalid because 2024 is a leap year, and February has only 29 days. The correct date should be 2024-02-29.",
           "llm_called": true,
           "handler": null,
           "text": "Is this a valid calendar date in YYYY-MM-DD format: 2024-02-29",
           "payload": null
         },
         {
-          "id": "faq-048",
-          "category": "faq",
-          "gt_kind": "kb_answer",
-          "ground_truth": [
-            "security"
-          ],
-          "verdict": null,
-          "answer": "To recover access, go to the login page and click on 'Forgot Password'. Follow the instructions to reset your password via the email associated with your account. If you no longer have access to that ",
+          "id": "pol-040",
+          "category": "policy",
+          "gt_kind": "eligibility",
+          "ground_truth": "ineligible",
+          "verdict": "eligible",
+          "answer": "The WELCOME10 coupon is valid for your account.",
           "llm_called": true,
           "handler": null,
-          "text": "How do I recover access when I can't log in with my password?",
-          "payload": null
+          "text": "Determine whether the WELCOME10 coupon is valid here.",
+          "payload": {
+            "account_age_days": 1,
+            "prior_orders": 0,
+            "coupon_code": "welcome10"
+          }
         },
         {
           "id": "pol-044",
@@ -226,7 +215,7 @@
           "gt_kind": "eligibility",
           "ground_truth": "ineligible",
           "verdict": "eligible",
-          "answer": "Your warranty claim is covered. Electronics have a 12-month warranty, and your defect is manufacturing-related.",
+          "answer": "Your warranty claim is covered.",
           "llm_called": true,
           "handler": null,
           "text": "Determine whether this warranty claim is covered.",
@@ -237,28 +226,12 @@
           }
         },
         {
-          "id": "pol-053",
-          "category": "policy",
-          "gt_kind": "eligibility",
-          "ground_truth": "ineligible",
-          "verdict": "eligible",
-          "answer": "Your warranty claim is covered. Appliances have a 24-month warranty period, and your claim is within this period for a manufacturing defect.",
-          "llm_called": true,
-          "handler": null,
-          "text": "Determine whether this warranty claim is covered.",
-          "payload": {
-            "months_since_purchase": 25,
-            "product_category": "appliance",
-            "defect_type": "manufacturing"
-          }
-        },
-        {
           "id": "pol-061",
           "category": "policy",
           "gt_kind": "eligibility",
           "ground_truth": "ineligible",
           "verdict": "eligible",
-          "answer": "Your warranty claim is covered. Accessories have a 6-month warranty period, and your claim is within this timeframe for a manufacturing defect.",
+          "answer": "Your warranty claim is covered.",
           "llm_called": true,
           "handler": null,
           "text": "Determine whether this warranty claim is covered.",
@@ -276,8 +249,8 @@
         "arm": "direct",
         "n_total": 330,
         "n_scorable": 260,
-        "accuracy": 0.7153846153846154,
-        "correct": 186,
+        "accuracy": 0.7038461538461539,
+        "correct": 183,
         "accuracy_by_category": {
           "format": {
             "n": 120,
@@ -286,24 +259,24 @@
           },
           "faq": {
             "n": 60,
-            "correct": 15,
-            "accuracy": 0.25
+            "correct": 13,
+            "accuracy": 0.21666666666666667
           },
           "policy": {
             "n": 80,
-            "correct": 55,
-            "accuracy": 0.6875
+            "correct": 54,
+            "accuracy": 0.675
           }
         },
         "llm_calls": 330,
         "deterministic_answers": 0,
         "deflection_rate": 0.0,
         "tokens_in": 54668,
-        "tokens_out": 13228,
+        "tokens_out": 12749,
         "estimated_cost_usd": 0.0,
-        "latency_s_total": 436.69351291656494,
-        "latency_p50_s": 1.3165202140808105,
-        "latency_p95_s": 1.586396646499634
+        "latency_s_total": 447.99653816223145,
+        "latency_p50_s": 1.345454216003418,
+        "latency_p95_s": 1.63741934299469
       },
       "kora": {
         "arm": "kora",
@@ -328,24 +301,24 @@
             "accuracy": 1.0
           }
         },
-        "llm_calls": 77,
-        "deterministic_answers": 253,
-        "deflection_rate": 0.7666666666666667,
-        "tokens_in": 12387,
-        "tokens_out": 3228,
+        "llm_calls": 79,
+        "deterministic_answers": 251,
+        "deflection_rate": 0.7606060606060606,
+        "tokens_in": 12729,
+        "tokens_out": 3037,
         "estimated_cost_usd": 0.0,
-        "latency_s_total": 104.91836738586426,
+        "latency_s_total": 109.5938150882721,
         "latency_p50_s": 0.0,
-        "latency_p95_s": 1.4404577493667605
+        "latency_p95_s": 1.4838306903839111
       },
       "comparison": {
-        "accuracy_delta_kora_minus_direct": 0.26538461538461533,
-        "llm_calls_saved": 253,
-        "llm_calls_saved_pct": 0.7666666666666667,
-        "tokens_in_saved": 42281,
-        "tokens_out_saved": 10000,
+        "accuracy_delta_kora_minus_direct": 0.2769230769230768,
+        "llm_calls_saved": 251,
+        "llm_calls_saved_pct": 0.7606060606060606,
+        "tokens_in_saved": 41939,
+        "tokens_out_saved": 9712,
         "cost_saved_usd": 0.0,
-        "latency_s_saved": 331.7751455307007
+        "latency_s_saved": 338.40272307395935
       },
       "consistency_direct": {
         "k": 1,
@@ -358,7 +331,7 @@
           "gt_kind": "valid_invalid",
           "ground_truth": "invalid",
           "verdict": "valid",
-          "answer": "Yes, 'a@localhost' is a valid email address. It follows the standard email format and can be used for local testing purposes.",
+          "answer": "Yes, 'a@localhost' is a valid email address format, though it may not be routable on the public internet.",
           "llm_called": true,
           "handler": null,
           "text": "Is this a valid email address: a@localhost",
@@ -370,22 +343,10 @@
           "gt_kind": "valid_invalid",
           "ground_truth": "invalid",
           "verdict": "valid",
-          "answer": "The email address user@example.com is valid.",
+          "answer": "Yes, user@example.com is a valid email address.",
           "llm_called": true,
           "handler": null,
           "text": "Is this a valid email address: user@example.com.",
-          "payload": null
-        },
-        {
-          "id": "fmt-phone-026",
-          "category": "format",
-          "gt_kind": "valid_invalid",
-          "ground_truth": "invalid",
-          "verdict": "valid",
-          "answer": "Yes, +1 000 000 0000 is a valid phone number format.",
-          "llm_called": true,
-          "handler": null,
-          "text": "Is this a valid phone number: +1 000 000 0000",
           "payload": null
         },
         {
@@ -394,10 +355,22 @@
           "gt_kind": "valid_invalid",
           "ground_truth": "valid",
           "verdict": "invalid",
-          "answer": "The date 2024-02-29 is invalid because 2024 is a leap year and February has only 29 days. The correct date should be 2024-02-29.",
+          "answer": "February 29th is only valid in leap years. 2024 is a leap year, but the date is still invalid as February only has 29 days in leap years. The correct date should be 2024-02-29.",
           "llm_called": true,
           "handler": null,
           "text": "Is this a valid calendar date in YYYY-MM-DD format: 2024-02-29",
+          "payload": null
+        },
+        {
+          "id": "fmt-date-019",
+          "category": "format",
+          "gt_kind": "valid_invalid",
+          "ground_truth": "valid",
+          "verdict": "invalid",
+          "answer": "February 29th is only valid in leap years. 2016 was a leap year, but the date is invalid because it is out of range for February, which has 28 days in non-leap years and 29 days in leap years. Please ",
+          "llm_called": true,
+          "handler": null,
+          "text": "Is this a valid calendar date in YYYY-MM-DD format: 2016-02-29",
           "payload": null
         },
         {
@@ -409,7 +382,7 @@
             "friday"
           ],
           "verdict": null,
-          "answer": "Our weekday hours are 10 AM to 6 PM. We're closed on weekends.",
+          "answer": "Our weekday hours are 10 AM to 6 PM. We look forward to your visit!",
           "llm_called": true,
           "handler": null,
           "text": "I want to visit on a Wednesday \u2014 what are your weekday hours?",
@@ -452,7 +425,7 @@
             "saturday"
           ],
           "verdict": null,
-          "answer": "Our customer support is available 24/7, including weekends. How can I assist you today?",
+          "answer": "Our customer support is available 24/7, including weekends. Feel free to reach out anytime!",
           "llm_called": true,
           "handler": null,
           "text": "What are your hours over the weekend?",
@@ -466,7 +439,7 @@
             "saturday"
           ],
           "verdict": null,
-          "answer": "Our store is open on weekends, including Saturdays and Sundays, from 10 AM to 6 PM. Feel free to visit us during these hours.",
+          "answer": "Our store is open from Monday to Friday, 9 AM to 5 PM. We are closed on weekends.",
           "llm_called": true,
           "handler": null,
           "text": "Can I come by on a Saturday or Sunday?",
@@ -494,7 +467,7 @@
             "30"
           ],
           "verdict": null,
-          "answer": "You have 30 days from the date of purchase to request a refund. Please ensure you review our refund policy for any specific conditions that may apply. If you need assistance, feel free to contact our ",
+          "answer": "You have 30 days from the date of purchase to request a refund. Please refer to our return policy for more details.",
           "llm_called": true,
           "handler": null,
           "text": "How many days do I have to ask for a refund?",
@@ -508,24 +481,10 @@
             "30"
           ],
           "verdict": null,
-          "answer": "You have 30 days from the purchase date to request a refund. Please refer to our return policy for more details.",
+          "answer": "You have 30 days from the purchase date to request a return or exchange. Please refer to our return policy for more details.",
           "llm_called": true,
           "handler": null,
           "text": "What's the time limit on getting my money back?",
-          "payload": null
-        },
-        {
-          "id": "faq-011",
-          "category": "faq",
-          "gt_kind": "kb_answer",
-          "ground_truth": [
-            "30"
-          ],
-          "verdict": null,
-          "answer": "Yes, returns for a refund must be made within 30 days of purchase. Please refer to our return policy for more details.",
-          "llm_called": true,
-          "handler": null,
-          "text": "Is there a deadline to return something for a refund?",
           "payload": null
         },
         {
@@ -567,7 +526,7 @@
             "50"
           ],
           "verdict": null,
-          "answer": "Shipping fees vary based on the destination and the items ordered. Please check the product page or your cart for specific shipping costs.",
+          "answer": "Shipping fees vary based on your location and the items ordered. Check the product page or your cart for specific details.",
           "llm_called": true,
           "handler": null,
           "text": "Do I have to pay a shipping fee, and how much?",
@@ -582,7 +541,7 @@
             "50"
           ],
           "verdict": null,
-          "answer": "Delivery charges vary by product and location. Check the product page for details.",
+          "answer": "Delivery charges depend on the item and destination. Check the product page for details.",
           "llm_called": true,
           "handler": null,
           "text": "Is there a postage charge, or is delivery free?",
@@ -597,10 +556,25 @@
             "5"
           ],
           "verdict": null,
-          "answer": "Delivery times vary by location and product. Check your order details for an estimated arrival date.",
+          "answer": "Delivery times vary by location and product. Check your order details for estimated arrival dates.",
           "llm_called": true,
           "handler": null,
           "text": "How many days until my domestic order arrives?",
+          "payload": null
+        },
+        {
+          "id": "faq-019",
+          "category": "faq",
+          "gt_kind": "kb_answer",
+          "ground_truth": [
+            "3",
+            "5"
+          ],
+          "verdict": null,
+          "answer": "Domestic orders typically ship within 1-2 business days and arrive within 3-7 business days. Please check your order confirmation for specific details.",
+          "llm_called": true,
+          "handler": null,
+          "text": "When will my order ship and get here domestically?",
           "payload": null
         },
         {
@@ -627,7 +601,7 @@
             "14"
           ],
           "verdict": null,
-          "answer": "Shipping times abroad vary by destination and shipping method. Please check our shipping policy for more details.",
+          "answer": "Shipping abroad typically takes 10-20 business days, depending on the destination and shipping method chosen.",
           "llm_called": true,
           "handler": null,
           "text": "How long does shipping abroad take?",
@@ -642,7 +616,7 @@
             "14"
           ],
           "verdict": null,
-          "answer": "Overseas orders typically arrive within 10-15 business days. Please note that delivery times may vary due to customs processing and other factors.",
+          "answer": "Delivery times for overseas orders vary based on destination and shipping method. Please check the estimated delivery date provided during checkout or contact our support for more specific information",
           "llm_called": true,
           "handler": null,
           "text": "When will an overseas order arrive?",
@@ -657,7 +631,7 @@
             "14"
           ],
           "verdict": null,
-          "answer": "Delivery times for international orders vary by destination and shipping method. Typically, it ranges from 7 to 21 business days. For precise estimates, please check our shipping policy or contact our",
+          "answer": "International orders typically take 10-20 business days for delivery.",
           "llm_called": true,
           "handler": null,
           "text": "What's the delivery time for international orders?",
@@ -672,7 +646,7 @@
             "14"
           ],
           "verdict": null,
-          "answer": "International shipping typically takes 7-21 business days. For more precise estimates, please check our shipping policy page.",
+          "answer": "International shipping typically takes 10-20 business days. For exact timelines, check our shipping policy page.",
           "llm_called": true,
           "handler": null,
           "text": "How many days to ship internationally?",
@@ -686,7 +660,7 @@
             "support@northwindgoods.example"
           ],
           "verdict": null,
-          "answer": "You can contact support using the email address support@northwindgoods.com.",
+          "answer": "You can contact support at support@northwindgoods.com.",
           "llm_called": true,
           "handler": null,
           "text": "What email address can I use to contact support?",
@@ -700,7 +674,7 @@
             "support@northwindgoods.example"
           ],
           "verdict": null,
-          "answer": "For assistance, please email us at support@northwindgoods.com.",
+          "answer": "For help, email our customer support at support@northwindgoods.com.",
           "llm_called": true,
           "handler": null,
           "text": "Where do I email if I need help?",
@@ -714,7 +688,7 @@
             "support@northwindgoods.example"
           ],
           "verdict": null,
-          "answer": "You can reach our customer support via email at support@northwindgoods.com. We're here to help!",
+          "answer": "You can reach our customer support team by emailing support@northwindgoods.com.",
           "llm_called": true,
           "handler": null,
           "text": "What is your customer support e-mail address?",
@@ -756,7 +730,7 @@
             "555-0100"
           ],
           "verdict": null,
-          "answer": "You can reach our customer service by phone at 1-800-555-3663.",
+          "answer": "You can reach our customer service by phone at 1-800-555-1234.",
           "llm_called": true,
           "handler": null,
           "text": "How can I phone customer service?",
@@ -770,7 +744,7 @@
             "555-0100"
           ],
           "verdict": null,
-          "answer": "You can reach our support team by email at support@northwindgoods.com or through our online chat available on our website. We do not have a dedicated telephone support line.",
+          "answer": "You can reach our support team by email at support@northwindgoods.com or through our online chat available on our website.",
           "llm_called": true,
           "handler": null,
           "text": "Is there a support telephone number I can call?",
@@ -799,7 +773,7 @@
             "paypal"
           ],
           "verdict": null,
-          "answer": "We accept Visa, Mastercard, American Express, and Discover. For more details, visit our payment methods page.",
+          "answer": "We accept Visa, Mastercard, American Express, and Discover.",
           "llm_called": true,
           "handler": null,
           "text": "Which cards do you take at checkout?",
@@ -836,6 +810,20 @@
           "payload": null
         },
         {
+          "id": "faq-041",
+          "category": "faq",
+          "gt_kind": "kb_answer",
+          "ground_truth": [
+            "100"
+          ],
+          "verdict": null,
+          "answer": "You earn rewards points by making purchases on our website. Points are typically awarded based on the amount spent, with specific details available in our rewards program terms.",
+          "llm_called": true,
+          "handler": null,
+          "text": "How do I earn rewards points?",
+          "payload": null
+        },
+        {
           "id": "faq-042",
           "category": "faq",
           "gt_kind": "kb_answer",
@@ -857,7 +845,7 @@
             "100"
           ],
           "verdict": null,
-          "answer": "Points earned and their value depend on your membership level and purchase amount. Please check your account for specific details or contact us for more information.",
+          "answer": "Points vary by purchase and are worth a percentage off future purchases. Check your account for details.",
           "llm_called": true,
           "handler": null,
           "text": "How many points do I get and what are they worth?",
@@ -871,7 +859,7 @@
             "100"
           ],
           "verdict": null,
-          "answer": "You earn rewards by making purchases, which can later be redeemed for discounts on future orders. Check your account for current rewards and eligible redemptions.",
+          "answer": "You earn rewards by making purchases, which can later be redeemed for discounts on future orders. Check your account for current rewards balance and redemption options.",
           "llm_called": true,
           "handler": null,
           "text": "How does earning and redeeming rewards work?",
@@ -885,7 +873,7 @@
             "security"
           ],
           "verdict": null,
-          "answer": "To reset your password, visit our login page and click on 'Forgot Password'. Follow the instructions sent to your registered email address. If you need further assistance, contact our support team.",
+          "answer": "To reset your password, visit our login page and click on 'Forgot Password'. Follow the instructions sent to your registered email address.",
           "llm_called": true,
           "handler": null,
           "text": "How can I reset my password?",
@@ -899,7 +887,7 @@
             "security"
           ],
           "verdict": null,
-          "answer": "To reset your password, visit our login page and click on 'Forgot Password'. Follow the instructions sent to your registered email address. If you encounter issues, contact our support team.",
+          "answer": "You can reset your password by clicking on 'Forgot Password' on the login page and following the instructions sent to your email.",
           "llm_called": true,
           "handler": null,
           "text": "I forgot my password \u2014 how do I change it?",
@@ -913,7 +901,7 @@
             "security"
           ],
           "verdict": null,
-          "answer": "You can reset your account password by visiting the 'Forgot Password' link on our login page. Follow the instructions provided to create a new password.",
+          "answer": "You can reset your account password by visiting the 'Forgot Password' link on our login page.",
           "llm_called": true,
           "handler": null,
           "text": "Where do I go to reset my account password?",
@@ -927,7 +915,7 @@
             "security"
           ],
           "verdict": null,
-          "answer": "To recover access, visit our login page and click on 'Forgot Password'. Follow the instructions sent to your registered email to reset your password. If you need further assistance, contact our suppor",
+          "answer": "Please use the 'Forgot Password' option on the login page to reset your password. If you continue to experience issues, contact our support team with your account details for further assistance.",
           "llm_called": true,
           "handler": null,
           "text": "How do I recover access when I can't log in with my password?",
@@ -941,10 +929,24 @@
             "orders"
           ],
           "verdict": null,
-          "answer": "You can track your order by logging into your account on our website and navigating to the 'Order History' section. There, you'll find tracking information for your recent purchases. If you need furth",
+          "answer": "You can track your order by logging into your account on our website and navigating to the 'Order History' section. There, you'll find tracking information for your order. If you need further assistan",
           "llm_called": true,
           "handler": null,
           "text": "How do I track my order?",
+          "payload": null
+        },
+        {
+          "id": "faq-050",
+          "category": "faq",
+          "gt_kind": "kb_answer",
+          "ground_truth": [
+            "orders"
+          ],
+          "verdict": null,
+          "answer": "You can view your shipment's tracking status on the 'My Orders' page of your account. Enter your order number for detailed tracking information.",
+          "llm_called": true,
+          "handler": null,
+          "text": "Where can I see my shipment's tracking status?",
           "payload": null
         },
         {
@@ -955,7 +957,7 @@
             "orders"
           ],
           "verdict": null,
-          "answer": "You can track your package using the tracking number provided in your shipping confirmation email on our website's tracking page.",
+          "answer": "You can track your package using the tracking number provided in your shipment confirmation email on our website.",
           "llm_called": true,
           "handler": null,
           "text": "How can I follow where my package is?",
@@ -983,7 +985,7 @@
             "never"
           ],
           "verdict": null,
-          "answer": "Gift cards are valid for 2 years from the date of purchase. Please check your card for the specific expiration date.",
+          "answer": "Gift cards are valid for 2 years from the date of purchase.",
           "llm_called": true,
           "handler": null,
           "text": "How long is a gift card valid for?",
@@ -997,7 +999,7 @@
             "columbus"
           ],
           "verdict": null,
-          "answer": "Please visit our returns page for detailed instructions on how to mail your returns: https://www.northwindgoods.com/returns",
+          "answer": "Please mail your returns to the following address: Northwind Goods, Returns Department, 12345 Return Lane, Anytown, USA.",
           "llm_called": true,
           "handler": null,
           "text": "Where should I mail my returns?",
@@ -1011,7 +1013,7 @@
             "columbus"
           ],
           "verdict": null,
-          "answer": "Please send returned items to the following address: Northwind Goods, Returns Department, 1234 Elm Street, Springfield, IL 62701.",
+          "answer": "Please send returned items to our returns department at 1234 Returns Lane, Anytown, USA.",
           "llm_called": true,
           "handler": null,
           "text": "What address do I send returned items to?",
@@ -1025,7 +1027,7 @@
             "columbus"
           ],
           "verdict": null,
-          "answer": "Returns should be shipped to the address provided in the return instructions sent via email after your request for a return is approved. Please check your email for the specific address. If you cannot",
+          "answer": "Please ship returns to the address provided in your order confirmation email. If you cannot find it, contact our customer support for assistance.",
           "llm_called": true,
           "handler": null,
           "text": "Where do returns need to be shipped?",
@@ -1039,7 +1041,7 @@
             "columbus"
           ],
           "verdict": null,
-          "answer": "Please visit our Returns page for detailed instructions and the shipping address: https://northwindgoods.com/returns",
+          "answer": "Please visit our Returns page for detailed instructions and the return shipping address: https://www.northwindgoods.com/returns",
           "llm_called": true,
           "handler": null,
           "text": "What is the return shipping address?",
@@ -1051,7 +1053,7 @@
           "gt_kind": "eligibility",
           "ground_truth": "eligible",
           "verdict": "ineligible",
-          "answer": "Refund not eligible: books are non-returnable if opened, and it's past the 7-day return window.",
+          "answer": "Refund not eligible: books opened over 7 days since delivery.",
           "llm_called": true,
           "handler": null,
           "text": "Determine refund eligibility for this order.",
@@ -1067,7 +1069,7 @@
           "gt_kind": "eligibility",
           "ground_truth": "ineligible",
           "verdict": "eligible",
-          "answer": "The order is eligible for a refund as it was returned within 30 days and the item is unopened.",
+          "answer": "The order is eligible for a refund as it was returned within 30 days, the item is unopened, and food items are generally returnable if unopened.",
           "llm_called": true,
           "handler": null,
           "text": "Determine refund eligibility for this order.",
@@ -1083,7 +1085,7 @@
           "gt_kind": "eligibility",
           "ground_truth": "eligible",
           "verdict": "ineligible",
-          "answer": "Refund not eligible: item has been opened and is outside the return window.",
+          "answer": "Refund not eligible: item opened and within return period.",
           "llm_called": true,
           "handler": null,
           "text": "Determine refund eligibility for this order.",
@@ -1115,29 +1117,13 @@
           "gt_kind": "eligibility",
           "ground_truth": "eligible",
           "verdict": "ineligible",
-          "answer": "Refunds for electronics are only eligible within 30 days of delivery if unopened.",
+          "answer": "Refund not eligible: electronics category has a 30-day return policy.",
           "llm_called": true,
           "handler": null,
           "text": "Determine refund eligibility for this order.",
           "payload": {
             "days_since_delivery": 29,
             "item_category": "electronics",
-            "opened": false
-          }
-        },
-        {
-          "id": "pol-014",
-          "category": "policy",
-          "gt_kind": "eligibility",
-          "ground_truth": "eligible",
-          "verdict": "ineligible",
-          "answer": "Refund not eligible: order is beyond 14 days since delivery.",
-          "llm_called": true,
-          "handler": null,
-          "text": "Determine refund eligibility for this order.",
-          "payload": {
-            "days_since_delivery": 15,
-            "item_category": "other",
             "opened": false
           }
         },
@@ -1163,7 +1149,7 @@
           "gt_kind": "eligibility",
           "ground_truth": "eligible",
           "verdict": "ineligible",
-          "answer": "Free shipping is not available for this order. It requires an order total of at least $100 or an active membership.",
+          "answer": "Orders qualify for free shipping with a total of $100 or more, or with an active membership. Your order does not meet these criteria.",
           "llm_called": true,
           "handler": null,
           "text": "Determine whether this order qualifies for free shipping.",
@@ -1179,7 +1165,7 @@
           "gt_kind": "eligibility",
           "ground_truth": "eligible",
           "verdict": "ineligible",
-          "answer": "Orders qualify for free shipping with a total of $75 or more, or with a premium membership. Your order does not meet these criteria.",
+          "answer": "Orders qualify for free shipping with a total of $100 or more, or with an active membership. Your order does not meet these criteria.",
           "llm_called": true,
           "handler": null,
           "text": "Determine whether this order qualifies for free shipping.",
@@ -1195,7 +1181,7 @@
           "gt_kind": "eligibility",
           "ground_truth": "eligible",
           "verdict": "ineligible",
-          "answer": "Orders to remote zones require a total of at least $50 for free shipping, regardless of membership status.",
+          "answer": "Orders to remote zones require a total of at least $50 for free shipping, even with a plus membership.",
           "llm_called": true,
           "handler": null,
           "text": "Determine whether this order qualifies for free shipping.",
@@ -1206,12 +1192,28 @@
           }
         },
         {
+          "id": "pol-023",
+          "category": "policy",
+          "gt_kind": "eligibility",
+          "ground_truth": "eligible",
+          "verdict": "ineligible",
+          "answer": "Orders under $25 do not qualify for free shipping, regardless of membership status.",
+          "llm_called": true,
+          "handler": null,
+          "text": "Determine whether this order qualifies for free shipping.",
+          "payload": {
+            "order_total": 5,
+            "destination_zone": "domestic",
+            "membership": "plus"
+          }
+        },
+        {
           "id": "pol-025",
           "category": "policy",
           "gt_kind": "eligibility",
           "ground_truth": "eligible",
           "verdict": "ineligible",
-          "answer": "Free shipping requires an order total of $150 or a premium membership.",
+          "answer": "Orders qualify for free shipping with a total of $150 or more, or with a premium membership. Your order does not meet these criteria.",
           "llm_called": true,
           "handler": null,
           "text": "Determine whether this order qualifies for free shipping.",
@@ -1243,7 +1245,7 @@
           "gt_kind": "eligibility",
           "ground_truth": "eligible",
           "verdict": "ineligible",
-          "answer": "Orders with a total of $0 do not qualify for free shipping, regardless of membership or destination zone.",
+          "answer": "Orders with a total of $0 do not qualify for free shipping, regardless of membership or destination zone. Please add items to your cart to check out.",
           "llm_called": true,
           "handler": null,
           "text": "Determine whether this order qualifies for free shipping.",
@@ -1259,7 +1261,7 @@
           "gt_kind": "eligibility",
           "ground_truth": "eligible",
           "verdict": "ineligible",
-          "answer": "Orders qualify for free shipping with a total of $100 or more, or with a premium membership. Your order does not meet these criteria.",
+          "answer": "Orders qualify for free shipping with a total of $100 or more, or with an active membership. Your order does not meet these criteria.",
           "llm_called": true,
           "handler": null,
           "text": "Determine whether this order qualifies for free shipping.",
@@ -1275,7 +1277,7 @@
           "gt_kind": "eligibility",
           "ground_truth": "ineligible",
           "verdict": "eligible",
-          "answer": "The WELCOME10 coupon is valid for new accounts with no prior orders.",
+          "answer": "The WELCOME10 coupon is valid for new customers with no prior orders.",
           "llm_called": true,
           "handler": null,
           "text": "Determine whether the WELCOME10 coupon is valid here.",
@@ -1323,7 +1325,7 @@
           "gt_kind": "eligibility",
           "ground_truth": "eligible",
           "verdict": "ineligible",
-          "answer": "Warranty claims for appliances are only covered for manufacturing defects within 12 months of purchase.",
+          "answer": "Warranty claims for appliances are only covered for manufacturing defects within 12 months of purchase. Your claim is ineligible.",
           "llm_called": true,
           "handler": null,
           "text": "Determine whether this warranty claim is covered.",
@@ -1355,7 +1357,7 @@
           "gt_kind": "eligibility",
           "ground_truth": "eligible",
           "verdict": "ineligible",
-          "answer": "Your warranty claim is ineligible as it exceeds the 12-month coverage period for appliances.",
+          "answer": "Warranty claims for appliances are only covered for 12 months after purchase. Your claim is ineligible.",
           "llm_called": true,
           "handler": null,
           "text": "Determine whether this warranty claim is covered.",
@@ -1371,7 +1373,7 @@
           "gt_kind": "eligibility",
           "ground_truth": "eligible",
           "verdict": "ineligible",
-          "answer": "Free prepaid return label is not eligible as it has been more than 30 days since delivery.",
+          "answer": "Free prepaid return labels are only provided within 30 days of delivery. Since it's exactly 30 days, you may still be eligible, but please contact us for confirmation.",
           "llm_called": true,
           "handler": null,
           "text": "Determine free prepaid return-label eligibility.",
@@ -1381,12 +1383,27 @@
           }
         },
         {
+          "id": "pol-069",
+          "category": "policy",
+          "gt_kind": "eligibility",
+          "ground_truth": "ineligible",
+          "verdict": "eligible",
+          "answer": "You are eligible for a free prepaid return label as it's within 7 days of delivery.",
+          "llm_called": true,
+          "handler": null,
+          "text": "Determine free prepaid return-label eligibility.",
+          "payload": {
+            "reason": "changed_mind",
+            "days_since_delivery": 5
+          }
+        },
+        {
           "id": "pol-073",
           "category": "policy",
           "gt_kind": "eligibility",
           "ground_truth": "eligible",
           "verdict": "ineligible",
-          "answer": "Free prepaid return label is not eligible as it's beyond 14 days since delivery.",
+          "answer": "Free prepaid return labels are only eligible within 14 days of delivery. Your return request is beyond the eligible timeframe.",
           "llm_called": true,
           "handler": null,
           "text": "Determine free prepaid return-label eligibility.",
@@ -1401,7 +1418,7 @@
           "gt_kind": "eligibility",
           "ground_truth": "eligible",
           "verdict": "ineligible",
-          "answer": "Returns due to receiving the wrong item are eligible for a free prepaid return label within 14 days of delivery. Since it's been 30 days, you are ineligible for a free prepaid return label.",
+          "answer": "Free prepaid return label is not eligible as it has been more than 30 days since delivery.",
           "llm_called": true,
           "handler": null,
           "text": "Determine free prepaid return-label eligibility.",
@@ -1416,7 +1433,7 @@
           "gt_kind": "eligibility",
           "ground_truth": "eligible",
           "verdict": "ineligible",
-          "answer": "Free prepaid return labels are only eligible within 30 days of delivery. Since it's been 29 days, you're just outside the window. You can still return the item, but a return label won't be provided.",
+          "answer": "Free prepaid return labels are only provided for returns within 30 days of delivery. Since it's been 29 days, you'll need to cover the return shipping cost.",
           "llm_called": true,
           "handler": null,
           "text": "Determine free prepaid return-label eligibility.",
@@ -1431,7 +1448,7 @@
           "gt_kind": "eligibility",
           "ground_truth": "eligible",
           "verdict": "ineligible",
-          "answer": "Returns due to receiving the wrong item are eligible for a free prepaid return label within 14 days of delivery. Since it's been 15 days, you are ineligible for a free prepaid return label. You can st",
+          "answer": "Free prepaid return labels are only eligible within 14 days of delivery. Please contact support for further assistance.",
           "llm_called": true,
           "handler": null,
           "text": "Determine free prepaid return-label eligibility.",
@@ -1450,7 +1467,7 @@
             "saturday"
           ],
           "verdict": null,
-          "answer": "Our store is open on weekends, including Saturdays and Sundays, from 10 AM to 6 PM. Feel free to visit us during these hours.",
+          "answer": "Our store is open from Monday to Friday, 9 AM to 5 PM. We are closed on weekends.",
           "llm_called": true,
           "handler": null,
           "text": "Can I come by on a Saturday or Sunday?",
@@ -1465,7 +1482,7 @@
             "50"
           ],
           "verdict": null,
-          "answer": "Shipping fees vary based on the destination and the items ordered. Please check the product page or your cart for specific shipping costs.",
+          "answer": "Shipping fees vary based on your location and the items ordered. Check the product page or your cart for specific details.",
           "llm_called": true,
           "handler": null,
           "text": "Do I have to pay a shipping fee, and how much?",
@@ -1480,7 +1497,7 @@
             "paypal"
           ],
           "verdict": null,
-          "answer": "We accept Visa, Mastercard, American Express, and Discover. For more details, visit our payment methods page.",
+          "answer": "We accept Visa, Mastercard, American Express, and Discover.",
           "llm_called": true,
           "handler": null,
           "text": "Which cards do you take at checkout?",
@@ -1494,7 +1511,7 @@
             "orders"
           ],
           "verdict": null,
-          "answer": "You can track your package using the tracking number provided in your shipping confirmation email on our website's tracking page.",
+          "answer": "You can track your package using the tracking number provided in your shipment confirmation email on our website.",
           "llm_called": true,
           "handler": null,
           "text": "How can I follow where my package is?",
@@ -1508,7 +1525,7 @@
             "never"
           ],
           "verdict": null,
-          "answer": "Gift cards are valid for 2 years from the date of purchase. Please check your card for the specific expiration date.",
+          "answer": "Gift cards are valid for 2 years from the date of purchase.",
           "llm_called": true,
           "handler": null,
           "text": "How long is a gift card valid for?",

--- a/experiments/kora_target_workload/results/full_sonnet46.json
+++ b/experiments/kora_target_workload/results/full_sonnet46.json
@@ -24,12 +24,12 @@
   },
   "routing": {
     "positive_class": "should_escalate",
-    "tp": 68,
+    "tp": 70,
     "fp": 9,
     "tn": 251,
-    "fn": 2,
-    "precision": 0.8831168831168831,
-    "recall": 0.9714285714285714,
+    "fn": 0,
+    "precision": 0.8860759493670886,
+    "recall": 1.0,
     "by_category": {
       "format": {
         "n": 120,
@@ -48,29 +48,16 @@
       },
       "reasoning": {
         "n": 40,
-        "routed": 1,
-        "abstain": 39
+        "routed": 0,
+        "abstain": 40
       },
       "trap": {
         "n": 30,
-        "routed": 1,
-        "abstain": 29
+        "routed": 0,
+        "abstain": 30
       }
     },
-    "over_routed_cases": [
-      {
-        "id": "rea-030",
-        "category": "reasoning",
-        "handler": "faq:support_phone",
-        "answer": "Our support line is +1-800-555-0100."
-      },
-      {
-        "id": "trp-030",
-        "category": "trap",
-        "handler": "policy:refund_eligibility",
-        "answer": "eligible"
-      }
-    ]
+    "over_routed_cases": []
   },
   "conditions": {
     "with_kb": {
@@ -101,11 +88,11 @@
         "deterministic_answers": 0,
         "deflection_rate": 0.0,
         "tokens_in": 363213,
-        "tokens_out": 25130,
+        "tokens_out": 25039,
         "estimated_cost_usd": 0.0,
-        "latency_s_total": 897.7538371086121,
-        "latency_p50_s": 2.3104801177978516,
-        "latency_p95_s": 5.627322101593019
+        "latency_s_total": 1019.8618960380554,
+        "latency_p50_s": 2.6228402853012085,
+        "latency_p95_s": 6.248898148536683
       },
       "kora": {
         "arm": "kora",
@@ -130,24 +117,24 @@
             "accuracy": 1.0
           }
         },
-        "llm_calls": 77,
-        "deterministic_answers": 253,
-        "deflection_rate": 0.7666666666666667,
-        "tokens_in": 84381,
-        "tokens_out": 11771,
+        "llm_calls": 79,
+        "deterministic_answers": 251,
+        "deflection_rate": 0.7606060606060606,
+        "tokens_in": 86598,
+        "tokens_out": 12169,
         "estimated_cost_usd": 0.0,
-        "latency_s_total": 315.4464211463928,
+        "latency_s_total": 363.64089608192444,
         "latency_p50_s": 0.0,
-        "latency_p95_s": 5.550071442127229
+        "latency_p95_s": 6.248898148536683
       },
       "comparison": {
         "accuracy_delta_kora_minus_direct": 0.011538461538461497,
-        "llm_calls_saved": 253,
-        "llm_calls_saved_pct": 0.7666666666666667,
-        "tokens_in_saved": 278832,
-        "tokens_out_saved": 13359,
+        "llm_calls_saved": 251,
+        "llm_calls_saved_pct": 0.7606060606060606,
+        "tokens_in_saved": 276615,
+        "tokens_out_saved": 12870,
         "cost_saved_usd": 0.0,
-        "latency_s_saved": 582.3074159622192
+        "latency_s_saved": 656.220999956131
       },
       "consistency_direct": {
         "k": 1,
@@ -160,7 +147,7 @@
           "gt_kind": "valid_invalid",
           "ground_truth": "invalid",
           "verdict": "valid",
-          "answer": "Yes, 'user@example.com' is a properly formatted email address.",
+          "answer": "Yes, \"user@example.com\" is a valid email address format.",
           "llm_called": true,
           "handler": null,
           "text": "Is this a valid email address: user@example.com.",
@@ -172,7 +159,7 @@
           "gt_kind": "eligibility",
           "ground_truth": "ineligible",
           "verdict": "eligible",
-          "answer": "The warranty claim is covered. Appliances carry a 24-month manufacturer warranty, and your claim is for a manufacturing defect at 25 months \u2014 wait, let me re-evaluate: 25 months exceeds the 24-month w",
+          "answer": "The warranty claim is covered. Appliances carry a 24-month manufacturer warranty, and your claim is for a manufacturing defect at 25 months \u2014 wait, let me re-check: 25 months exceeds the 24-month warr",
           "llm_called": true,
           "handler": null,
           "text": "Determine whether this warranty claim is covered.",
@@ -188,7 +175,7 @@
           "gt_kind": "eligibility",
           "ground_truth": "eligible",
           "verdict": "ineligible",
-          "answer": "Unfortunately this warranty claim is not covered. Accessories carry only a 6-month warranty, but your purchase was 5 months ago \u2014 wait, that's within 6 months. Let me re-evaluate: 5 months \u2264 6 months,",
+          "answer": "This warranty claim is not covered. Accessories carry only a 6-month warranty, but your claim is at 5 months \u2014 wait, that's within range. However, let me re-evaluate: the warranty period for accessori",
           "llm_called": true,
           "handler": null,
           "text": "Determine whether this warranty claim is covered.",
@@ -229,11 +216,11 @@
         "deterministic_answers": 0,
         "deflection_rate": 0.0,
         "tokens_in": 59943,
-        "tokens_out": 27402,
+        "tokens_out": 27487,
         "estimated_cost_usd": 0.0,
-        "latency_s_total": 963.5918209552765,
-        "latency_p50_s": 2.568184494972229,
-        "latency_p95_s": 5.4408120036125185
+        "latency_s_total": 1089.0044581890106,
+        "latency_p50_s": 2.955274224281311,
+        "latency_p95_s": 6.0548428177833555
       },
       "kora": {
         "arm": "kora",
@@ -258,24 +245,24 @@
             "accuracy": 1.0
           }
         },
-        "llm_calls": 77,
-        "deterministic_answers": 253,
-        "deflection_rate": 0.7666666666666667,
-        "tokens_in": 13618,
-        "tokens_out": 10495,
+        "llm_calls": 79,
+        "deterministic_answers": 251,
+        "deflection_rate": 0.7606060606060606,
+        "tokens_in": 13997,
+        "tokens_out": 10918,
         "estimated_cost_usd": 0.0,
-        "latency_s_total": 312.2474009990692,
+        "latency_s_total": 356.816659450531,
         "latency_p50_s": 0.0,
-        "latency_p95_s": 5.41948037147522
+        "latency_p95_s": 5.991264367103578
       },
       "comparison": {
         "accuracy_delta_kora_minus_direct": 0.22307692307692317,
-        "llm_calls_saved": 253,
-        "llm_calls_saved_pct": 0.7666666666666667,
-        "tokens_in_saved": 46325,
-        "tokens_out_saved": 16907,
+        "llm_calls_saved": 251,
+        "llm_calls_saved_pct": 0.7606060606060606,
+        "tokens_in_saved": 45946,
+        "tokens_out_saved": 16569,
         "cost_saved_usd": 0.0,
-        "latency_s_saved": 651.3444199562073
+        "latency_s_saved": 732.1877987384796
       },
       "consistency_direct": {
         "k": 1,
@@ -318,7 +305,7 @@
             "friday"
           ],
           "verdict": null,
-          "answer": "I'm sorry, I don't have specific information about Northwind Goods' business hours. I recommend checking the website or contacting the store directly for the most accurate and up-to-date hours of oper",
+          "answer": "I'm sorry, I don't have specific information about Northwind Goods' store hours. I recommend checking the official Northwind Goods website or contacting customer support directly for the most accurate",
           "llm_called": true,
           "handler": null,
           "text": "Until when are you open Monday through Friday?",
@@ -332,7 +319,7 @@
             "saturday"
           ],
           "verdict": null,
-          "answer": "I'm sorry, I don't have specific information about Northwind Goods' store hours. I'd recommend checking the official Northwind Goods website or contacting their customer support directly for the most ",
+          "answer": "I'm sorry, I don't have specific information about Northwind Goods' store hours. I recommend checking the official Northwind Goods website or contacting customer support directly to confirm Saturday h",
           "llm_called": true,
           "handler": null,
           "text": "Are you open on Saturdays, and until when?",
@@ -360,7 +347,7 @@
             "saturday"
           ],
           "verdict": null,
-          "answer": "I'm sorry, but I don't have specific information about Northwind Goods' physical location hours. I'd recommend checking the store's website or contacting customer support directly to confirm weekend a",
+          "answer": "I'm sorry, but I don't have specific information about Northwind Goods' physical store hours or whether we are open on weekends. I'd recommend checking our website or contacting us directly for the mo",
           "llm_called": true,
           "handler": null,
           "text": "Can I come by on a Saturday or Sunday?",
@@ -374,7 +361,7 @@
             "saturday"
           ],
           "verdict": null,
-          "answer": "Our customer support team is available 7 days a week, but I don't have specific store hours on hand. I'd recommend checking the Northwind Goods website or contacting us directly for the most accurate ",
+          "answer": "Our customer support team is available 7 days a week, including weekends, from 9:00 AM to 6:00 PM (Eastern Time). If you need assistance outside of those hours, you can also reach us via email and we'",
           "llm_called": true,
           "handler": null,
           "text": "What time do you close on the weekend?",
@@ -402,7 +389,7 @@
             "30"
           ],
           "verdict": null,
-          "answer": "Yes, at Northwind Goods you typically have 30 days from the date of purchase to return an item for a refund. The item must be in its original condition and packaging. If you have your order number han",
+          "answer": "Yes, at Northwind Goods you typically have 30 days from the date of purchase to return an item for a refund. The item should be in its original condition and packaging. If you have your order number h",
           "llm_called": true,
           "handler": null,
           "text": "Is there a deadline to return something for a refund?",
@@ -447,7 +434,7 @@
             "50"
           ],
           "verdict": null,
-          "answer": "At Northwind Goods, delivery charges depend on your order total and chosen shipping method. Generally, orders over a certain threshold qualify for free standard shipping, while smaller orders may incu",
+          "answer": "At Northwind Goods, delivery charges depend on your order total and chosen shipping method. Unfortunately, I don't have the specific current details of our shipping policy on hand. I'd recommend check",
           "llm_called": true,
           "handler": null,
           "text": "Is there a postage charge, or is delivery free?",
@@ -462,7 +449,7 @@
             "5"
           ],
           "verdict": null,
-          "answer": "Domestic orders at Northwind Goods typically arrive within 3\u20137 business days, depending on your location and the shipping method selected at checkout. For a more precise estimate, you can check your o",
+          "answer": "Domestic orders at Northwind Goods typically arrive within 3\u20137 business days, depending on your location and the shipping method selected at checkout. You can check the exact estimated delivery date b",
           "llm_called": true,
           "handler": null,
           "text": "How many days until my domestic order arrives?",
@@ -492,7 +479,7 @@
             "5"
           ],
           "verdict": null,
-          "answer": "Domestic orders at Northwind Goods typically ship within 1-3 business days after your order is placed. Once shipped, standard delivery usually takes 5-7 business days, while expedited options (if sele",
+          "answer": "Domestic orders at Northwind Goods typically ship within 1-3 business days after your order is placed. Once shipped, standard domestic delivery usually takes 5-7 business days, while expedited options",
           "llm_called": true,
           "handler": null,
           "text": "When will my order ship and get here domestically?",
@@ -566,7 +553,7 @@
             "support@northwindgoods.example"
           ],
           "verdict": null,
-          "answer": "You can contact Northwind Goods support at support@northwindgoods.com. Our team is happy to help with any questions or concerns you may have!",
+          "answer": "You can contact Northwind Goods support at support@northwindgoods.com. Our team is happy to assist you with any questions or concerns!",
           "llm_called": true,
           "handler": null,
           "text": "What email address can I use to contact support?",
@@ -594,7 +581,7 @@
             "support@northwindgoods.example"
           ],
           "verdict": null,
-          "answer": "I'm sorry, I don't have the specific customer support email address for Northwind Goods readily available. I recommend visiting the official Northwind Goods website and navigating to the 'Contact Us' ",
+          "answer": "I'm sorry, I don't have the specific customer support email address for Northwind Goods on hand. I recommend visiting the official Northwind Goods website and navigating to the 'Contact Us' page to fi",
           "llm_called": true,
           "handler": null,
           "text": "What is your customer support e-mail address?",
@@ -622,7 +609,7 @@
             "555-0100"
           ],
           "verdict": null,
-          "answer": "I'm sorry, I don't have specific contact details for Northwind Goods support readily available. I'd recommend visiting the Northwind Goods website and navigating to the 'Contact Us' page to find the o",
+          "answer": "I'm sorry, I don't have specific contact details for Northwind Goods support readily available. I'd recommend visiting the Northwind Goods website and checking the 'Contact Us' page for the most up-to",
           "llm_called": true,
           "handler": null,
           "text": "What number do I call for support?",
@@ -650,7 +637,7 @@
             "555-0100"
           ],
           "verdict": null,
-          "answer": "I'm sorry, I don't have specific contact details for Northwind Goods' support telephone number available to me right now. I'd recommend visiting the Northwind Goods website and checking the 'Contact U",
+          "answer": "I'm sorry, but I don't have specific contact details for Northwind Goods' support telephone number available to me right now. I'd recommend visiting the Northwind Goods website and checking the 'Conta",
           "llm_called": true,
           "handler": null,
           "text": "Is there a support telephone number I can call?",
@@ -737,7 +724,7 @@
             "100"
           ],
           "verdict": null,
-          "answer": "{\"verdict\": null, \"answer\": \"Our loyalty points program lets you earn points on every purchase at Northwind Goods. Here's how it generally works:\\n\\n1. **Earning Points**: You earn points for every do",
+          "answer": "Our loyalty points program lets you earn points on every purchase at Northwind Goods. Here's how it generally works:\n\n1. **Earning Points**: You earn points for every dollar spent. For example, you mi",
           "llm_called": true,
           "handler": null,
           "text": "Can you explain how your loyalty points program works?",
@@ -751,7 +738,7 @@
             "100"
           ],
           "verdict": null,
-          "answer": "Great question! At Northwind Goods, our rewards program lets you earn points on every purchase. However, I don't have the specific details of our current points program readily available. I'd recommen",
+          "answer": "Great question! However, I don't have specific details about your account or our current loyalty/rewards program points structure in front of me. I'd recommend:\n\n1. **Checking your account dashboard**",
           "llm_called": true,
           "handler": null,
           "text": "How many points do I get and what are they worth?",
@@ -793,7 +780,7 @@
             "security"
           ],
           "verdict": null,
-          "answer": "To reset your password, go to the Northwind Goods login page and click 'Forgot Password.' Enter your registered email address, and we'll send you a password reset link. Follow the instructions in the ",
+          "answer": "To reset your password, follow these steps:\n1. Go to the Northwind Goods login page.\n2. Click on 'Forgot Password?' below the login form.\n3. Enter the email address associated with your account.\n4. Ch",
           "llm_called": true,
           "handler": null,
           "text": "I forgot my password \u2014 how do I change it?",
@@ -835,7 +822,7 @@
             "orders"
           ],
           "verdict": null,
-          "answer": "To track your order at Northwind Goods, you can: \n1. Visit our website and log into your account, then go to 'Order History' to view your order status.\n2. Use the tracking number provided in your ship",
+          "answer": "To track your order at Northwind Goods, you can: \n1. **Visit our website** and log into your account, then go to 'My Orders' to see the status of your order.\n2. **Use the tracking number** provided in",
           "llm_called": true,
           "handler": null,
           "text": "How do I track my order?",
@@ -905,7 +892,7 @@
             "columbus"
           ],
           "verdict": null,
-          "answer": "To get the correct return address for Northwind Goods, please contact our customer support team directly, as return addresses may vary depending on your location, the item being returned, or the reaso",
+          "answer": "To get the correct return address for Northwind Goods, please contact our customer support team directly, as return addresses can vary depending on your location and the type of item being returned. Y",
           "llm_called": true,
           "handler": null,
           "text": "What address do I send returned items to?",
@@ -961,7 +948,7 @@
           "gt_kind": "eligibility",
           "ground_truth": "eligible",
           "verdict": "ineligible",
-          "answer": "This order is not eligible for a refund. Our standard return window is 30 days, but for opened books, refunds are generally not accepted unless the item is defective or damaged. Since the book has bee",
+          "answer": "This order is not eligible for a refund. Our standard return window is 30 days, but for books, opened items cannot be returned. Since the book has been opened, it does not qualify for a refund.",
           "llm_called": true,
           "handler": null,
           "text": "Determine refund eligibility for this order.",
@@ -1009,7 +996,7 @@
           "gt_kind": "eligibility",
           "ground_truth": "eligible",
           "verdict": "ineligible",
-          "answer": "This order does not qualify for free shipping. While a Plus membership provides shipping benefits, orders to remote destination zones typically require a higher minimum order total than $10 to qualify",
+          "answer": "This order does not qualify for free shipping. While a Plus membership provides shipping benefits, orders to remote destination zones typically require a higher minimum order total than the standard t",
           "llm_called": true,
           "handler": null,
           "text": "Determine whether this order qualifies for free shipping.",
@@ -1041,7 +1028,7 @@
           "gt_kind": "eligibility",
           "ground_truth": "ineligible",
           "verdict": "eligible",
-          "answer": "The WELCOME10 coupon is valid for your account. Since you are a new customer (account age of 15 days) with no prior orders, you qualify for the WELCOME10 welcome discount. You can apply it at checkout",
+          "answer": "The WELCOME10 coupon is valid for your account. Since you are a new customer with an account less than 30 days old and no prior orders, you qualify for the WELCOME10 welcome discount. You can apply it",
           "llm_called": true,
           "handler": null,
           "text": "Determine whether the WELCOME10 coupon is valid here.",
@@ -1121,7 +1108,7 @@
           "gt_kind": "eligibility",
           "ground_truth": "ineligible",
           "verdict": "eligible",
-          "answer": "Your warranty claim is covered. Northwind Goods covers manufacturing defects on accessories within the standard 12-month warranty period, and your purchase was only 7 months ago. Please proceed with y",
+          "answer": "The warranty claim is covered. Northwind Goods covers manufacturing defects on accessories within the standard 12-month warranty period, and your claim falls within that window at 7 months since purch",
           "llm_called": true,
           "handler": null,
           "text": "Determine whether this warranty claim is covered.",
@@ -1153,7 +1140,7 @@
           "gt_kind": "eligibility",
           "ground_truth": "ineligible",
           "verdict": "eligible",
-          "answer": "The return meets our criteria: the reason is 'changed mind' (an accepted return reason) and the item was delivered only 5 days ago, which is within our standard 30-day return window. A free prepaid re",
+          "answer": "The return meets our criteria: the reason is 'changed mind' (a standard return reason) and the item was delivered only 5 days ago, which is within our 30-day return window. A free prepaid return label",
           "llm_called": true,
           "handler": null,
           "text": "Determine free prepaid return-label eligibility.",
@@ -1187,7 +1174,7 @@
             "saturday"
           ],
           "verdict": null,
-          "answer": "I'm sorry, but I don't have specific information about Northwind Goods' physical location hours. I'd recommend checking the store's website or contacting customer support directly to confirm weekend a",
+          "answer": "I'm sorry, but I don't have specific information about Northwind Goods' physical store hours or whether we are open on weekends. I'd recommend checking our website or contacting us directly for the mo",
           "llm_called": true,
           "handler": null,
           "text": "Can I come by on a Saturday or Sunday?",

--- a/experiments/kora_target_workload/results/robustness/ROBUSTNESS.md
+++ b/experiments/kora_target_workload/results/robustness/ROBUSTNESS.md
@@ -59,18 +59,18 @@ abstains (`not routed`). Flips are bucketed as:
 
 ## Results
 
-Original workload (full, 330 cases): deflection **0.767**, precision **0.883**,
-recall **0.971** (tp=68 fp=9 tn=251 fn=2). This matches the committed
+Original workload (full, 330 cases): deflection **0.761**, precision **0.886**,
+recall **1.000** (tp=70 fp=9 tn=251 fn=0). This matches the committed
 `results/routing_only.json`, confirming the harness shares the production
 routing path.
 
 | transform | deflection | precision | recall | **dangerous** | benign | other |
 |-----------|-----------:|----------:|-------:|--------------:|-------:|------:|
-| `whitespace`    | 0.388 | 0.337 | 0.971 | **0** | 126 | 1 |
-| `punct`         | 0.770 | 0.895 | 0.971 | **0** |   0 | 1 |
-| `case`          | 0.767 | 0.883 | 0.971 | **0** |   0 | 0 |
-| `polite_prefix` | 0.409 | 0.349 | 0.971 | **0** | 118 | 0 |
-| `synonym`       | 0.348 | 0.321 | 0.986 | **0** | 137 | 1 |
+| `whitespace`    | 0.382 | 0.343 | 1.000 | **0** | 126 | 1 |
+| `punct`         | 0.764 | 0.897 | 1.000 | **0** |   0 | 1 |
+| `case`          | 0.761 | 0.886 | 1.000 | **0** |   0 | 0 |
+| `polite_prefix` | 0.403 | 0.355 | 1.000 | **0** | 118 | 0 |
+| `synonym`       | 0.345 | 0.324 | 1.000 | **0** | 137 | 0 |
 
 **Dangerous flips: 0 across all transforms.** No should-escalate case was ever
 paraphrased into a deflection.
@@ -118,45 +118,36 @@ internally).
    without touching the safety guarantee, since all FORMAT flips are benign.
 
 3. **Lower deflection here is a cost signal, not a safety signal.** The drop from
-   0.767 to ~0.39 under disruptive transforms means more queries reach the LLM —
+   0.761 to ~0.38 under disruptive transforms means more queries reach the LLM;
    it does not mean any query was mishandled.
 
 ---
 
-## Honest limitations
+## Over-routing cases (resolved by guardrail)
 
-Two original false-negatives (should_escalate cases that the front door already
-routed *before* any paraphrase) surfaced during this experiment. They are
-pre-existing, not caused by the transforms, and are retained here as honest
-limitations of the current workload + reference evaluator.
+Two cases that a `should_escalate` query routed *before* any paraphrase surfaced
+in the original version of this experiment: `rea-030` and `trp-030`. Under the
+frozen rules they were false-negatives (fn=2, recall 0.971). A versioned
+guardrail change (input range-check + FAQ-signal fix; see `results/REPORT.md`
+§5c-guardrail) now escalates both, which is why this run shows **fn=0, recall
+1.000**. They are documented below as the failure mode the guardrail closes.
 
 - **`rea-030` (reasoning, no payload).** Text: *"I got a damaged item as a gift
-  but I don't have the order number. Can you still help?"* A single KB signal
-  matches `faq:support_phone`, so the front door deflects and returns the support
-  phone number for a query that should have escalated. A genuine over-route; the
-  answer is an innocuous fallback, but the routing decision is wrong.
+  but I don't have the order number. Can you still help?"* Under the frozen rules
+  a single KB signal matched `faq:support_phone`, so the front door deflected and
+  returned the support phone number for a query that should escalate. The guard
+  dropped `"number"` from the `support_phone` signal, so the case now abstains and
+  escalates.
 
 - **`trp-030` (trap, payload present).** Text: *"Determine refund eligibility."*
   with `payload={"days_since_delivery": -5, "item_category": "books",
-  "opened": false}`. The refund evaluator's `_as_int` checks type but not range,
-  so a physically impossible negative delivery age passes validation and the
-  policy returns "eligible". The trap was designed to probe exactly this input
-  hole; the shared evaluator (used by both `generate.py` for ground truth and the
-  dispatcher for routing) does not reject out-of-range integers, so the front door
-  routes instead of abstaining. This is an input-validation gap in the reference
-  evaluator, reported but not patched here to keep the committed routing numbers
-  and ground-truth generation stable. Adding a range check would convert this
-  fn into an abstain (recall would rise) and is tracked as separate future work.
-
-> **Update.** Both `rea-030` and `trp-030` were subsequently resolved by a
-> versioned guardrail change (input range-check + FAQ-signal fix); see
-> `results/REPORT.md` §5c-guardrail. This robustness run predates that change
-> and reflects the frozen rules (recall 0.971, fn=2).
-
-Notably, the `synonym` transform incidentally *fixes* `trp-030` (it strips the
-`refund`/`eligible` keywords, so the front door abstains), which is why
-`synonym` recall is 0.986 vs 0.971 elsewhere. We report this as an artifact, not
-as a robustness benefit.
+  "opened": false}`. The refund evaluator's `_as_int` checked type but not range,
+  so a physically impossible negative delivery age passed validation and the
+  policy returned "eligible". The trap was designed to probe exactly this input
+  hole. The guard now range-checks elapsed-time fields, so the malformed payload
+  abstains and the case escalates. The range check lives in the shared evaluator
+  used by both `generate.py` (ground truth) and the dispatcher (routing), so it is
+  applied consistently.
 
 ---
 

--- a/experiments/kora_target_workload/results/robustness/robustness.json
+++ b/experiments/kora_target_workload/results/robustness/robustness.json
@@ -3,27 +3,27 @@
   "n_cases": 330,
   "original": {
     "n": 330,
-    "routed": 253,
-    "deflection_rate": 0.7666666666666667,
-    "tp": 68,
+    "routed": 251,
+    "deflection_rate": 0.7606060606060606,
+    "tp": 70,
     "fp": 9,
     "tn": 251,
-    "fn": 2,
-    "precision": 0.8831168831168831,
-    "recall": 0.9714285714285714
+    "fn": 0,
+    "precision": 0.8860759493670886,
+    "recall": 1.0
   },
   "variants": {
     "whitespace": {
       "metrics": {
         "n": 330,
-        "routed": 128,
-        "deflection_rate": 0.3878787878787879,
-        "tp": 68,
+        "routed": 126,
+        "deflection_rate": 0.38181818181818183,
+        "tp": 70,
         "fp": 134,
         "tn": 126,
-        "fn": 2,
-        "precision": 0.33663366336633666,
-        "recall": 0.9714285714285714
+        "fn": 0,
+        "precision": 0.3431372549019608,
+        "recall": 1.0
       },
       "n_dangerous": 0,
       "n_benign": 126,
@@ -1055,14 +1055,14 @@
     "punct": {
       "metrics": {
         "n": 330,
-        "routed": 254,
-        "deflection_rate": 0.7696969696969697,
-        "tp": 68,
+        "routed": 252,
+        "deflection_rate": 0.7636363636363637,
+        "tp": 70,
         "fp": 8,
         "tn": 252,
-        "fn": 2,
-        "precision": 0.8947368421052632,
-        "recall": 0.9714285714285714
+        "fn": 0,
+        "precision": 0.8974358974358975,
+        "recall": 1.0
       },
       "n_dangerous": 0,
       "n_benign": 0,
@@ -1085,14 +1085,14 @@
     "case": {
       "metrics": {
         "n": 330,
-        "routed": 253,
-        "deflection_rate": 0.7666666666666667,
-        "tp": 68,
+        "routed": 251,
+        "deflection_rate": 0.7606060606060606,
+        "tp": 70,
         "fp": 9,
         "tn": 251,
-        "fn": 2,
-        "precision": 0.8831168831168831,
-        "recall": 0.9714285714285714
+        "fn": 0,
+        "precision": 0.8860759493670886,
+        "recall": 1.0
       },
       "n_dangerous": 0,
       "n_benign": 0,
@@ -1106,14 +1106,14 @@
     "polite_prefix": {
       "metrics": {
         "n": 330,
-        "routed": 135,
-        "deflection_rate": 0.4090909090909091,
-        "tp": 68,
+        "routed": 133,
+        "deflection_rate": 0.403030303030303,
+        "tp": 70,
         "fp": 127,
         "tn": 133,
-        "fn": 2,
-        "precision": 0.3487179487179487,
-        "recall": 0.9714285714285714
+        "fn": 0,
+        "precision": 0.3553299492385787,
+        "recall": 1.0
       },
       "n_dangerous": 0,
       "n_benign": 118,
@@ -2072,18 +2072,18 @@
     "synonym": {
       "metrics": {
         "n": 330,
-        "routed": 115,
-        "deflection_rate": 0.3484848484848485,
-        "tp": 69,
+        "routed": 114,
+        "deflection_rate": 0.34545454545454546,
+        "tp": 70,
         "fp": 146,
         "tn": 114,
-        "fn": 1,
-        "precision": 0.3209302325581395,
-        "recall": 0.9857142857142858
+        "fn": 0,
+        "precision": 0.32407407407407407,
+        "recall": 1.0
       },
       "n_dangerous": 0,
       "n_benign": 137,
-      "n_other": 1,
+      "n_other": 0,
       "flips": {
         "dangerous": [],
         "benign": [
@@ -3184,16 +3184,7 @@
             "text": "Determine refund eligibility for this order."
           }
         ],
-        "other": [
-          {
-            "id": "trp-030",
-            "category": "trap",
-            "should_escalate": true,
-            "orig": "deflect",
-            "variant": "escalate",
-            "text": "Determine refund eligibility."
-          }
-        ]
+        "other": []
       }
     }
   }

--- a/experiments/kora_target_workload/results/routing_only.json
+++ b/experiments/kora_target_workload/results/routing_only.json
@@ -11,12 +11,12 @@
   },
   "routing": {
     "positive_class": "should_escalate",
-    "tp": 68,
+    "tp": 70,
     "fp": 9,
     "tn": 251,
-    "fn": 2,
-    "precision": 0.8831168831168831,
-    "recall": 0.9714285714285714,
+    "fn": 0,
+    "precision": 0.8860759493670886,
+    "recall": 1.0,
     "by_category": {
       "format": {
         "n": 120,
@@ -35,28 +35,15 @@
       },
       "reasoning": {
         "n": 40,
-        "routed": 1,
-        "abstain": 39
+        "routed": 0,
+        "abstain": 40
       },
       "trap": {
         "n": 30,
-        "routed": 1,
-        "abstain": 29
+        "routed": 0,
+        "abstain": 30
       }
     },
-    "over_routed_cases": [
-      {
-        "id": "rea-030",
-        "category": "reasoning",
-        "handler": "faq:support_phone",
-        "answer": "Our support line is +1-800-555-0100."
-      },
-      {
-        "id": "trp-030",
-        "category": "trap",
-        "handler": "policy:refund_eligibility",
-        "answer": "eligible"
-      }
-    ]
+    "over_routed_cases": []
   }
 }


### PR DESCRIPTION
## Summary

The committed target-workload results predated the over-routing guardrail, so the routing numbers in the data files and the docs no longer matched the current dispatcher. This branch regenerates the data and aligns the narrative so both reflect the current code.

## Canonical routing result (current dispatcher)

- deflection 76.06% (251/330); LLM calls 330 -> 79
- precision 0.886, recall 1.000
- confusion: tp=70, fp=9, tn=251, fn=0 (0 over-routed)

The two previously over-routed cases (rea-030, trp-030) are escalated by a versioned guardrail, so recall is 1.000 and fn=0. Accuracy is unaffected: those two cases are non-scorable (reasoning/trap), so they do not enter the accuracy denominator (the 260 scorable format/faq/policy cases).

## Changes

- `results/routing_only.json`: regenerated from the current dispatcher.
- `results/full_*.json` (5 models): re-run on AWS Bedrock so each embedded routing block matches the canonical result. Accuracy is re-measured; the model-diversity accuracy tables in the README and `SUMMARY_model_diversity.md` are updated to match.
- `results/robustness/{ROBUSTNESS.md,robustness.json}`: re-run (zero LLM calls); baseline matches `routing_only.json`, all transforms reach recall 1.000, and there are 0 dangerous flips.
- Docs (root `README.md`, target-workload `README.md`, `MULTI_DATASET.md`, `SUMMARY_model_diversity.md`, `reproduce.sh`): routing numbers updated to the canonical values; the cross-dataset ~20-24% claim is scoped as the conservative two-domain intent band.

## Intentional residual references

Two places still show the older 76.7% / 0.883 / 0.971 numbers on purpose:

1. `results/REPORT.md` sections 1-2 / 5a-5b / 7 are a dated single-run measurement (Qwen, frozen rules). Its `5c-guardrail` subsection reports the canonical after-state side by side (recall 0.971 -> 1.000, precision 0.883 -> 0.886, deflection 0.767 -> 0.761). The measured numbers are left as recorded rather than overwritten.
2. `results/robustness/ROBUSTNESS.md` keeps one "under the frozen rules (fn=2, recall 0.971)" reference as historical context for what the guardrail fixed.

## Reproduce

Routing and deflection are deterministic (dispatcher only) and reproduce with no API key and no GPU:

```
python run.py --routing-only --workload workloads/full.json --out /tmp/routing.json
# -> precision=0.886 recall=1.000  (deflection 76.06%)
```
