### PR TITLE
Task 018: Add Solution Protocol v0 foundation

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Most AI systems treat every task as a model task. KORA starts one step earlier: 
 - Mark provider-needed tasks explicitly.
 - Inspect privacy-safe local device and runtime-candidate metadata.
 - Run optional local execution paths through explicitly configured MLX or llama.cpp runtimes.
+- Validate independently packaged AI Solutions before installation or execution.
 - Build and query a deterministic local evidence index from text-layer PDFs.
 
 ## Quick Start
@@ -45,6 +46,16 @@ Inspect the local system without starting a runtime or calling a provider:
 python3 -m kora system inventory
 ```
 
+### Solution Protocol v0alpha1
+
+Validate the bundled reference Solution without executing it:
+
+```bash
+python3 -m kora solution validate examples/solutions/hello-solution --json
+```
+
+The validator checks the manifest, referenced JSON Schemas, Task Graph, capability declarations, approvals, package paths, and SHA-256 integrity offline. See [Solution Protocol v0alpha1](docs/solution-protocol-v0.md). Host lifecycle and Solution execution are later milestones.
+
 ### Research Foundry Alpha
 
 Install the optional PDF dependency, ingest your own or public text-layer PDFs, and retrieve an evidence card:
@@ -55,7 +66,7 @@ python3 -m kora research ingest ./papers --state-dir ./.kora-research --json
 python3 -m kora research query ./.kora-research "reflection tokens" --top-k 3 --markdown
 ```
 
-The output is deterministic retrieved evidence—not model-generated synthesis. Each result includes a source title, page, stable chunk/evidence ID, and verbatim retrieved excerpt. State remains in the directory you explicitly select. See [Research Foundry Alpha](docs/research-foundry-alpha.md) for its Local Only boundary and limitations.
+Research Foundry is an implemented reference vertical, not the definition of the KORA platform. Its output is deterministic retrieved evidence—not model-generated synthesis. Each result includes a source title, page, stable chunk/evidence ID, and verbatim retrieved excerpt. State remains in the directory you explicitly select. See [Research Foundry Alpha](docs/research-foundry-alpha.md) for its Local Only boundary and limitations.
 
 ### Optional local runtime adapters
 
