### PR TITLE
Unblock offline reproduction on Python 3.10

### DIFF
--- a/experiments/kora_target_workload/README.md
+++ b/experiments/kora_target_workload/README.md
@@ -68,10 +68,11 @@ This is the heart of KORA's claim, and it is fully reproducible offline.
 ## Reproduce
 
 ```bash
-# From this directory. Requires Python 3.10+ and pyyaml.
-pip install pyyaml
-# For workload regeneration, pin the validators used to build it:
-#   pip install email_validator==2.3.0 phonenumbers==9.0.33   (Python 3.10)
+# From this directory. Requires Python 3.10+.
+# The deterministic dispatcher validates emails and phone numbers with the same
+# libraries that built the workload, so routing-only needs them too (pinned to the
+# versions in the workload's `generated_with` field for byte-identical verdicts):
+pip install pyyaml email_validator==2.3.0 phonenumbers==9.0.33
 
 # (1) Routing only — no LLM, no key, no GPU. Reproduces deflection/precision/recall.
 python run.py --routing-only --workload workloads/full.json --out /tmp/routing.json

--- a/experiments/kora_target_workload/run.py
+++ b/experiments/kora_target_workload/run.py
@@ -43,7 +43,9 @@ HERE = Path(__file__).resolve().parent
 sys.path.insert(0, str(HERE))
 
 import yaml  # noqa: E402
-from openai import OpenAI  # noqa: E402
+# `openai` is imported lazily, only when an OpenAI/vLLM client is actually
+# constructed (see main()). The --routing-only path and the bedrock backend make
+# no OpenAI calls, so they must not require the `openai` package to be installed.
 from bedrock_client import BedrockClient  # noqa: E402
 
 from kora import dispatcher  # noqa: E402
@@ -501,6 +503,7 @@ def main() -> None:
     if args.backend == "bedrock":
         client = BedrockClient(region=args.region)
     else:
+        from openai import OpenAI  # lazy: only the vLLM/OpenAI backend needs it
         client = OpenAI(base_url=args.base_url, api_key=os.getenv("VLLM_API_KEY", "EMPTY"))
     llm = LLM(client, args.model)
     # Fixed judge: when --judge-model is set, use a separate grader LLM (same across all arms); otherwise reuse the served llm.
@@ -508,6 +511,7 @@ def main() -> None:
         if args.backend == "bedrock":
             judge_client = BedrockClient(region=args.region)
         else:
+            from openai import OpenAI  # lazy: only the vLLM/OpenAI backend needs it
             judge_client = OpenAI(base_url=args.base_url, api_key=os.getenv("VLLM_API_KEY", "EMPTY"))
         judge_llm = LLM(judge_client, args.judge_model)
     else:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "kora"
 version = "0.1.0a0"
 description = "Open-source execution control for AI systems"
 readme = "README.md"
-requires-python = ">=3.11"
+requires-python = ">=3.10"
 license = { text = "Apache-2.0" }
 authors = [
   { name = "hkalbertkim" },
@@ -21,6 +21,7 @@ classifiers = [
   "Intended Audience :: Developers",
   "License :: OSI Approved :: Apache Software License",
   "Programming Language :: Python :: 3",
+  "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Topic :: Scientific/Engineering :: Artificial Intelligence",
   "Topic :: Software Development :: Libraries :: Python Modules",


### PR DESCRIPTION
## Summary

A clean-clone walkthrough of the offline reproduction path hit three blockers before any benchmark could run. This branch fixes all three so a new user on Python 3.10 can `pip install -e .` and run the credential-free routing reproduction by following the docs.

## Fixes

- **F1: Python version.** `pyproject.toml` required `>=3.11`, which blocks `pip install -e .` on Python 3.10 (the default on Ubuntu 22.04). The package and all Quick Start examples run on 3.10, and the target-workload's frozen provenance records `python 3.10.12`. Relaxed `requires-python` to `>=3.10` and added the 3.10 classifier.

- **F2: openai import.** `experiments/kora_target_workload/run.py` imported `openai` at module top, so `--routing-only` (documented as zero LLM calls, no key) crashed with `ModuleNotFoundError: No module named 'openai'`. The import is now lazy, done only where an OpenAI/vLLM client is constructed. The routing-only path and the Bedrock backend no longer require the `openai` package.

- **F3: routing-only dependencies.** The routing-only reproduce step listed only `pyyaml`, but the deterministic dispatcher validates emails and phone numbers with `email_validator` and `phonenumbers`. The experiment README now lists them (pinned to the versions in the workload's `generated_with` field) in the routing-only step.

## Verification

- `pip install -e .` succeeds on Python 3.10; `kora doctor`, `proxy-demo`, and `cache_reuse` run.
- `python run.py --routing-only --workload workloads/full.json` runs with only `pyyaml`, `email_validator`, and `phonenumbers` installed (no `openai`).
- Target-workload tests pass.

## Notes

This branch changes packaging, one import, and reproduce-step dependencies only. No numeric result claims are changed.
