### PR TITLE
Task 020: add local capability registry and runtime resolution

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,11 +60,12 @@ The validator checks manifests, referenced JSON Schemas, Task Graphs, capability
 A bounded reference Host can then install and run either Solution through the same local lifecycle:
 
 ```bash
+python3 -m kora solution runtimes --store /tmp/kora-host --json
 python3 -m kora solution install examples/solutions/hello-solution --store /tmp/kora-host --json
 python3 -m kora solution run example.hello --store /tmp/kora-host --input examples/solutions/inputs/hello.json --json
 ```
 
-The input file is a JSON object such as `{"message":"Hello"}`. The Host verifies the installed snapshot before execution and persists schema-validated status and result records. Its reference capabilities are deterministic and offline; stop/resume, provider/model/GPU execution, and production validation remain deferred. See [Solution Protocol v0alpha1](docs/solution-protocol-v0.md) and the [reference Solution guide](examples/solutions/README.md).
+The input file is a JSON object such as `{"message":"Hello"}`. The Host verifies both the installed snapshot and its local runtime registry, resolves one compatible trusted runtime before every run, records the runtime descriptor digest, and persists schema-validated status and result records. Its reference capabilities are deterministic and offline; stop/resume, provider/model/GPU execution, and production validation remain deferred. See [Solution Protocol v0alpha1](docs/solution-protocol-v0.md) and the [reference Solution guide](examples/solutions/README.md).
 
 ### Research Foundry Alpha
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -11,7 +11,7 @@ This documentation index is for readers who want more detail than the root [READ
 - [Example catalog](../examples/README.md) - runnable examples grouped by use case.
 - [Packaging: getkora strategy](packaging/getkora_distribution_strategy.md) - package-name and install-path status.
 - [Research Foundry Alpha](research-foundry-alpha.md) - Local Only text-layer PDF ingest, lexical retrieval, and deterministic evidence cards.
-- [Solution Protocol v0alpha1](solution-protocol-v0.md) - offline package validation, bounded deterministic Host lifecycle, status/result contracts, and conformance boundary.
+- [Solution Protocol v0alpha1](solution-protocol-v0.md) - offline package validation, integrity-checked local capability registry, deterministic runtime resolution, bounded Host lifecycle, status/result contracts, and conformance boundary.
 - [Reference Solutions](../examples/solutions/README.md) - two synthetic packages using the same Protocol and Host interface.
 
 ## Flagship Examples

--- a/docs/solution-protocol-v0.md
+++ b/docs/solution-protocol-v0.md
@@ -81,6 +81,23 @@ Local file paths reject absolute paths, parent traversal, and symlinks. Reads an
 
 No reference capability performs a provider call, model inference, network request, or GPU execution.
 
+## Local capability registry and runtime resolution
+
+The Host store contains an explicit local capability runtime registry. A runtime descriptor is validated against `kora/solution/schemas/runtime-descriptor.schema.json` and declares:
+
+- stable runtime id and semantic version;
+- compatible Solution Protocol versions;
+- the exact capabilities implemented by its binding;
+- supported Task Graph run kinds;
+- deterministic selection priority;
+- whether the runtime may use network, model inference, or GPU execution.
+
+Registration persists a canonical descriptor and a digest-bearing receipt under the isolated Host store. Descriptor files, receipts, paths, and directory contents are verified before listing, validation, installation, and every run. A persisted descriptor alone is not executable: the current Host process must also supply a matching trusted in-process binding. v0alpha1 does not dynamically import code from the registry.
+
+Resolution requires one runtime to provide every capability required by a Solution; capabilities are not split across runtimes. Candidates are filtered by protocol, Task Graph run kind, and execution policy. The unique highest-priority compatible binding is selected. No candidate, an unbound descriptor, or a highest-priority tie fails closed with a bounded machine-readable error.
+
+The bundled Host registers `kora.reference` version `0.1.0` on startup. This registry is local Host metadata, not a remote registry, package marketplace, general KORA Target Registry, or production plugin system.
+
 ## Policy and approvals
 
 Task tags beginning with `side_effect:` declare effects used by the graph. Each effect must appear in both `policy.sideEffects` and `policy.approvals`.
@@ -116,17 +133,18 @@ The reference Host adds a second installation boundary:
 3. copy the package into an isolated local store;
 4. validate the copied package again;
 5. persist a receipt containing every copied file digest and a deterministic tree digest;
-6. verify the complete installed snapshot before every run.
+6. verify the complete installed snapshot before every run;
+7. resolve and record the selected integrity-checked local runtime.
 
-This Host receipt covers `solution.json` and detects added, removed, or modified installed files before execution.
+This Host receipt covers `solution.json` and detects added, removed, or modified installed files before execution. Runtime descriptor and registration-receipt integrity are verified independently before execution.
 
 ## Bounded Host lifecycle
 
 The implemented synchronous interface is:
 
-1. `validate`: read-only package validation against runtime capabilities;
-2. `install`: isolated copy, revalidation, and full-snapshot receipt;
-3. `run`: integrity, package, input, approval, runtime, and output gates;
+1. `validate`: read-only package validation plus deterministic local runtime resolution;
+2. `install`: isolated copy, revalidation, full-snapshot receipt, and selected-runtime evidence;
+3. `run`: package and runtime integrity, fresh runtime resolution, input, approval, execution, and output gates;
 4. `status`: schema-validated persisted lifecycle status;
 5. `result`: schema-validated final result envelope.
 
@@ -164,6 +182,7 @@ Both contracts include:
 
 - schema and protocol version;
 - Solution id and version;
+- selected runtime id, version, and descriptor digest when resolution succeeds;
 - run id and lifecycle state;
 - input and output validation status;
 - a relative evidence/status reference;
@@ -180,8 +199,9 @@ Validate either reference Solution without executing it:
     kora solution validate examples/solutions/hello-solution --json
     kora solution validate examples/solutions/document-transform-fixture --json
 
-Install and run through an explicit local store:
+Inspect the integrity-verified runtime registry, then install and run through an explicit local store:
 
+    kora solution runtimes --store /tmp/kora-host --json
     kora solution install examples/solutions/hello-solution --store /tmp/kora-host --json
     kora solution run example.hello --store /tmp/kora-host --input examples/solutions/inputs/hello.json --json
     kora solution status RUN_ID --store /tmp/kora-host --json
@@ -198,7 +218,7 @@ The two synthetic reference Solutions are:
 
 They use the same manifest, input/output schema, Task Graph, policy, integrity, Host lifecycle, status, and result contracts. Neither adds workflow-specific KORA Core logic.
 
-Automated conformance covers valid installation and deterministic runs, malformed input/output, missing capabilities, undeclared side effects, missing approvals, installed-package tampering, deliberate runtime failure, lifecycle transitions, isolated file operations, contract corruption, and zero network/model/GPU activity.
+Automated conformance covers descriptor validation, trusted binding requirements, deterministic priority selection, ambiguity rejection, no cross-runtime capability splitting, execution-policy filtering, registry and installed-package tampering, valid installation and deterministic runs, malformed input/output, missing capabilities, undeclared side effects, missing approvals, deliberate runtime failure, lifecycle transitions, isolated file operations, contract corruption, and zero network/model/GPU activity.
 
 ## Current boundary
 
@@ -209,6 +229,8 @@ Implemented:
 - two synthetic reference Solutions;
 - isolated local installation and full installed-snapshot verification;
 - bounded deterministic reference runtime;
+- integrity-checked local capability registry and deterministic runtime resolution;
+- runtime descriptor schema and selected-runtime evidence;
 - synchronous run, status, and result lifecycle;
 - machine-readable result and runtime-status schemas;
 - fail-closed conformance tests.
@@ -218,7 +240,7 @@ Deferred:
 - remove/update lifecycle;
 - stop/resume and checkpoints;
 - cache execution;
-- persistent external capability registry and runtime negotiation;
+- dynamic runtime discovery, loading, installation, or remote registry synchronization;
 - provider, model, network, and GPU capabilities;
 - package signing;
 - SDK scaffold and packaging;

--- a/examples/solutions/README.md
+++ b/examples/solutions/README.md
@@ -14,9 +14,10 @@ python3 -m kora solution validate examples/solutions/hello-solution --json
 python3 -m kora solution validate examples/solutions/document-transform-fixture --json
 ```
 
-Install a package into an explicit isolated store:
+Inspect the local runtime registry, then install a package into an explicit isolated store:
 
 ```bash
+python3 -m kora solution runtimes --store /tmp/kora-host --json
 python3 -m kora solution install examples/solutions/hello-solution --store /tmp/kora-host --json
 python3 -m kora solution install examples/solutions/document-transform-fixture --store /tmp/kora-host --json
 ```
@@ -30,6 +31,6 @@ python3 -m kora solution status RUN_ID --store /tmp/kora-host --json
 python3 -m kora solution result RUN_ID --store /tmp/kora-host --json
 ```
 
-The reference Host is synchronous, deterministic, and offline. It verifies package integrity and input/approval policy before execution, validates output afterward, and persists schema-validated status and result records.
+The reference Host is synchronous, deterministic, and offline. It verifies package and local runtime-registry integrity, resolves one trusted capability runtime before execution, validates input/approval policy and output, and persists schema-validated status and result records with selected-runtime evidence. The registry does not dynamically load code.
 
 These fixtures do not prove production readiness, output quality, customer savings, or commercial-product selection. Stop/resume, cache execution, provider/model/GPU capabilities, and production validation remain deferred.

--- a/kora/cli.py
+++ b/kora/cli.py
@@ -452,6 +452,13 @@ def main(argv: list[str] | None = None) -> int:
     solution_validate.add_argument("--capability", action="append", dest="capabilities")
     solution_validate.add_argument("--json", action="store_true", help="print structured JSON")
 
+    solution_runtimes = solution_subparsers.add_parser(
+        "runtimes",
+        help="list integrity-verified local capability runtimes",
+    )
+    solution_runtimes.add_argument("--store", required=True, help="explicit local Host store directory")
+    solution_runtimes.add_argument("--json", action="store_true", help="print structured JSON")
+
     solution_install = solution_subparsers.add_parser(
         "install",
         help="validate and install a Solution into an isolated local store",
@@ -462,7 +469,7 @@ def main(argv: list[str] | None = None) -> int:
 
     solution_run = solution_subparsers.add_parser(
         "run",
-        help="run an installed Solution through the bounded reference runtime",
+        help="run an installed Solution through a resolved local capability runtime",
     )
     solution_run.add_argument("solution_id", help="installed Solution id")
     solution_run.add_argument("--version", help="installed Solution version")
@@ -626,6 +633,29 @@ def main(argv: list[str] | None = None) -> int:
             print(f"- apiVersion: {result['api_version']}")
             print(f"- verified files: {len(result['verified_files'])}")
             print("- execution performed: false")
+        return 0
+
+    if args.command == "solution" and args.solution_command == "runtimes":
+        try:
+            payload = LocalSolutionHost(args.store).runtimes()
+        except (OSError, SolutionHostError, TypeError, ValueError) as exc:
+            error = (
+                exc
+                if isinstance(exc, SolutionHostError)
+                else SolutionHostError("runtime_registry_failed", "runtime registry failed closed")
+            )
+            if args.json:
+                print(json.dumps(error.to_dict(), indent=2, sort_keys=True), file=sys.stderr)
+            else:
+                print(f"Runtime registry failed: {error.detail}", file=sys.stderr)
+            return 1
+        if args.json:
+            print(json.dumps(payload, indent=2, sort_keys=True))
+        else:
+            print("Local capability runtimes")
+            for entry in payload["runtimes"]:
+                identity = entry["descriptor"]["runtime"]
+                print(f"- {identity['id']} {identity['version']} (bound: {str(entry['bound']).lower()})")
         return 0
 
     if args.command == "solution" and args.solution_command == "install":

--- a/kora/solution/__init__.py
+++ b/kora/solution/__init__.py
@@ -2,6 +2,7 @@
 
 from .contracts import (
     RESULT_ENVELOPE_SCHEMA,
+    RUNTIME_DESCRIPTOR_SCHEMA,
     RUNTIME_STATUS_SCHEMA,
     SolutionContractError,
     validate_contract_instance,
@@ -12,6 +13,12 @@ from .reference_runtime import (
     ReferenceRuntime,
     ReferenceRuntimeError,
     RuntimeExecution,
+)
+from .runtime_registry import (
+    CapabilityRegistryError,
+    CapabilityRuntime,
+    LocalCapabilityRegistry,
+    ResolvedRuntime,
 )
 from .validator import (
     DEFAULT_REFERENCE_CAPABILITIES,
@@ -25,11 +32,16 @@ __all__ = [
     "DEFAULT_REFERENCE_CAPABILITIES",
     "REFERENCE_CAPABILITIES",
     "RESULT_ENVELOPE_SCHEMA",
+    "RUNTIME_DESCRIPTOR_SCHEMA",
     "RUNTIME_STATUS_SCHEMA",
     "SUPPORTED_API_VERSION",
+    "CapabilityRegistryError",
+    "CapabilityRuntime",
+    "LocalCapabilityRegistry",
     "LocalSolutionHost",
     "ReferenceRuntime",
     "ReferenceRuntimeError",
+    "ResolvedRuntime",
     "RuntimeExecution",
     "SolutionContractError",
     "SolutionHostError",

--- a/kora/solution/contracts.py
+++ b/kora/solution/contracts.py
@@ -10,6 +10,7 @@ from jsonschema import Draft202012Validator, FormatChecker
 from jsonschema.exceptions import SchemaError
 
 RESULT_ENVELOPE_SCHEMA = "result-envelope.schema.json"
+RUNTIME_DESCRIPTOR_SCHEMA = "runtime-descriptor.schema.json"
 RUNTIME_STATUS_SCHEMA = "runtime-status.schema.json"
 
 
@@ -85,6 +86,7 @@ def validate_declared_instance(schema_path: Path, payload: Any) -> tuple[str, ..
 
 __all__ = [
     "RESULT_ENVELOPE_SCHEMA",
+    "RUNTIME_DESCRIPTOR_SCHEMA",
     "RUNTIME_STATUS_SCHEMA",
     "SolutionContractError",
     "canonical_json_bytes",

--- a/kora/solution/host.py
+++ b/kora/solution/host.py
@@ -24,6 +24,12 @@ from .contracts import (
     validate_declared_instance,
 )
 from .reference_runtime import ReferenceRuntime, ReferenceRuntimeError
+from .runtime_registry import (
+    CapabilityRegistryError,
+    CapabilityRuntime,
+    LocalCapabilityRegistry,
+    ResolvedRuntime,
+)
 from .validator import (
     SUPPORTED_API_VERSION,
     SolutionValidationError,
@@ -39,13 +45,18 @@ VERSION_PATTERN = re.compile(
 )
 RESULT_ERROR_CODES = frozenset(
     {
+        "ambiguous_runtime",
         "approval_required",
         "deliberate_failure",
+        "incompatible_runtime",
         "input_validation_failed",
         "integrity_mismatch",
+        "missing_capability_runtime",
         "output_validation_failed",
         "package_validation_failed",
         "runtime_failure",
+        "runtime_integrity_mismatch",
+        "runtime_unavailable",
     }
 )
 TRANSITIONS = {
@@ -141,7 +152,8 @@ class LocalSolutionHost:
         self,
         store_root: str | Path,
         *,
-        runtime: ReferenceRuntime | None = None,
+        runtime: CapabilityRuntime | None = None,
+        runtimes: Iterable[CapabilityRuntime] | None = None,
         clock: Callable[[], str] | None = None,
         run_id_factory: Callable[[], str] | None = None,
     ):
@@ -150,16 +162,27 @@ class LocalSolutionHost:
         if self.store_root.is_symlink() or not self.store_root.is_dir():
             raise SolutionHostError("invalid_store", "Host store root must be a regular directory")
         self.store_root = self.store_root.resolve()
-        self.runtime = runtime or ReferenceRuntime()
+        if runtime is not None and runtimes is not None:
+            raise SolutionHostError("invalid_runtime_configuration", "use runtime or runtimes, not both")
+        configured_runtimes = tuple(runtimes) if runtimes is not None else (runtime or ReferenceRuntime(),)
+        if not configured_runtimes:
+            raise SolutionHostError("invalid_runtime_configuration", "at least one runtime is required")
         self._clock = clock or _utc_now
         self._run_id_factory = run_id_factory or (lambda: uuid.uuid4().hex)
         self.installed_root = self._store_subdirectory("installed", create=True)
         self.runs_root = self._store_subdirectory("runs", create=True)
+        self.runtimes_root = self._store_subdirectory("runtimes", create=True)
+        try:
+            self.runtime_registry = LocalCapabilityRegistry(self.runtimes_root)
+            for configured_runtime in configured_runtimes:
+                self.runtime_registry.register(configured_runtime)
+        except CapabilityRegistryError as exc:
+            raise SolutionHostError(exc.code, exc.detail) from exc
 
     def validate(self, package_root: str | Path) -> dict[str, Any]:
         report = validate_solution_package(
             package_root,
-            available_capabilities=self.runtime.capabilities,
+            available_capabilities=self._available_capabilities(),
         )
         package = Path(package_root).expanduser().resolve()
         manifest = load_json_object(package / "solution.json")
@@ -174,6 +197,9 @@ class LocalSolutionHost:
                 "unsupported_runtime_task_kind",
                 "bounded reference Host accepts only deterministic Task Graph nodes",
             )
+        resolved = self._resolve_runtime(manifest, graph)
+        report = dict(report)
+        report["runtime_resolution"] = resolved.identity
         return report
 
     def install(self, package_root: str | Path) -> dict[str, Any]:
@@ -211,6 +237,7 @@ class LocalSolutionHost:
                 "schema_version": "kora.solution.install/v0alpha1",
                 "protocol_version": copied_report["api_version"],
                 "solution": {"id": solution_id, "version": version},
+                "runtime_resolution": copied_report["runtime_resolution"],
                 "package_digest": source_digest,
                 "files": copied_files,
                 "installed_at": installed_at,
@@ -250,6 +277,7 @@ class LocalSolutionHost:
             "schema_version": "kora.solution.runtime-status/v0alpha1",
             "protocol_version": SUPPORTED_API_VERSION,
             "solution": {"id": solution_id, "version": resolved_version},
+            "runtime": None,
             "run_id": run_id,
             "lifecycle_state": "created",
             "validation": {"input": "not_run", "output": "not_run"},
@@ -276,7 +304,7 @@ class LocalSolutionHost:
         try:
             self._verify_install(install_path)
             package = install_path / "package"
-            validate_solution_package(package, available_capabilities=self.runtime.capabilities)
+            validate_solution_package(package, available_capabilities=self._available_capabilities())
             manifest = load_json_object(package / "solution.json")
             if manifest["metadata"] != {"id": solution_id, "version": resolved_version}:
                 raise SolutionHostError("integrity_mismatch", "installed Solution identity changed")
@@ -285,6 +313,12 @@ class LocalSolutionHost:
                     "network_policy_not_supported",
                     "bounded reference Host accepts only network-denied Solutions",
                 )
+            graph_payload = load_json_object(package / manifest["graph"]["source"])
+            graph = normalize_graph(TaskGraph.model_validate(graph_payload))
+            validate_graph(graph)
+            resolved_runtime = self._resolve_runtime(manifest, graph)
+            status["runtime"] = resolved_runtime.identity
+            self._persist_status(run_directory, status)
 
             input_schema = package / manifest["inputs"]["schema"]
             input_errors = validate_declared_instance(input_schema, input_payload)
@@ -308,14 +342,11 @@ class LocalSolutionHost:
                     detail="one or more declared approvals were not granted",
                 )
 
-            graph_payload = load_json_object(package / manifest["graph"]["source"])
-            graph = normalize_graph(TaskGraph.model_validate(graph_payload))
-            validate_graph(graph)
             status["validation"]["output"] = "pending"
             status["activity"]["execution_performed"] = True
             self._transition(run_directory, status, "running")
 
-            execution = self.runtime.execute(
+            execution = resolved_runtime.runtime.execute(
                 graph,
                 input_payload,
                 run_directory=run_directory,
@@ -392,6 +423,42 @@ class LocalSolutionHost:
         except (OSError, TypeError, ValueError, SolutionContractError) as exc:
             raise SolutionHostError("invalid_result_envelope", "result envelope failed validation") from exc
         return payload
+
+    def runtimes(self) -> dict[str, Any]:
+        """Return integrity-verified local runtime registrations."""
+
+        try:
+            return self.runtime_registry.list()
+        except CapabilityRegistryError as exc:
+            raise SolutionHostError(exc.code, exc.detail) from exc
+
+    def _available_capabilities(self) -> frozenset[str]:
+        try:
+            return self.runtime_registry.available_capabilities
+        except CapabilityRegistryError as exc:
+            raise SolutionHostError(exc.code, exc.detail) from exc
+
+    def _resolve_runtime(
+        self,
+        manifest: dict[str, Any],
+        graph: TaskGraph,
+    ) -> ResolvedRuntime:
+        required_capabilities = {
+            task.run.spec.handler
+            for task in graph.tasks
+        }
+        task_kinds = {task.run.kind for task in graph.tasks}
+        try:
+            return self.runtime_registry.resolve(
+                required_capabilities,
+                protocol_version=manifest["apiVersion"],
+                task_kinds=task_kinds,
+                allow_network=False,
+                allow_model=False,
+                allow_gpu=False,
+            )
+        except CapabilityRegistryError as exc:
+            raise SolutionHostError(exc.code, exc.detail) from exc
 
     def _store_subdirectory(self, name: str, *, create: bool) -> Path:
         path = self.store_root / name
@@ -556,6 +623,7 @@ class LocalSolutionHost:
             "schema_version": "kora.solution.result/v0alpha1",
             "protocol_version": status["protocol_version"],
             "solution": dict(status["solution"]),
+            "runtime": None if status["runtime"] is None else dict(status["runtime"]),
             "run_id": status["run_id"],
             "lifecycle_state": status["lifecycle_state"],
             "validation": dict(status["validation"]),

--- a/kora/solution/reference_runtime.py
+++ b/kora/solution/reference_runtime.py
@@ -179,9 +179,31 @@ def _read_local_file(workspace: Path, params: dict[str, Any]) -> dict[str, Any]:
 class ReferenceRuntime:
     """Execute only the bounded deterministic capabilities in this module."""
 
+    runtime_id = "kora.reference"
+    runtime_version = "0.1.0"
+    priority = 100
+
     @property
     def capabilities(self) -> frozenset[str]:
         return REFERENCE_CAPABILITIES
+
+    @property
+    def descriptor(self) -> dict[str, Any]:
+        """Return the validated static descriptor used by local resolution."""
+
+        return {
+            "schema_version": "kora.runtime.descriptor/v0alpha1",
+            "runtime": {"id": self.runtime_id, "version": self.runtime_version},
+            "protocol_versions": ["kora.dev/v0alpha1"],
+            "capabilities": sorted(self.capabilities),
+            "task_kinds": ["det"],
+            "priority": self.priority,
+            "execution": {
+                "network_access": False,
+                "model_inference": False,
+                "gpu_execution": False,
+            },
+        }
 
     def execute(
         self,

--- a/kora/solution/runtime_registry.py
+++ b/kora/solution/runtime_registry.py
@@ -1,0 +1,451 @@
+"""Integrity-checked local capability runtime registration and resolution."""
+
+from __future__ import annotations
+
+import hashlib
+import re
+import shutil
+import uuid
+from collections.abc import Iterable
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Protocol
+
+from .contracts import (
+    RUNTIME_DESCRIPTOR_SCHEMA,
+    SolutionContractError,
+    canonical_json_bytes,
+    load_json_object,
+    validate_contract_instance,
+)
+
+MAX_REGISTERED_RUNTIMES = 64
+RUNTIME_ID_PATTERN = re.compile(r"^[a-z0-9]+(?:[._-][a-z0-9]+)*$")
+RUNTIME_VERSION_PATTERN = re.compile(
+    r"^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(?:-[0-9A-Za-z.-]+)?$"
+)
+
+
+class CapabilityRuntime(Protocol):
+    """Runtime interface accepted by the local registry."""
+
+    @property
+    def capabilities(self) -> frozenset[str]:
+        """Return the exact capability set implemented by this binding."""
+
+    @property
+    def descriptor(self) -> dict[str, Any]:
+        """Return a machine-readable runtime descriptor."""
+
+
+class CapabilityRegistryError(RuntimeError):
+    """Bounded local registry or resolution failure."""
+
+    def __init__(self, code: str, detail: str):
+        self.code = code
+        rendered = " ".join(str(detail).split()) or "runtime registry operation failed"
+        self.detail = rendered[:512]
+        super().__init__(self.detail)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "status": "error",
+            "error": {"code": self.code, "detail": self.detail},
+        }
+
+
+@dataclass(frozen=True)
+class ResolvedRuntime:
+    """Verified descriptor and in-process runtime selected for one run."""
+
+    descriptor: dict[str, Any]
+    descriptor_digest: str
+    runtime: CapabilityRuntime
+
+    @property
+    def identity(self) -> dict[str, str]:
+        return {
+            "id": self.descriptor["runtime"]["id"],
+            "version": self.descriptor["runtime"]["version"],
+            "descriptor_digest": self.descriptor_digest,
+        }
+
+
+def _utc_now() -> str:
+    return (
+        datetime.now(timezone.utc)
+        .isoformat(timespec="microseconds")
+        .replace("+00:00", "Z")
+    )
+
+
+def _is_utc_timestamp(value: Any) -> bool:
+    if not isinstance(value, str) or not value.endswith("Z"):
+        return False
+    try:
+        parsed = datetime.fromisoformat(value[:-1] + "+00:00")
+    except ValueError:
+        return False
+    return parsed.tzinfo == timezone.utc
+
+
+def _descriptor_digest(descriptor: dict[str, Any]) -> str:
+    return hashlib.sha256(canonical_json_bytes(descriptor)).hexdigest()
+
+
+def _atomic_write_json(path: Path, payload: Any) -> None:
+    temporary = path.with_name(f".{path.name}.{uuid.uuid4().hex}.tmp")
+    temporary.write_bytes(canonical_json_bytes(payload))
+    temporary.replace(path)
+
+
+class LocalCapabilityRegistry:
+    """Persist verified descriptors and bind trusted in-process runtimes."""
+
+    def __init__(self, root: str | Path):
+        candidate = Path(root).expanduser()
+        candidate.mkdir(parents=True, exist_ok=True)
+        if candidate.is_symlink() or not candidate.is_dir():
+            raise CapabilityRegistryError(
+                "invalid_runtime_registry",
+                "runtime registry root must be a regular directory",
+            )
+        self.root = candidate.resolve()
+        self._bindings: dict[tuple[str, str], CapabilityRuntime] = {}
+
+    def register(self, runtime: CapabilityRuntime) -> dict[str, Any]:
+        """Register one trusted runtime binding with an integrity receipt."""
+
+        try:
+            descriptor = runtime.descriptor
+        except (AttributeError, TypeError, ValueError) as exc:
+            raise CapabilityRegistryError(
+                "invalid_runtime_descriptor",
+                "runtime did not provide a valid descriptor",
+            ) from exc
+        if not isinstance(descriptor, dict):
+            raise CapabilityRegistryError(
+                "invalid_runtime_descriptor",
+                "runtime descriptor must be an object",
+            )
+        descriptor = dict(descriptor)
+        try:
+            validate_contract_instance(RUNTIME_DESCRIPTOR_SCHEMA, descriptor)
+        except (SolutionContractError, TypeError, ValueError) as exc:
+            raise CapabilityRegistryError(
+                "invalid_runtime_descriptor",
+                "runtime descriptor failed schema validation",
+            ) from exc
+
+        declared = frozenset(descriptor["capabilities"])
+        try:
+            implemented = frozenset(runtime.capabilities)
+        except (AttributeError, TypeError, ValueError) as exc:
+            raise CapabilityRegistryError(
+                "invalid_runtime_binding",
+                "runtime capability binding is invalid",
+            ) from exc
+        if declared != implemented or not callable(getattr(runtime, "execute", None)):
+            raise CapabilityRegistryError(
+                "invalid_runtime_binding",
+                "runtime binding does not match its descriptor",
+            )
+
+        runtime_id = descriptor["runtime"]["id"]
+        version = descriptor["runtime"]["version"]
+        target = self._entry_path(runtime_id, version)
+        digest = _descriptor_digest(descriptor)
+        if target.exists():
+            existing, existing_digest = self._verify_entry(target)
+            if existing_digest != digest or existing != descriptor:
+                raise CapabilityRegistryError(
+                    "runtime_already_registered",
+                    "a different descriptor is already registered for this runtime version",
+                )
+        else:
+            if len(self._entry_paths()) >= MAX_REGISTERED_RUNTIMES:
+                raise CapabilityRegistryError(
+                    "runtime_registry_limit_exceeded",
+                    "runtime registry reached its bounded entry limit",
+                )
+            target.parent.mkdir(parents=True, exist_ok=True)
+            temporary = target.parent / f".register-{uuid.uuid4().hex}"
+            try:
+                temporary.mkdir()
+                _atomic_write_json(temporary / "runtime.json", descriptor)
+                _atomic_write_json(
+                    temporary / "registration.json",
+                    {
+                        "schema_version": "kora.runtime.registration/v0alpha1",
+                        "runtime": {"id": runtime_id, "version": version},
+                        "descriptor_digest": digest,
+                        "registered_at": _utc_now(),
+                    },
+                )
+                temporary.replace(target)
+            except Exception:
+                if temporary.exists():
+                    shutil.rmtree(temporary)
+                raise
+            self._verify_entry(target)
+
+        self._bindings[(runtime_id, version)] = runtime
+        return {
+            "schema_version": "kora.runtime.registration/v0alpha1",
+            "runtime": {"id": runtime_id, "version": version},
+            "descriptor_digest": digest,
+            "bound": True,
+            "activity": {
+                "execution_performed": False,
+                "network_accessed": False,
+                "model_inference_performed": False,
+                "gpu_execution_performed": False,
+            },
+        }
+
+    def list(self) -> dict[str, Any]:
+        """List verified local descriptors without executing a runtime."""
+
+        entries = []
+        for path in self._entry_paths():
+            descriptor, digest = self._verify_entry(path)
+            key = (
+                descriptor["runtime"]["id"],
+                descriptor["runtime"]["version"],
+            )
+            entries.append(
+                {
+                    "descriptor": descriptor,
+                    "descriptor_digest": digest,
+                    "bound": key in self._bindings,
+                }
+            )
+        return {
+            "schema_version": "kora.runtime.registry-list/v0alpha1",
+            "runtimes": entries,
+            "activity": {
+                "execution_performed": False,
+                "network_accessed": False,
+                "model_inference_performed": False,
+                "gpu_execution_performed": False,
+            },
+        }
+
+    @property
+    def available_capabilities(self) -> frozenset[str]:
+        """Return capabilities from verified, bound, offline runtimes."""
+
+        capabilities: set[str] = set()
+        for path in self._entry_paths():
+            descriptor, _ = self._verify_entry(path)
+            key = (
+                descriptor["runtime"]["id"],
+                descriptor["runtime"]["version"],
+            )
+            execution = descriptor["execution"]
+            if (
+                key in self._bindings
+                and not execution["network_access"]
+                and not execution["model_inference"]
+                and not execution["gpu_execution"]
+            ):
+                capabilities.update(descriptor["capabilities"])
+        return frozenset(capabilities)
+
+    def resolve(
+        self,
+        required_capabilities: Iterable[str],
+        *,
+        protocol_version: str,
+        task_kinds: Iterable[str],
+        allow_network: bool = False,
+        allow_model: bool = False,
+        allow_gpu: bool = False,
+    ) -> ResolvedRuntime:
+        """Resolve one compatible runtime or reject ambiguous selection."""
+
+        required = frozenset(required_capabilities)
+        kinds = frozenset(task_kinds)
+        verified: list[tuple[dict[str, Any], str]] = [
+            self._verify_entry(path) for path in self._entry_paths()
+        ]
+        capable = [
+            item for item in verified if required <= frozenset(item[0]["capabilities"])
+        ]
+        if not capable:
+            raise CapabilityRegistryError(
+                "missing_capability_runtime",
+                "no registered runtime provides every required capability",
+            )
+
+        compatible = []
+        for descriptor, digest in capable:
+            execution = descriptor["execution"]
+            if protocol_version not in descriptor["protocol_versions"]:
+                continue
+            if not kinds <= frozenset(descriptor["task_kinds"]):
+                continue
+            if execution["network_access"] and not allow_network:
+                continue
+            if execution["model_inference"] and not allow_model:
+                continue
+            if execution["gpu_execution"] and not allow_gpu:
+                continue
+            compatible.append((descriptor, digest))
+        if not compatible:
+            raise CapabilityRegistryError(
+                "incompatible_runtime",
+                "registered capability runtimes are incompatible with this execution policy",
+            )
+
+        bound = []
+        for descriptor, digest in compatible:
+            key = (
+                descriptor["runtime"]["id"],
+                descriptor["runtime"]["version"],
+            )
+            if key in self._bindings:
+                bound.append((descriptor, digest, self._bindings[key]))
+        if not bound:
+            raise CapabilityRegistryError(
+                "runtime_unavailable",
+                "compatible runtime descriptors have no trusted local binding",
+            )
+
+        highest = max(item[0]["priority"] for item in bound)
+        selected = [item for item in bound if item[0]["priority"] == highest]
+        if len(selected) != 1:
+            raise CapabilityRegistryError(
+                "ambiguous_runtime",
+                "multiple compatible runtimes have the same highest priority",
+            )
+        descriptor, digest, runtime = selected[0]
+        return ResolvedRuntime(
+            descriptor=descriptor,
+            descriptor_digest=digest,
+            runtime=runtime,
+        )
+
+    def _entry_paths(self) -> list[Path]:
+        entries: list[Path] = []
+        for runtime_root in sorted(self.root.iterdir()):
+            if runtime_root.name.startswith("."):
+                raise CapabilityRegistryError(
+                    "runtime_integrity_mismatch",
+                    "runtime registry contains an incomplete entry",
+                )
+            if (
+                runtime_root.is_symlink()
+                or not runtime_root.is_dir()
+                or not RUNTIME_ID_PATTERN.fullmatch(runtime_root.name)
+            ):
+                raise CapabilityRegistryError(
+                    "runtime_integrity_mismatch",
+                    "runtime registry contains an unsafe runtime directory",
+                )
+            versions = sorted(runtime_root.iterdir())
+            if not versions:
+                raise CapabilityRegistryError(
+                    "runtime_integrity_mismatch",
+                    "runtime registry contains an incomplete runtime directory",
+                )
+            for entry in versions:
+                if (
+                    entry.name.startswith(".")
+                    or entry.is_symlink()
+                    or not entry.is_dir()
+                    or not RUNTIME_VERSION_PATTERN.fullmatch(entry.name)
+                ):
+                    raise CapabilityRegistryError(
+                        "runtime_integrity_mismatch",
+                        "runtime registry contains an unsafe version directory",
+                    )
+                entries.append(entry)
+        return entries
+
+    def _entry_path(self, runtime_id: str, version: str) -> Path:
+        if not RUNTIME_ID_PATTERN.fullmatch(
+            runtime_id
+        ) or not RUNTIME_VERSION_PATTERN.fullmatch(version):
+            raise CapabilityRegistryError(
+                "invalid_runtime_descriptor",
+                "runtime identity is invalid",
+            )
+        runtime_root = self.root / runtime_id
+        if runtime_root.exists() and (
+            runtime_root.is_symlink() or not runtime_root.is_dir()
+        ):
+            raise CapabilityRegistryError(
+                "runtime_integrity_mismatch",
+                "runtime registry identity directory is unsafe",
+            )
+        target = runtime_root / version
+        resolved = target.resolve(strict=False)
+        if not resolved.is_relative_to(self.root) or target.is_symlink():
+            raise CapabilityRegistryError(
+                "runtime_integrity_mismatch",
+                "runtime registry entry escaped its root",
+            )
+        return resolved
+
+    def _verify_entry(self, path: Path) -> tuple[dict[str, Any], str]:
+        if (
+            path.is_symlink()
+            or not path.is_dir()
+            or not path.resolve().is_relative_to(self.root)
+        ):
+            raise CapabilityRegistryError(
+                "runtime_integrity_mismatch",
+                "runtime registry entry is unsafe",
+            )
+        children = sorted(child.name for child in path.iterdir())
+        if children != ["registration.json", "runtime.json"]:
+            raise CapabilityRegistryError(
+                "runtime_integrity_mismatch",
+                "runtime registry entry contains unexpected files",
+            )
+        descriptor_path = path / "runtime.json"
+        receipt_path = path / "registration.json"
+        if descriptor_path.is_symlink() or receipt_path.is_symlink():
+            raise CapabilityRegistryError(
+                "runtime_integrity_mismatch",
+                "runtime registry files must not be symbolic links",
+            )
+        try:
+            descriptor = load_json_object(descriptor_path)
+            receipt = load_json_object(receipt_path)
+            descriptor_bytes = descriptor_path.read_bytes()
+            receipt_bytes = receipt_path.read_bytes()
+            validate_contract_instance(RUNTIME_DESCRIPTOR_SCHEMA, descriptor)
+        except (OSError, TypeError, ValueError, SolutionContractError) as exc:
+            raise CapabilityRegistryError(
+                "runtime_integrity_mismatch",
+                "runtime registry entry failed validation",
+            ) from exc
+        identity = descriptor["runtime"]
+        expected_identity = {"id": path.parent.name, "version": path.name}
+        digest = _descriptor_digest(descriptor)
+        if (
+            identity != expected_identity
+            or descriptor_bytes != canonical_json_bytes(descriptor)
+            or receipt_bytes != canonical_json_bytes(receipt)
+            or receipt.get("schema_version") != "kora.runtime.registration/v0alpha1"
+            or receipt.get("runtime") != expected_identity
+            or receipt.get("descriptor_digest") != digest
+            or not _is_utc_timestamp(receipt.get("registered_at"))
+        ):
+            raise CapabilityRegistryError(
+                "runtime_integrity_mismatch",
+                "runtime descriptor or registration receipt was modified",
+            )
+        return descriptor, digest
+
+
+__all__ = [
+    "MAX_REGISTERED_RUNTIMES",
+    "CapabilityRegistryError",
+    "CapabilityRuntime",
+    "LocalCapabilityRegistry",
+    "ResolvedRuntime",
+]

--- a/kora/solution/schemas/result-envelope.schema.json
+++ b/kora/solution/schemas/result-envelope.schema.json
@@ -8,6 +8,7 @@
     "schema_version",
     "protocol_version",
     "solution",
+    "runtime",
     "run_id",
     "lifecycle_state",
     "validation",
@@ -21,6 +22,7 @@
     "schema_version": {"const": "kora.solution.result/v0alpha1"},
     "protocol_version": {"const": "kora.dev/v0alpha1"},
     "solution": {"$ref": "#/$defs/solutionIdentity"},
+    "runtime": {"oneOf": [{"$ref": "#/$defs/runtimeIdentity"}, {"type": "null"}]},
     "run_id": {"$ref": "#/$defs/runId"},
     "lifecycle_state": {"enum": ["succeeded", "failed"]},
     "validation": {"$ref": "#/$defs/finalValidation"},
@@ -38,6 +40,7 @@
       },
       "then": {
         "properties": {
+          "runtime": {"$ref": "#/$defs/runtimeIdentity"},
           "validation": {
             "properties": {
               "input": {"const": "valid"},
@@ -78,6 +81,22 @@
         }
       }
     },
+    "runtimeIdentity": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "version", "descriptor_digest"],
+      "properties": {
+        "id": {
+          "type": "string",
+          "pattern": "^[a-z0-9]+(?:[._-][a-z0-9]+)*$"
+        },
+        "version": {
+          "type": "string",
+          "pattern": "^(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)(?:-[0-9A-Za-z.-]+)?$"
+        },
+        "descriptor_digest": {"type": "string", "pattern": "^[a-f0-9]{64}$"}
+      }
+    },
     "runId": {
       "type": "string",
       "pattern": "^[a-f0-9]{32}$"
@@ -97,13 +116,18 @@
     },
     "errorCode": {
       "enum": [
+        "ambiguous_runtime",
         "approval_required",
         "deliberate_failure",
+        "incompatible_runtime",
         "input_validation_failed",
         "integrity_mismatch",
+        "missing_capability_runtime",
         "output_validation_failed",
         "package_validation_failed",
-        "runtime_failure"
+        "runtime_failure",
+        "runtime_integrity_mismatch",
+        "runtime_unavailable"
       ]
     },
     "error": {

--- a/kora/solution/schemas/runtime-descriptor.schema.json
+++ b/kora/solution/schemas/runtime-descriptor.schema.json
@@ -1,0 +1,78 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://kora.dev/schemas/runtime-descriptor-v0alpha1.json",
+  "title": "KORA Capability Runtime Descriptor v0alpha1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "runtime",
+    "protocol_versions",
+    "capabilities",
+    "task_kinds",
+    "priority",
+    "execution"
+  ],
+  "properties": {
+    "schema_version": {"const": "kora.runtime.descriptor/v0alpha1"},
+    "runtime": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "version"],
+      "properties": {
+        "id": {
+          "type": "string",
+          "pattern": "^[a-z0-9]+(?:[._-][a-z0-9]+)*$"
+        },
+        "version": {
+          "type": "string",
+          "pattern": "^(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)(?:-[0-9A-Za-z.-]+)?$"
+        }
+      }
+    },
+    "protocol_versions": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": {
+        "type": "string",
+        "pattern": "^kora\\.dev/v[0-9]+(?:alpha|beta)?[0-9]+$"
+      }
+    },
+    "capabilities": {
+      "type": "array",
+      "minItems": 1,
+      "maxItems": 128,
+      "uniqueItems": true,
+      "items": {
+        "type": "string",
+        "pattern": "^[a-z0-9]+(?:[._-][a-z0-9]+)*$"
+      }
+    },
+    "task_kinds": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": {"enum": ["det", "llm"]}
+    },
+    "priority": {
+      "type": "integer",
+      "minimum": -1000,
+      "maximum": 1000
+    },
+    "execution": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "network_access",
+        "model_inference",
+        "gpu_execution"
+      ],
+      "properties": {
+        "network_access": {"type": "boolean"},
+        "model_inference": {"type": "boolean"},
+        "gpu_execution": {"type": "boolean"}
+      }
+    }
+  }
+}