@@ -116,6 +127,7 @@ See the [claim registry](docs/claims/kora-claim-registry.md) and [public languag
 ## Documentation
 
 - [Documentation index](docs/README.md)
+- [Solution Protocol v0alpha1](docs/solution-protocol-v0.md)
 - [Vision: AI Workload Control Layer](docs/vision/kora_workload_control_layer.md)
 - [Example catalog](examples/README.md)
 - [Packaging: getkora strategy](docs/packaging/getkora_distribution_strategy.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -11,6 +11,7 @@ This documentation index is for readers who want more detail than the root [READ
 - [Example catalog](../examples/README.md) - runnable examples grouped by use case.
 - [Packaging: getkora strategy](packaging/getkora_distribution_strategy.md) - package-name and install-path status.
 - [Research Foundry Alpha](research-foundry-alpha.md) - Local Only text-layer PDF ingest, lexical retrieval, and deterministic evidence cards.
+- [Solution Protocol v0alpha1](solution-protocol-v0.md) - offline package manifest, capability, policy, graph, schema, and integrity validation contract.
 
 ## Flagship Examples
 

--- a/docs/solution-protocol-v0.md
+++ b/docs/solution-protocol-v0.md
@@ -1,0 +1,155 @@
+# KORA Solution Protocol v0alpha1
+
+Status: initial public architecture and validation contract.
+
+KORA Solution Protocol separates KORA's execution-control layer from independently developed AI services. A conforming Solution Package declares what it needs, what it may do, how its Task Graph is validated, and how its files are integrity-checked before execution.
+
+This initial slice is deliberately offline and fail-closed. It validates packages; it does not install or execute them.
+
+## Responsibilities
+
+KORA Core owns cross-solution execution intelligence:
+
+- deterministic-first and model-necessity decisions;
+- Task Graph semantics;
+- capability selection;
+- privacy, budget, approval, and side-effect policy;
+- cache/reuse decisions;
+- execution evidence and failure semantics.
+
+A KORA Host owns package discovery, validation, installation, lifecycle, status, and evidence surfaces.
+
+Capability Runtimes implement concrete deterministic tools, local models, provider adapters, and artifact operations.
+
+A Solution Package owns only its workflow-specific manifest, schemas, Task Graph, policy declaration, and implementation assets.
+
+A new Solution must not require workflow-specific KORA Core changes.
+
+## Package layout
+
+A v0alpha1 package uses JSON for its canonical signed and hashed representation:
+
+    example-solution/
+      solution.json
+      graph/
+        workflow.json
+      schemas/
+        input.schema.json
+        output.schema.json
+
+YAML authoring and canonical conversion may be added by the SDK later. JSON is the only canonical v0alpha1 validation format.
+
+## Manifest
+
+The manifest is solution.json and contains:
+
+- apiVersion: protocol compatibility identifier;
+- kind: Solution;
+- metadata: stable Solution id and semantic version;
+- requires: KORA version constraint and required capabilities;
+- inputs and outputs: JSON Schema files;
+- graph: Task Graph file;
+- policy: network, side effects, and approvals;
+- integrity: SHA-256 digests for every referenced package file.
+
+The machine-readable schema is packaged at kora/solution/schemas/solution-manifest.schema.json.
+
+## Compatibility
+
+The only supported initial apiVersion is kora.dev/v0alpha1.
+
+Unsupported versions fail before schema, graph, capability, or execution processing. Future major protocol changes may be incompatible. Additive evolution within the same compatibility line must preserve existing valid packages.
+
+The requires.kora field is recorded in this slice but full version-range resolution is deferred to the Host lifecycle milestone.
+
+## Capabilities
+
+Every deterministic handler or model adapter used by the Task Graph must appear in requires.capabilities.
+
+Validation fails when:
+
+- a graph uses an undeclared capability;
+- a declared capability is unavailable from the Host capability set.
+
+The initial offline reference capability set contains det.echo and text.normalize. A persistent capability registry is the next Host milestone.
+
+## Policy and approvals
+
+Task tags beginning with side_effect: declare effects used by the graph. Each effect must appear in policy.sideEffects and policy.approvals.
+
+Network is denied by default in the reference fixtures. When network is allowed, policy.approvals must include network.access.
+
+This intentionally conservative v0 rule will later evolve into typed approval scopes and lifecycle-bound grants.
+
+## Task Graph
+
+The protocol reuses KORA Task IR v0.1. Validation includes:
+
+- Pydantic structure validation;
+- unique task ids;
+- valid root;
+- known dependencies;
+- required verification schema for model tasks;
+- cycle rejection;
+- declared capability and side-effect checks.
+
+## Integrity
+
+solution.json is not self-hashed because that would create a circular digest. Every referenced graph and schema file must be listed in integrity.files.
+
+Validation rejects:
+
+- missing referenced files;
+- absolute paths or parent traversal;
+- symlinked validated files;
+- SHA-256 mismatch.
+
+The design follows the same content-addressed trust principle used by OCI descriptors: verify size and digest before consuming untrusted content. The initial KORA slice requires SHA-256.
+
+## CLI
+
+Validate the bundled reference Solution:
+
+    kora solution validate examples/solutions/hello-solution
+
+Structured output:
+
+    kora solution validate examples/solutions/hello-solution --json
+
+Override the available Host capability set for conformance testing:
+
+    kora solution validate examples/solutions/hello-solution --capability det.echo
+
+Validation performs no Solution execution, provider call, model inference, network request, or GPU work.
+
+## Current boundary
+
+Implemented in this slice:
+
+- strict manifest schema;
+- referenced JSON Schema checks;
+- Task Graph validation;
+- capability declaration and availability checks;
+- side-effect and approval checks;
+- path containment and symlink rejection;
+- SHA-256 verification;
+- structured CLI results;
+- positive and negative conformance tests.
+
+Deferred:
+
+- installation and removal;
+- persistent capability registry;
+- runtime handshake;
+- result/status envelopes;
+- stop/resume lifecycle;
+- cache execution;
+- package signing;
+- SDK scaffold and packaging;
+- registry/marketplace;
+- YAML authoring;
+- commercial Solution selection.
+
+## Alpha direction
+
+Protocol Alpha ultimately requires two different reference Solutions to install and run through the same contract without Core changes. hello-solution is the first validation fixture. document-transform-fixture, Host lifecycle, reference runtime, and full conformance execution follow in later bounded slices.

--- a/examples/solutions/hello-solution/graph/workflow.json
+++ b/examples/solutions/hello-solution/graph/workflow.json
@@ -1,0 +1,33 @@
+{
+  "graph_id": "example.hello",
+  "version": "0.1",
+  "root": "hello",
+  "defaults": {
+    "budget": {
+      "max_time_ms": 1000,
+      "max_tokens": 0,
+      "max_retries": 0
+    }
+  },
+  "tasks": [
+    {
+      "id": "hello",
+      "type": "deterministic",
+      "deps": [],
+      "in": {
+        "message": "$.message"
+      },
+      "run": {
+        "kind": "det",
+        "spec": {
+          "handler": "det.echo",
+          "args": {}
+        }
+      },
+      "policy": {
+        "on_fail": "fail"
+      },
+      "tags": []
+    }
+  ]
+}

--- a/examples/solutions/hello-solution/schemas/input.schema.json
+++ b/examples/solutions/hello-solution/schemas/input.schema.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["message"],
+  "properties": {
+    "message": {
+      "type": "string"
+    }
+  }
+}

--- a/examples/solutions/hello-solution/schemas/output.schema.json
+++ b/examples/solutions/hello-solution/schemas/output.schema.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["message"],
+  "properties": {
+    "message": {
+      "type": "string"
+    }
+  }
+}

--- a/examples/solutions/hello-solution/solution.json
+++ b/examples/solutions/hello-solution/solution.json
@@ -1,0 +1,36 @@
+{
+  "apiVersion": "kora.dev/v0alpha1",
+  "kind": "Solution",
+  "metadata": {
+    "id": "example.hello",
+    "version": "0.1.0"
+  },
+  "requires": {
+    "kora": ">=0.1.0a0,<0.2",
+    "capabilities": [
+      "det.echo"
+    ]
+  },
+  "inputs": {
+    "schema": "schemas/input.schema.json"
+  },
+  "graph": {
+    "source": "graph/workflow.json"
+  },
+  "outputs": {
+    "schema": "schemas/output.schema.json"
+  },
+  "policy": {
+    "network": "denied",
+    "sideEffects": [],
+    "approvals": []
+  },
+  "integrity": {
+    "algorithm": "sha256",
+    "files": {
+      "graph/workflow.json": "a5733a60449f726449d4ee72f9c8a893ac8b36defc69da5c7d8b299e354b5155",
+      "schemas/input.schema.json": "943d327c29d244f6626068d351f9b88a89b58197f30f2d32e80d3afac029bec2",
+      "schemas/output.schema.json": "943d327c29d244f6626068d351f9b88a89b58197f30f2d32e80d3afac029bec2"
+    }
+  }
+}

--- a/kora/cli.py
+++ b/kora/cli.py
@@ -38,6 +38,7 @@ from kora.openai_proxy_demo import (
     write_report as write_proxy_report,
 )
 from kora.research import ResearchFoundry, ResearchFoundryError, canonical_json, render_evidence_card_markdown
+from kora.solution import SolutionValidationError, validate_solution_package
 from kora.studio_server import (
     DEFAULT_STUDIO_HOST,
     DEFAULT_STUDIO_PORT,
@@ -433,6 +434,19 @@ def main(argv: list[str] | None = None) -> int:
     research_query.add_argument("--output", help="optional path to save the selected card format")
     research_query.add_argument("--run-json-out", help="optional path to save local query events and counters")
 
+    solution_parser = subparsers.add_parser(
+        "solution",
+        help="validate and manage KORA Solution Packages",
+    )
+    solution_subparsers = solution_parser.add_subparsers(dest="solution_command", required=True)
+    solution_validate = solution_subparsers.add_parser(
+        "validate",
+        help="validate a Solution Package offline without executing it",
+    )
+    solution_validate.add_argument("package", help="Solution Package directory containing solution.json")
+    solution_validate.add_argument("--capability", action="append", dest="capabilities")
+    solution_validate.add_argument("--json", action="store_true", help="print structured JSON")
+
     system_parser = subparsers.add_parser(
         "system",
         help="inspect local KORA Foundation system metadata",
@@ -545,6 +559,33 @@ def main(argv: list[str] | None = None) -> int:
         print(render_first_value_markdown(result))
         print(f"Saved JSON: {args.json_out}")
         print(f"Saved Markdown: {args.md_out}")
+        return 0
+
+    if args.command == "solution" and args.solution_command == "validate":
+        try:
+            result = validate_solution_package(
+                args.package,
+                available_capabilities=args.capabilities,
+            )
+        except SolutionValidationError as exc:
+            payload = exc.to_dict()
+            if args.json:
+                print(json.dumps(payload, indent=2, sort_keys=True), file=sys.stderr)
+            else:
+                print("Solution Package invalid", file=sys.stderr)
+                for issue in exc.issues:
+                    location = f" ({issue.path})" if issue.path else ""
+                    print(f"- {issue.code}{location}: {issue.message}", file=sys.stderr)
+            return 1
+        if args.json:
+            print(json.dumps(result, indent=2, sort_keys=True))
+        else:
+            print("Solution Package valid")
+            print(f"- id: {result['solution_id']}")
+            print(f"- version: {result['solution_version']}")
+            print(f"- apiVersion: {result['api_version']}")
+            print(f"- verified files: {len(result['verified_files'])}")
+            print("- execution performed: false")
         return 0
 
     if args.command == "research":

--- a/kora/solution/__init__.py
+++ b/kora/solution/__init__.py
@@ -1,0 +1,17 @@
+"""KORA Solution Protocol validation primitives."""
+
+from .validator import (
+    DEFAULT_REFERENCE_CAPABILITIES,
+    SUPPORTED_API_VERSION,
+    SolutionValidationError,
+    SolutionValidationIssue,
+    validate_solution_package,
+)
+
+__all__ = [
+    "DEFAULT_REFERENCE_CAPABILITIES",
+    "SUPPORTED_API_VERSION",
+    "SolutionValidationError",
+    "SolutionValidationIssue",
+    "validate_solution_package",
+]

--- a/kora/solution/schemas/solution-manifest.schema.json
+++ b/kora/solution/schemas/solution-manifest.schema.json
@@ -1,0 +1,141 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://kora.dev/schemas/solution-manifest-v0alpha1.json",
+  "title": "KORA Solution Manifest v0alpha1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "apiVersion",
+    "kind",
+    "metadata",
+    "requires",
+    "inputs",
+    "graph",
+    "outputs",
+    "policy",
+    "integrity"
+  ],
+  "properties": {
+    "apiVersion": {
+      "const": "kora.dev/v0alpha1"
+    },
+    "kind": {
+      "const": "Solution"
+    },
+    "metadata": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "version"],
+      "properties": {
+        "id": {
+          "type": "string",
+          "pattern": "^[a-z0-9]+(?:[._-][a-z0-9]+)*$",
+          "minLength": 3,
+          "maxLength": 128
+        },
+        "version": {
+          "type": "string",
+          "pattern": "^(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)(?:-[0-9A-Za-z.-]+)?$"
+        }
+      }
+    },
+    "requires": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["kora", "capabilities"],
+      "properties": {
+        "kora": {
+          "type": "string",
+          "minLength": 1
+        },
+        "capabilities": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "pattern": "^[a-z][a-z0-9]*(?:[._-][a-z0-9]+)+$"
+          },
+          "uniqueItems": true
+        }
+      }
+    },
+    "inputs": {
+      "$ref": "#/$defs/schemaReference"
+    },
+    "graph": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["source"],
+      "properties": {
+        "source": {
+          "$ref": "#/$defs/packagePath"
+        }
+      }
+    },
+    "outputs": {
+      "$ref": "#/$defs/schemaReference"
+    },
+    "policy": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["network", "sideEffects", "approvals"],
+      "properties": {
+        "network": {
+          "enum": ["denied", "allowed"]
+        },
+        "sideEffects": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "pattern": "^[a-z][a-z0-9]*(?:[._-][a-z0-9]+)+$"
+          },
+          "uniqueItems": true
+        },
+        "approvals": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "pattern": "^[a-z][a-z0-9]*(?:[._-][a-z0-9]+)+$"
+          },
+          "uniqueItems": true
+        }
+      }
+    },
+    "integrity": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["algorithm", "files"],
+      "properties": {
+        "algorithm": {
+          "const": "sha256"
+        },
+        "files": {
+          "type": "object",
+          "minProperties": 1,
+          "propertyNames": {
+            "$ref": "#/$defs/packagePath"
+          },
+          "additionalProperties": {
+            "type": "string",
+            "pattern": "^[a-f0-9]{64}$"
+          }
+        }
+      }
+    }
+  },
+  "$defs": {
+    "packagePath": {
+      "type": "string",
+      "pattern": "^(?!/)(?!.*(?:^|/)\\.\\.(?:/|$))[A-Za-z0-9._-]+(?:/[A-Za-z0-9._-]+)*$"
+    },
+    "schemaReference": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["schema"],
+      "properties": {
+        "schema": {
+          "$ref": "#/$defs/packagePath"
+        }
+      }
+    }
+  }
+}

--- a/kora/solution/validator.py
+++ b/kora/solution/validator.py
@@ -1,0 +1,328 @@
+"""Offline, fail-closed validation for KORA Solution Protocol v0 packages."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any, Iterable
+
+from jsonschema import Draft202012Validator
+from jsonschema.exceptions import SchemaError
+
+from kora.task_ir import TaskGraph, normalize_graph, validate_graph
+
+SUPPORTED_API_VERSION = "kora.dev/v0alpha1"
+DEFAULT_REFERENCE_CAPABILITIES = frozenset({"det.echo", "text.normalize"})
+MANIFEST_NAME = "solution.json"
+SCHEMA_NAME = "solution-manifest.schema.json"
+
+
+@dataclass(frozen=True, order=True)
+class SolutionValidationIssue:
+    """A stable, machine-readable package validation issue."""
+
+    code: str
+    message: str
+    path: str = ""
+
+    def to_dict(self) -> dict[str, str]:
+        return asdict(self)
+
+
+class SolutionValidationError(ValueError):
+    """Raised when a Solution Package fails one or more validation gates."""
+
+    def __init__(self, issues: Iterable[SolutionValidationIssue]):
+        ordered = tuple(sorted(issues))
+        if not ordered:
+            raise ValueError("SolutionValidationError requires at least one issue")
+        self.issues = ordered
+        super().__init__("; ".join(f"{issue.code}: {issue.message}" for issue in ordered))
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "status": "invalid",
+            "issues": [issue.to_dict() for issue in self.issues],
+        }
+
+
+def _issue(code: str, message: str, path: str = "") -> SolutionValidationError:
+    return SolutionValidationError([SolutionValidationIssue(code=code, message=message, path=path)])
+
+
+def _load_json(path: Path, *, code: str) -> Any:
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError as exc:
+        raise _issue(code, f"required file not found: {path.name}", str(path)) from exc
+    except IsADirectoryError as exc:
+        raise _issue(code, f"expected a file: {path.name}", str(path)) from exc
+    except UnicodeDecodeError as exc:
+        raise _issue(code, f"file is not valid UTF-8: {path.name}", str(path)) from exc
+    except json.JSONDecodeError as exc:
+        raise _issue(
+            code,
+            f"invalid JSON at line {exc.lineno}, column {exc.colno}: {exc.msg}",
+            str(path),
+        ) from exc
+
+
+def _resolve_package_file(root: Path, relative: str, *, code: str) -> Path:
+    rel_path = Path(relative)
+    if rel_path.is_absolute() or ".." in rel_path.parts:
+        raise _issue(code, f"path must stay within the package: {relative}", relative)
+
+    unresolved = root / rel_path
+    if unresolved.is_symlink():
+        raise _issue(code, f"symbolic links are not allowed in validated package files: {relative}", relative)
+
+    try:
+        resolved = unresolved.resolve(strict=True)
+    except FileNotFoundError as exc:
+        raise _issue(code, f"required package file not found: {relative}", relative) from exc
+
+    if not resolved.is_relative_to(root):
+        raise _issue(code, f"path resolves outside the package: {relative}", relative)
+    if not resolved.is_file():
+        raise _issue(code, f"expected a regular file: {relative}", relative)
+    return resolved
+
+
+def _manifest_schema() -> dict[str, Any]:
+    path = Path(__file__).with_name("schemas") / SCHEMA_NAME
+    payload = _load_json(path, code="internal_schema_error")
+    if not isinstance(payload, dict):
+        raise _issue("internal_schema_error", "bundled manifest schema must be a JSON object", str(path))
+    return payload
+
+
+def _validate_manifest_shape(manifest: Any) -> dict[str, Any]:
+    if not isinstance(manifest, dict):
+        raise _issue("manifest_schema_error", "solution.json must contain a JSON object", MANIFEST_NAME)
+
+    api_version = manifest.get("apiVersion")
+    if isinstance(api_version, str) and api_version != SUPPORTED_API_VERSION:
+        raise _issue(
+            "unsupported_protocol_version",
+            f"supported apiVersion is {SUPPORTED_API_VERSION}; received {api_version}",
+            "apiVersion",
+        )
+
+    validator = Draft202012Validator(_manifest_schema())
+    issues = []
+    for error in sorted(validator.iter_errors(manifest), key=lambda item: list(item.absolute_path)):
+        location = ".".join(str(part) for part in error.absolute_path)
+        issues.append(
+            SolutionValidationIssue(
+                code="manifest_schema_error",
+                message=error.message,
+                path=location,
+            )
+        )
+    if issues:
+        raise SolutionValidationError(issues)
+    return manifest
+
+
+def _validate_json_schema(path: Path, *, label: str) -> None:
+    payload = _load_json(path, code="referenced_schema_error")
+    if not isinstance(payload, dict):
+        raise _issue("referenced_schema_error", f"{label} schema must be a JSON object", str(path))
+    try:
+        Draft202012Validator.check_schema(payload)
+    except SchemaError as exc:
+        raise _issue("referenced_schema_error", f"invalid {label} JSON Schema: {exc.message}", str(path)) from exc
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _validate_integrity(root: Path, manifest: dict[str, Any]) -> list[str]:
+    integrity = manifest["integrity"]
+    expected_files: dict[str, str] = integrity["files"]
+    referenced = {
+        manifest["inputs"]["schema"],
+        manifest["graph"]["source"],
+        manifest["outputs"]["schema"],
+    }
+    missing = sorted(referenced - set(expected_files))
+    if missing:
+        raise SolutionValidationError(
+            SolutionValidationIssue(
+                code="integrity_reference_missing",
+                message=f"referenced file is absent from integrity.files: {relative}",
+                path=relative,
+            )
+            for relative in missing
+        )
+
+    issues: list[SolutionValidationIssue] = []
+    verified: list[str] = []
+    for relative, expected in sorted(expected_files.items()):
+        try:
+            path = _resolve_package_file(root, relative, code="integrity_file_error")
+        except SolutionValidationError as exc:
+            issues.extend(exc.issues)
+            continue
+        actual = _sha256(path)
+        if actual != expected:
+            issues.append(
+                SolutionValidationIssue(
+                    code="integrity_mismatch",
+                    message=f"SHA-256 mismatch for {relative}",
+                    path=relative,
+                )
+            )
+        else:
+            verified.append(relative)
+    if issues:
+        raise SolutionValidationError(issues)
+    return verified
+
+
+def _validate_graph_and_policy(
+    graph_path: Path,
+    manifest: dict[str, Any],
+    *,
+    available_capabilities: frozenset[str],
+) -> tuple[list[str], list[str]]:
+    payload = _load_json(graph_path, code="task_graph_error")
+    try:
+        graph = normalize_graph(TaskGraph.model_validate(payload))
+        validate_graph(graph)
+    except (ValueError, TypeError) as exc:
+        raise _issue("task_graph_error", str(exc), manifest["graph"]["source"]) from exc
+
+    declared = set(manifest["requires"]["capabilities"])
+    used: set[str] = set()
+    effects: set[str] = set()
+    for task in graph.tasks:
+        if task.run.kind == "det":
+            used.add(task.run.spec.handler)
+        else:
+            used.add(task.run.spec.adapter)
+        effects.update(
+            tag.removeprefix("side_effect:")
+            for tag in task.tags
+            if tag.startswith("side_effect:") and tag != "side_effect:"
+        )
+
+    issues: list[SolutionValidationIssue] = []
+    for capability in sorted(used - declared):
+        issues.append(
+            SolutionValidationIssue(
+                code="undeclared_capability",
+                message=f"Task Graph uses undeclared capability: {capability}",
+                path="requires.capabilities",
+            )
+        )
+    for capability in sorted(declared - available_capabilities):
+        issues.append(
+            SolutionValidationIssue(
+                code="missing_capability",
+                message=f"Host does not provide required capability: {capability}",
+                path="requires.capabilities",
+            )
+        )
+
+    policy = manifest["policy"]
+    declared_effects = set(policy["sideEffects"])
+    approvals = set(policy["approvals"])
+    for effect in sorted(effects - declared_effects):
+        issues.append(
+            SolutionValidationIssue(
+                code="undeclared_side_effect",
+                message=f"Task Graph uses undeclared side effect: {effect}",
+                path="policy.sideEffects",
+            )
+        )
+    for effect in sorted(declared_effects - approvals):
+        issues.append(
+            SolutionValidationIssue(
+                code="missing_approval",
+                message=f"side effect requires explicit approval declaration: {effect}",
+                path="policy.approvals",
+            )
+        )
+    if policy["network"] == "allowed" and "network.access" not in approvals:
+        issues.append(
+            SolutionValidationIssue(
+                code="missing_approval",
+                message="network access requires network.access approval",
+                path="policy.approvals",
+            )
+        )
+    if issues:
+        raise SolutionValidationError(issues)
+    return sorted(declared), sorted(used)
+
+
+def validate_solution_package(
+    package_root: str | Path,
+    *,
+    available_capabilities: Iterable[str] | None = None,
+) -> dict[str, Any]:
+    """Validate a Solution Package without executing it or accessing the network."""
+
+    root = Path(package_root).expanduser()
+    try:
+        root = root.resolve(strict=True)
+    except FileNotFoundError as exc:
+        raise _issue("package_not_found", f"package directory not found: {package_root}", str(package_root)) from exc
+    if not root.is_dir():
+        raise _issue("package_not_directory", f"package root is not a directory: {package_root}", str(root))
+
+    manifest_path = root / MANIFEST_NAME
+    if manifest_path.is_symlink():
+        raise _issue("manifest_file_error", "solution.json must not be a symbolic link", MANIFEST_NAME)
+    manifest = _validate_manifest_shape(_load_json(manifest_path, code="manifest_file_error"))
+
+    verified_files = _validate_integrity(root, manifest)
+
+    input_schema_path = _resolve_package_file(
+        root,
+        manifest["inputs"]["schema"],
+        code="referenced_schema_error",
+    )
+    output_schema_path = _resolve_package_file(
+        root,
+        manifest["outputs"]["schema"],
+        code="referenced_schema_error",
+    )
+    graph_path = _resolve_package_file(
+        root,
+        manifest["graph"]["source"],
+        code="task_graph_error",
+    )
+    _validate_json_schema(input_schema_path, label="input")
+    _validate_json_schema(output_schema_path, label="output")
+
+    capabilities = frozenset(
+        DEFAULT_REFERENCE_CAPABILITIES
+        if available_capabilities is None
+        else available_capabilities
+    )
+    declared, used = _validate_graph_and_policy(
+        graph_path,
+        manifest,
+        available_capabilities=capabilities,
+    )
+
+    return {
+        "status": "valid",
+        "api_version": manifest["apiVersion"],
+        "solution_id": manifest["metadata"]["id"],
+        "solution_version": manifest["metadata"]["version"],
+        "declared_capabilities": declared,
+        "used_capabilities": used,
+        "verified_files": verified_files,
+        "execution_performed": False,
+        "network_accessed": False,
+    }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,7 @@ dev = [
 include = ["kora*"]
 
 [tool.setuptools.package-data]
-kora = ["studio_assets/*.css", "studio_assets/*.js"]
+kora = ["solution/schemas/*.json", "studio_assets/*.css", "studio_assets/*.js"]
 
 [tool.pytest.ini_options]
 pythonpath = ["."]

--- a/tests/test_kora_studio_server.py
+++ b/tests/test_kora_studio_server.py
@@ -1097,11 +1097,12 @@ def test_studio_css_helper_loads_package_controlled_source_file() -> None:
     assert "https://" not in css_source
 
 
-def test_studio_package_data_includes_only_package_controlled_css_and_javascript_assets() -> None:
+def test_package_data_includes_only_reviewed_protocol_and_studio_assets() -> None:
     pyproject_path = Path(__file__).resolve().parents[1] / "pyproject.toml"
     pyproject = tomllib.loads(pyproject_path.read_text(encoding="utf-8"))
 
     assert pyproject["tool"]["setuptools"]["package-data"]["kora"] == [
+        "solution/schemas/*.json",
         "studio_assets/*.css",
         "studio_assets/*.js",
     ]

--- a/tests/test_solution_cli.py
+++ b/tests/test_solution_cli.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from kora.cli import main
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+HELLO_SOLUTION = REPO_ROOT / "examples" / "solutions" / "hello-solution"
+
+
+def test_solution_validate_cli_json(capsys) -> None:
+    exit_code = main(["solution", "validate", str(HELLO_SOLUTION), "--json"])
+    captured = capsys.readouterr()
+
+    assert exit_code == 0
+    payload = json.loads(captured.out)
+    assert payload["status"] == "valid"
+    assert payload["solution_id"] == "example.hello"
+    assert payload["execution_performed"] is False
+
+
+def test_solution_validate_cli_reports_missing_capability(capsys) -> None:
+    exit_code = main(
+        [
+            "solution",
+            "validate",
+            str(HELLO_SOLUTION),
+            "--capability",
+            "text.normalize",
+            "--json",
+        ]
+    )
+    captured = capsys.readouterr()
+
+    assert exit_code == 1
+    payload = json.loads(captured.err)
+    assert payload["status"] == "invalid"
+    assert payload["issues"][0]["code"] == "missing_capability"

--- a/tests/test_solution_validator.py
+++ b/tests/test_solution_validator.py
@@ -1,0 +1,139 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import shutil
+from pathlib import Path
+
+import pytest
+
+from kora.solution import SolutionValidationError, validate_solution_package
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+HELLO_SOLUTION = REPO_ROOT / "examples" / "solutions" / "hello-solution"
+
+
+def _copy_solution(tmp_path: Path) -> Path:
+    target = tmp_path / "solution"
+    shutil.copytree(HELLO_SOLUTION, target)
+    return target
+
+
+def _load_manifest(package: Path) -> dict:
+    return json.loads((package / "solution.json").read_text(encoding="utf-8"))
+
+
+def _write_manifest(package: Path, manifest: dict) -> None:
+    (package / "solution.json").write_text(
+        json.dumps(manifest, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+
+def _write_graph_and_refresh_digest(package: Path, graph: dict) -> None:
+    graph_path = package / "graph" / "workflow.json"
+    graph_path.write_text(json.dumps(graph, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    manifest = _load_manifest(package)
+    manifest["integrity"]["files"]["graph/workflow.json"] = hashlib.sha256(
+        graph_path.read_bytes()
+    ).hexdigest()
+    _write_manifest(package, manifest)
+
+
+def _codes(exc: SolutionValidationError) -> set[str]:
+    return {issue.code for issue in exc.issues}
+
+
+def test_hello_solution_validates_offline() -> None:
+    result = validate_solution_package(HELLO_SOLUTION)
+
+    assert result["status"] == "valid"
+    assert result["solution_id"] == "example.hello"
+    assert result["declared_capabilities"] == ["det.echo"]
+    assert result["execution_performed"] is False
+    assert result["network_accessed"] is False
+    assert result["verified_files"] == [
+        "graph/workflow.json",
+        "schemas/input.schema.json",
+        "schemas/output.schema.json",
+    ]
+
+
+def test_unsupported_protocol_version_fails_before_execution(tmp_path: Path) -> None:
+    package = _copy_solution(tmp_path)
+    manifest = _load_manifest(package)
+    manifest["apiVersion"] = "kora.dev/v1"
+    _write_manifest(package, manifest)
+
+    with pytest.raises(SolutionValidationError) as captured:
+        validate_solution_package(package)
+
+    assert _codes(captured.value) == {"unsupported_protocol_version"}
+
+
+def test_tampered_file_fails_integrity(tmp_path: Path) -> None:
+    package = _copy_solution(tmp_path)
+    graph_path = package / "graph" / "workflow.json"
+    graph_path.write_text(graph_path.read_text(encoding="utf-8") + "\n", encoding="utf-8")
+
+    with pytest.raises(SolutionValidationError) as captured:
+        validate_solution_package(package)
+
+    assert "integrity_mismatch" in _codes(captured.value)
+
+
+def test_cycle_fails_graph_validation_after_valid_integrity(tmp_path: Path) -> None:
+    package = _copy_solution(tmp_path)
+    graph = json.loads((package / "graph" / "workflow.json").read_text(encoding="utf-8"))
+    graph["tasks"][0]["deps"] = ["hello"]
+    _write_graph_and_refresh_digest(package, graph)
+
+    with pytest.raises(SolutionValidationError) as captured:
+        validate_solution_package(package)
+
+    assert _codes(captured.value) == {"task_graph_error"}
+    assert "cycle" in str(captured.value).lower()
+
+
+def test_undeclared_capability_fails_closed(tmp_path: Path) -> None:
+    package = _copy_solution(tmp_path)
+    graph = json.loads((package / "graph" / "workflow.json").read_text(encoding="utf-8"))
+    graph["tasks"][0]["run"]["spec"]["handler"] = "text.normalize"
+    _write_graph_and_refresh_digest(package, graph)
+
+    with pytest.raises(SolutionValidationError) as captured:
+        validate_solution_package(package)
+
+    assert "undeclared_capability" in _codes(captured.value)
+
+
+def test_missing_host_capability_fails_closed() -> None:
+    with pytest.raises(SolutionValidationError) as captured:
+        validate_solution_package(HELLO_SOLUTION, available_capabilities=set())
+
+    assert _codes(captured.value) == {"missing_capability"}
+
+
+def test_side_effect_requires_declaration_and_approval(tmp_path: Path) -> None:
+    package = _copy_solution(tmp_path)
+    graph = json.loads((package / "graph" / "workflow.json").read_text(encoding="utf-8"))
+    graph["tasks"][0]["tags"] = ["side_effect:artifact.write"]
+    _write_graph_and_refresh_digest(package, graph)
+
+    with pytest.raises(SolutionValidationError) as captured:
+        validate_solution_package(package)
+
+    assert _codes(captured.value) == {"undeclared_side_effect"}
+
+
+def test_parent_traversal_path_is_rejected_by_manifest_schema(tmp_path: Path) -> None:
+    package = _copy_solution(tmp_path)
+    manifest = _load_manifest(package)
+    manifest["inputs"]["schema"] = "../outside.json"
+    _write_manifest(package, manifest)
+
+    with pytest.raises(SolutionValidationError) as captured:
+        validate_solution_package(package)
+
+    assert _codes(captured.value) == {"manifest_schema_error"}


### PR DESCRIPTION
## Summary

- define the first bounded KORA Solution Protocol v0 contract
- add a fail-closed, offline Solution package validator
- expose `kora solution validate <package>`
- add a synthetic `hello-solution` fixture and protocol-focused tests
- update public documentation and package the manifest schema

## Validation

- focused Solution Protocol tests: 10 passed
- full test suite: 612 passed
- source-install readiness: 6/6 passed
- installed-source CLI smoke validation: passed
- Markdown link validation: passed
- `git diff --check`: passed
- public/private boundary scan: passed

## Boundaries

- validates packages but does not execute a Solution
- performs no network, provider, model, or GPU calls
- does not select the first commercial Solution
- does not add a registry, marketplace, or multi-device runtime
- preserves the existing deterministic-first Core and claim boundaries