--- a/kora/solution/schemas/runtime-status.schema.json
+++ b/kora/solution/schemas/runtime-status.schema.json
@@ -8,6 +8,7 @@
     "schema_version",
     "protocol_version",
     "solution",
+    "runtime",
     "run_id",
     "lifecycle_state",
     "validation",
@@ -35,6 +36,27 @@
         }
       }
     },
+    "runtime": {
+      "oneOf": [
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["id", "version", "descriptor_digest"],
+          "properties": {
+            "id": {
+              "type": "string",
+              "pattern": "^[a-z0-9]+(?:[._-][a-z0-9]+)*$"
+            },
+            "version": {
+              "type": "string",
+              "pattern": "^(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)(?:-[0-9A-Za-z.-]+)?$"
+            },
+            "descriptor_digest": {"type": "string", "pattern": "^[a-f0-9]{64}$"}
+          }
+        },
+        {"type": "null"}
+      ]
+    },
     "run_id": {"type": "string", "pattern": "^[a-f0-9]{32}$"},
     "lifecycle_state": {
       "enum": ["created", "validating", "running", "succeeded", "failed"]
@@ -61,13 +83,18 @@
           "properties": {
             "code": {
               "enum": [
+                "ambiguous_runtime",
                 "approval_required",
                 "deliberate_failure",
+                "incompatible_runtime",
                 "input_validation_failed",
                 "integrity_mismatch",
+                "missing_capability_runtime",
                 "output_validation_failed",
                 "package_validation_failed",
-                "runtime_failure"
+                "runtime_failure",
+                "runtime_integrity_mismatch",
+                "runtime_unavailable"
               ]
             },
             "detail": {"type": "string", "minLength": 1, "maxLength": 512}

--- a/tests/test_solution_cli.py
+++ b/tests/test_solution_cli.py
@@ -38,3 +38,22 @@ def test_solution_validate_cli_reports_missing_capability(capsys) -> None:
     payload = json.loads(captured.err)
     assert payload["status"] == "invalid"
     assert payload["issues"][0]["code"] == "missing_capability"
+
+
+def test_solution_runtimes_cli_lists_bound_offline_runtime(
+    tmp_path: Path,
+    capsys,
+) -> None:
+    exit_code = main(
+        ["solution", "runtimes", "--store", str(tmp_path / "host"), "--json"]
+    )
+    captured = capsys.readouterr()
+
+    assert exit_code == 0
+    payload = json.loads(captured.out)
+    assert payload["runtimes"][0]["descriptor"]["runtime"] == {
+        "id": "kora.reference",
+        "version": "0.1.0",
+    }
+    assert payload["runtimes"][0]["bound"] is True
+    assert payload["activity"]["execution_performed"] is False

--- a/tests/test_solution_runtime_registry.py
+++ b/tests/test_solution_runtime_registry.py
@@ -1,0 +1,225 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from kora.solution import (
+    RESULT_ENVELOPE_SCHEMA,
+    RUNTIME_STATUS_SCHEMA,
+    CapabilityRegistryError,
+    LocalCapabilityRegistry,
+    LocalSolutionHost,
+    ReferenceRuntime,
+    SolutionHostError,
+    validate_contract_instance,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+HELLO_SOLUTION = REPO_ROOT / "examples" / "solutions" / "hello-solution"
+DOCUMENT_SOLUTION = REPO_ROOT / "examples" / "solutions" / "document-transform-fixture"
+
+
+def _resolve(registry: LocalCapabilityRegistry, capabilities: set[str]):
+    return registry.resolve(
+        capabilities,
+        protocol_version="kora.dev/v0alpha1",
+        task_kinds={"det"},
+    )
+
+
+def test_registration_list_and_priority_resolution_are_deterministic(
+    tmp_path: Path,
+) -> None:
+    class LowerPriorityRuntime(ReferenceRuntime):
+        runtime_id = "fixture.lower"
+        priority = 10
+
+    class HigherPriorityRuntime(ReferenceRuntime):
+        runtime_id = "fixture.higher"
+        priority = 20
+
+    registry = LocalCapabilityRegistry(tmp_path / "runtimes")
+    lower = registry.register(LowerPriorityRuntime())
+    higher = registry.register(HigherPriorityRuntime())
+    listing = registry.list()
+    selected = _resolve(registry, {"det.echo"})
+
+    assert (
+        lower["activity"]
+        == higher["activity"]
+        == {
+            "execution_performed": False,
+            "network_accessed": False,
+            "model_inference_performed": False,
+            "gpu_execution_performed": False,
+        }
+    )
+    assert [entry["descriptor"]["runtime"]["id"] for entry in listing["runtimes"]] == [
+        "fixture.higher",
+        "fixture.lower",
+    ]
+    assert selected.identity["id"] == "fixture.higher"
+    assert len(selected.identity["descriptor_digest"]) == 64
+
+
+def test_persisted_descriptor_without_trusted_binding_cannot_execute(
+    tmp_path: Path,
+) -> None:
+    root = tmp_path / "runtimes"
+    LocalCapabilityRegistry(root).register(ReferenceRuntime())
+    reopened = LocalCapabilityRegistry(root)
+
+    listing = reopened.list()
+    assert listing["runtimes"][0]["bound"] is False
+
+    with pytest.raises(CapabilityRegistryError) as captured:
+        _resolve(reopened, {"det.echo"})
+
+    assert captured.value.code == "runtime_unavailable"
+
+
+def test_equal_highest_priority_is_rejected_as_ambiguous(tmp_path: Path) -> None:
+    class FirstRuntime(ReferenceRuntime):
+        runtime_id = "fixture.first"
+
+    class SecondRuntime(ReferenceRuntime):
+        runtime_id = "fixture.second"
+
+    registry = LocalCapabilityRegistry(tmp_path / "runtimes")
+    registry.register(FirstRuntime())
+    registry.register(SecondRuntime())
+
+    with pytest.raises(CapabilityRegistryError) as captured:
+        _resolve(registry, {"det.echo"})
+
+    assert captured.value.code == "ambiguous_runtime"
+
+
+def test_capabilities_are_not_split_across_multiple_runtimes(tmp_path: Path) -> None:
+    class EchoRuntime(ReferenceRuntime):
+        runtime_id = "fixture.echo"
+
+        @property
+        def capabilities(self) -> frozenset[str]:
+            return frozenset({"det.echo"})
+
+    class NormalizeRuntime(ReferenceRuntime):
+        runtime_id = "fixture.normalize"
+
+        @property
+        def capabilities(self) -> frozenset[str]:
+            return frozenset({"text.normalize"})
+
+    registry = LocalCapabilityRegistry(tmp_path / "runtimes")
+    registry.register(EchoRuntime())
+    registry.register(NormalizeRuntime())
+
+    with pytest.raises(CapabilityRegistryError) as captured:
+        _resolve(registry, {"det.echo", "text.normalize"})
+
+    assert captured.value.code == "missing_capability_runtime"
+
+
+def test_runtime_execution_policy_is_enforced_before_selection(tmp_path: Path) -> None:
+    class NetworkRuntime(ReferenceRuntime):
+        runtime_id = "fixture.network"
+
+        @property
+        def descriptor(self) -> dict[str, Any]:
+            descriptor = super().descriptor
+            descriptor["execution"]["network_access"] = True
+            return descriptor
+
+    registry = LocalCapabilityRegistry(tmp_path / "runtimes")
+    registry.register(NetworkRuntime())
+
+    with pytest.raises(CapabilityRegistryError) as captured:
+        _resolve(registry, {"det.echo"})
+
+    assert captured.value.code == "incompatible_runtime"
+
+
+def test_descriptor_binding_mismatch_and_registry_tampering_fail_closed(
+    tmp_path: Path,
+) -> None:
+    class MismatchedRuntime(ReferenceRuntime):
+        runtime_id = "fixture.mismatch"
+
+        @property
+        def descriptor(self) -> dict[str, Any]:
+            descriptor = super().descriptor
+            descriptor["capabilities"] = ["det.echo"]
+            return descriptor
+
+    registry = LocalCapabilityRegistry(tmp_path / "mismatch")
+    with pytest.raises(CapabilityRegistryError) as mismatch:
+        registry.register(MismatchedRuntime())
+    assert mismatch.value.code == "invalid_runtime_binding"
+
+    verified = LocalCapabilityRegistry(tmp_path / "verified")
+    verified.register(ReferenceRuntime())
+    descriptor_path = (
+        tmp_path / "verified" / "kora.reference" / "0.1.0" / "runtime.json"
+    )
+    payload = json.loads(descriptor_path.read_text(encoding="utf-8"))
+    payload["priority"] = 999
+    descriptor_path.write_text(json.dumps(payload), encoding="utf-8")
+
+    with pytest.raises(CapabilityRegistryError) as tampered:
+        verified.list()
+    assert tampered.value.code == "runtime_integrity_mismatch"
+
+
+def test_host_records_selected_runtime_for_both_reference_solutions(
+    tmp_path: Path,
+) -> None:
+    host = LocalSolutionHost(tmp_path / "host")
+    hello_receipt = host.install(HELLO_SOLUTION)
+    document_receipt = host.install(DOCUMENT_SOLUTION)
+    hello = host.run("example.hello", {"message": "Hello"})
+    document = host.run("example.document-transform", {"text": "  A   B  "})
+
+    expected = hello_receipt["runtime_resolution"]
+    assert document_receipt["runtime_resolution"] == expected
+    assert hello["runtime"] == document["runtime"] == expected
+    assert host.status(hello["run_id"])["runtime"] == expected
+    validate_contract_instance(RUNTIME_STATUS_SCHEMA, host.status(document["run_id"]))
+    validate_contract_instance(RESULT_ENVELOPE_SCHEMA, document)
+    assert hello["activity"]["network_accessed"] is False
+    assert hello["activity"]["model_inference_performed"] is False
+    assert hello["activity"]["gpu_execution_performed"] is False
+
+
+def test_registry_tampering_after_install_creates_valid_failed_result(
+    tmp_path: Path,
+) -> None:
+    host = LocalSolutionHost(tmp_path / "host")
+    host.install(HELLO_SOLUTION)
+    descriptor_path = host.runtimes_root / "kora.reference" / "0.1.0" / "runtime.json"
+    descriptor_path.write_bytes(descriptor_path.read_bytes() + b"\n")
+
+    result = host.run("example.hello", {"message": "Hello"})
+
+    assert result["lifecycle_state"] == "failed"
+    assert result["runtime"] is None
+    assert result["error"]["code"] == "runtime_integrity_mismatch"
+    assert result["activity"]["execution_performed"] is False
+    validate_contract_instance(RESULT_ENVELOPE_SCHEMA, result)
+
+
+def test_host_rejects_ambiguous_runtime_before_install(tmp_path: Path) -> None:
+    class AlternateRuntime(ReferenceRuntime):
+        runtime_id = "fixture.alternate"
+
+    host = LocalSolutionHost(
+        tmp_path / "host",
+        runtimes=(ReferenceRuntime(), AlternateRuntime()),
+    )
+
+    with pytest.raises(SolutionHostError) as captured:
+        host.install(HELLO_SOLUTION)
+
+    assert captured.value.code == "ambiguous_runtime"


### PR DESCRIPTION
## Summary

- add an integrity-checked local capability runtime registry to the bounded Solution Host
- validate machine-readable runtime descriptors and require matching trusted in-process bindings
- resolve one compatible runtime deterministically by protocol, task kind, capabilities, execution policy, and unique highest priority
- record selected runtime identity and descriptor digest in install, status, and result evidence
- add `kora solution runtimes` plus conformance coverage for ambiguity, unavailable bindings, capability splitting, policy filtering, and tampering

## Validation

- focused Solution validator/Host/registry/CLI tests: 36 passed
- full regression: 640 passed
- source-install readiness: 6/6 passed
- installed non-editable CLI smoke: passed
- offline release smoke: passed
- Ruff, compileall, Markdown links, and diff checks: passed
- added-line private-path, credential, non-ASCII, control/bidi, and new-symlink scans: zero findings

## Boundaries

- trusted in-process bindings only; no dynamic code loading
- one runtime must satisfy all required capabilities; no cross-runtime composition
- deterministic offline reference execution only
- no provider, model, network, GPU, production, release, marketplace, or commercial-Solution work
- no public claim expansion
