### PR TITLE
Add bounded three-system benchmark execution harness

### DIFF
--- a/docs/benchmark-three-system-execution.md
+++ b/docs/benchmark-three-system-execution.md
@@ -1,0 +1,118 @@
+# Three-system execution harness (experimental v1)
+
+This opt-in harness connects fixed benchmark workers; it does not register remote or
+model runtimes in the offline Solution Host. Existing false-only activity contracts
+remain unchanged. Business-specific arithmetic/classification fixtures live in
+`kora.benchmarks`, outside Core. This is not a general remote execution service.
+
+## Topology and responsibilities
+
+| System | Deterministic fixture | Inference | Control |
+| --- | --- | --- | --- |
+| Single machine | Local worker | Persistent local model server | Explicit benchmark node dispatch |
+| Two-machine cluster | Second worker | First worker's persistent model server | Fixed task distribution |
+| Native baseline | Common client arithmetic | Direct native model endpoint | No KORA routing/reuse/deflection |
+
+A D-only native-baseline result is labelled **h100-client-only**. It is not a GPU or
+server benchmark. M-only does not exercise both cluster workers. Only a successful
+W run with two distinct worker identities sets `cluster_cooperation_observed`.
+Worker identity is an operator declaration authenticated by the shared secret and
+SSH host trust, not hardware attestation. Capture separate host/process evidence.
+No model sharding, memory pooling or H100 parity is claimed.
+
+## Start a worker
+
+Install the repository using Python 3.10 or newer. Generate a random secret with at
+least 32 characters and deliver it privately to the trusted workers. Set
+`KORA_BENCHMARK_TOKEN` without placing its value in command history or public files.
+
+Worker configuration:
+
+```json
+{
+  "worker_id": "worker-b",
+  "port": 9182
+}
+```
+
+Run `python -m kora.benchmarks.worker --config worker.json`.
+A worker always binds 127.0.0.1. For remote access, establish a verified SSH tunnel,
+for example `ssh -N -L 127.0.0.1:9282:127.0.0.1:9182 trusted-worker`.
+Do not expose the worker port directly to a LAN or the Internet.
+
+To enable inference, add a `backend` object with `url`, `model`, `generation`,
+`identity`, and optionally `timeout` (seconds, default 120), `token`, or `token_env`.
+Prefer `token_env` so credentials stay out of configuration files.
+The endpoint must be loopback or an SSH tunnel. The separately launched persistent
+model server owns model loading; this worker never reloads a model per request.
+Record server PID, startup-to-ready time and artifact hashes separately.
+Worker health reports its own uptime and capabilities, not model readiness.
+The adapter checks the served model ID before each inference. This is not sufficient
+to prove weights, tokenizer or template; verify those artifacts before measurement.
+No automatic model substitution or download occurs in this harness.
+
+## Request, status and retries
+
+`GET /health` and `POST /jobs` require Bearer authentication.
+Requests have exactly `schema_version: kora.benchmark.worker/v1`, `boot_id`,
+`job_id`, `operation`, `input`, and SHA-256 `input_hash`.
+Hash encoding is sorted compact UTF-8 JSON with non-ASCII preserved and no NaN.
+
+Limits: 64 KiB request/response read, eight HTTP handler threads, one active operation,
+1024 retained job outcomes per worker incarnation. Socket/header reads time out
+after five seconds. Model socket inactivity timeout defaults to 120 seconds; this is not a process-level
+absolute execution deadline.
+Only fixed arithmetic and configured model operations exist; callers cannot submit
+commands, endpoint URLs, files or arbitrary capabilities.
+
+Same ID + identical request returns the original outcome with
+`duplicate_delivery: true`; it does not rerun inference.
+Same ID + different request fails 409. An in-flight duplicate fails 409.
+A full ledger fails 503 without evicting deduplication records.
+After worker restart, old `boot_id` fails 409. Retained outcomes are in memory,
+not crash-durable; do not retry with a fresh ID after an uncertain timeout.
+Exactly-once execution across process failure is not claimed.
+
+A failed model HTTP call can leave native inference running. The worker retains
+`unknown-or-not-started` rather than falsely recording that no computation happened.
+No backend cancellation or automatic retry is promised. Resolve native server health
+before restarting the worker. Model failures quarantine new model jobs with
+\`model-recovery-required\`; deterministic operations remain available. Only successful completions with engine usage fields
+increment `model_calls_completed`; unknown failures remain explicitly failed.
+Duplicate-delivery responses refer to original execution timing, not a new execution.
+
+## Three-system CLI
+
+`python -m kora.benchmarks.three_system --config systems.json --fixtures workloads.json --output new-run-directory --scenario W --repetitions 5`
+
+Configuration contains `mp`, `cluster`, and `h100`.
+The first two contain `token_env`, `model_worker`, `deterministic_worker`, and
+`identity`. Worker references contain `url` and `worker_id`.
+H100 contains `backend` as above and `identity`; it does not run a KORA worker.
+Use the pinned comparison plan in `examples/benchmarks/three-environment/`.
+The CLI does not provision or stop an existing native server.
+
+Outputs:
+- `events.jsonl`: `kora.benchmark.event/v1`, per-run sequence, start/node/finish events.
+- `results.jsonl`: `kora.benchmark.execution/v1`, input hash, configuration,
+  node evidence, actual engine tokens, fixture quality and controller elapsed time.
+- TSV terminal table. Exit status is nonzero when any result fails its quality gate.
+
+Runs are sequential and concurrency is one. Controller elapsed time includes
+transport/health calls; node time and load time are separate. No clock synchronization
+is assumed. Events indicate lifecycle; this version does not stream individual tokens.
+TTFT, GPU memory, energy and prefill/decode speed are not inferred from total time.
+Warmups must be executed into a separate output directory before measured repetitions.
+Unknown cases fail before creating output. Failed rows remain in the result set.
+
+Quality parses the whole response as JSON, requires exactly `category`, and checks the
+frozen expected fixture output. No prose stripping or semantic judging is performed.
+These fixtures do not establish general model quality. D, M and W are supported;
+bounded exact reuse and a live comparison UI belong to later work.
+
+## Validation boundary
+
+Unit tests use mocked model responses explicitly; they prove transport/state handling,
+not inference performance. Real measurements require verified artifacts and separate
+live evidence. A model mismatch or unavailable H100 slot is a blocker, not a successful
+three-system benchmark. Preserve active native services and obtain a benchmark slot.

--- a/docs/reports/task024-three-system-execution.md
+++ b/docs/reports/task024-three-system-execution.md
@@ -1,7 +1,8 @@
 # Task 024 — Three-system execution harness
 
 Classification: **needs-cto-review**. The implementation is reviewable; the
-three-system live acceptance gate remains **blocked on native model availability**.
+three-system live acceptance gate has **passed the bounded M/W fixtures** after an
+authorized native service window and verified restoration.
 Base: `88540fd11a0f5eacc965a5c9872d3d659fd3edc7`.
 An open PR is not merge approval or sprint completion.
 
@@ -21,7 +22,7 @@ No workflow-specific code is added to Core.
 
 ## Validation
 
-- Full regression during implementation: 723 passed.
+- Full regression after the operations addition: 725 passed (including two lease tests).
 - Focused transport/state/integration tests: 18 passed.
 - Isolated non-editable source installation: passed.
 - Offline release smoke: passed; no release performed.
@@ -31,14 +32,14 @@ No workflow-specific code is added to Core.
   model mismatch, missing usage, invalid outputs and distinct cluster workers.
 - Mocked model tests are labelled as such; live evidence is separate.
 
-## Live acceptance, bounded synthetic fixtures
+## Initial local acceptance (historical, before native service window)
 
 Pinned Qwen3-30B-A3B Q4_K_M file and upstream tokenizer hashes verified.
 The GGUF embedded template differs from the pinned upstream template.
 Both local servers explicitly use upstream template SHA-256
 `a55ee1b1660128b7098723e0abcd92caa0788061051c62d51cbe87d9cf1974d8`.
 The original GGUF file remains unchanged. This does not prove cross-engine tokenizer
-equivalence; the controlled native comparison still needs validation.
+equivalence. Subsequent bounded native acceptance is recorded below.
 
 | Scenario | Single machine | Two-worker set | Native endpoint |
 | --- | --- | --- | --- |
@@ -58,13 +59,11 @@ client and transport overhead; the short classification fixture is not a heavy
 generation throughput benchmark. No H100 parity, general quality, cost, energy,
 low-memory optimization gain or broad workload claim follows from these results.
 
-## Native endpoint blocker
+## Initial native endpoint blocker (resolved)
 
-The existing native endpoint serves a different model and occupies most GPU memory.
-The adapter fails before generation rather than substituting that model.
-Its service remains running. A dedicated window is required to run the pinned
-native model, verify template/generation/cache settings, warm up, collect all
-outcomes and restore the original service. No service stop is included in this change.
+The original endpoint served a different model and occupied most GPU memory.
+The adapter rejected it before generation. This initial blocker was resolved by
+the subsequently authorized temporary window and verified restoration below.
 
 ## Review and scope boundaries
 
@@ -77,12 +76,48 @@ Allowed changes: new benchmark modules/tests, example configuration and bounded
 documentation. No existing Solution/Core implementation is altered.
 No credentials, private endpoint addresses, personal data, model weights or raw
 host logs are committed. Local model execution and trusted-network testing were
-authorized for this task. No external provider inference, native-service stop,
-merge, release, repository settings or public performance expansion occurred.
+authorized for this task, including the temporary native-service handover.
+No external provider inference, merge, release, repository settings or public
+performance expansion occurred.
 
 ## Next gate
 
-Review the code and its experimental contract. Complete matched native execution
-during an explicitly allocated service window; then rerun acceptance and update
-the sprint status. UI, exact reuse and broader comparative evidence remain later
+Review the code, shared-resource helper and bounded native acceptance. The native
+execution gate is complete; merge remains separately unapproved. UI, exact reuse and broader comparative evidence remain later
 work. See [execution guide](../benchmark-three-system-execution.md).
+
+
+## Authorized native acceptance and shared usage board
+
+The native endpoint was run in an explicit temporary service window. Existing
+service requests were checked before handover. Systemd time limits and an exit
+restoration action protected the borrowed service. Initial launches exposed missing
+CUDA/ninja PATH entries; the already-installed runtime paths were applied to the
+new process only. A readiness preflight also rejected an attempt while the original
+service was still restarting. Those failures are retained, not hidden.
+
+Six cases, three warmups per case per local/native set (54/54 passed),
+then five repetitions per case:
+
+| Scenario | Single machine | Two-worker set | Native H100 |
+| --- | --- | --- | --- |
+| M | 30/30 exact fixture passes | 30/30 | 30/30 |
+| W | 30/30 exact fixture passes | 30/30, both workers observed | 30/30 |
+
+Each set/scenario has 30 actual model completions and 300 actual output tokens.
+Input hashes agree. The original service was restored and its health/model verified.
+The resource lease was released after verification. Native BF16 and local Q4_K_M
+remain different configurations, so this is not a hardware-only comparison.
+
+Median controller milliseconds: M single361.71 / worker set472.52 / native218.14;
+W single350.65 / cluster520.70 / native280.83. These very short, synthetic
+classification fixtures establish execution connectivity and exact fixture output,
+not heavy generation throughput, broad quality, H100 parity or cost advantage.
+
+User-authorized operations addition: standalone scripts/gpu_lease.py, focused tests
+and docs/shared-gpu-leases.md. Atomic cooperative leases record project, owner,
+purpose, expected end, heartbeat, actual observed memory/PID/cgroup and elapsed
+reservation time. Conflicts and stale leases fail closed; the utility never kills
+another workload. Existing shared services can be labelled separately from leases.
+This remains a cooperative convention, not compulsory GPU isolation or a scheduler.
+No credentials, raw private host logs or project-specific service controls are public.

--- a/docs/reports/task024-three-system-execution.md
+++ b/docs/reports/task024-three-system-execution.md
@@ -1,0 +1,88 @@
+# Task 024 — Three-system execution harness
+
+Classification: **needs-cto-review**. The implementation is reviewable; the
+three-system live acceptance gate remains **blocked on native model availability**.
+Base: `88540fd11a0f5eacc965a5c9872d3d659fd3edc7`.
+An open PR is not merge approval or sprint completion.
+
+## Problem and change
+
+The offline node runtime cannot truthfully describe real inference or remote worker
+activity. Add an opt-in benchmark harness with independent versioned worker, event
+and execution records. The existing offline Solution contracts are unchanged.
+A fixed benchmark client dispatches arithmetic and model nodes to authenticated
+loopback workers over SSH tunnels. Inference uses persistent local servers.
+The native comparison endpoint is contacted directly, without a KORA worker or
+KORA routing/reuse/deflection on that server.
+
+This is a bounded harness, not general Host registry integration, durable execution,
+model sharding, pooled memory, exact reuse or a production network service.
+No workflow-specific code is added to Core.
+
+## Validation
+
+- Full regression during implementation: 723 passed.
+- Focused transport/state/integration tests: 18 passed.
+- Isolated non-editable source installation: passed.
+- Offline release smoke: passed; no release performed.
+- Ruff: passed after import, exception type and formatting repairs.
+- Negative coverage: authentication, frame/body bounds, changed request IDs, in-flight
+  duplicates, incarnation mismatch, full ledger, failure retention/quarantine,
+  model mismatch, missing usage, invalid outputs and distinct cluster workers.
+- Mocked model tests are labelled as such; live evidence is separate.
+
+## Live acceptance, bounded synthetic fixtures
+
+Pinned Qwen3-30B-A3B Q4_K_M file and upstream tokenizer hashes verified.
+The GGUF embedded template differs from the pinned upstream template.
+Both local servers explicitly use upstream template SHA-256
+`a55ee1b1660128b7098723e0abcd92caa0788061051c62d51cbe87d9cf1974d8`.
+The original GGUF file remains unchanged. This does not prove cross-engine tokenizer
+equivalence; the controlled native comparison still needs validation.
+
+| Scenario | Single machine | Two-worker set | Native endpoint |
+| --- | --- | --- | --- |
+| D, six cases | 6/6, zero model completions | 6/6, deterministic worker only | Client-only arithmetic; no GPU measurement |
+| M, six cases × five | 30/30 fixture quality | 30/30 fixture quality, model worker only | 30 model-mismatch failures |
+| W, six cases × five | 30/30 fixture quality | 30/30, both workers observed | 30 model-mismatch failures |
+
+Each successful M/W row reports one actual completion and ten engine-reported output
+tokens. Input hashes agree across systems per case. Three ready warmups per case
+were retained separately for each local set. Two earlier single-machine warmup
+connection failures occurred before worker readiness; they remain in the private
+diagnostic record. Launch procedures were corrected to wait for authenticated health.
+
+The two-worker topology has a common client coordinating both worker machines.
+It is not a direct peer-to-peer Ethernet throughput measurement. Timings include
+client and transport overhead; the short classification fixture is not a heavy
+generation throughput benchmark. No H100 parity, general quality, cost, energy,
+low-memory optimization gain or broad workload claim follows from these results.
+
+## Native endpoint blocker
+
+The existing native endpoint serves a different model and occupies most GPU memory.
+The adapter fails before generation rather than substituting that model.
+Its service remains running. A dedicated window is required to run the pinned
+native model, verify template/generation/cache settings, warm up, collect all
+outcomes and restore the original service. No service stop is included in this change.
+
+## Review and scope boundaries
+
+Implementation/review passes: initial protocol, transport hardening, live acceptance,
+final lint/report. Repairs included explicit native-client-only labelling, failed
+quality token accounting, worker readiness, upstream template selection, relocated
+dynamic-library lookup, model-failure quarantine and malformed response handling.
+
+Allowed changes: new benchmark modules/tests, example configuration and bounded
+documentation. No existing Solution/Core implementation is altered.
+No credentials, private endpoint addresses, personal data, model weights or raw
+host logs are committed. Local model execution and trusted-network testing were
+authorized for this task. No external provider inference, native-service stop,
+merge, release, repository settings or public performance expansion occurred.
+
+## Next gate
+
+Review the code and its experimental contract. Complete matched native execution
+during an explicitly allocated service window; then rerun acceptance and update
+the sprint status. UI, exact reuse and broader comparative evidence remain later
+work. See [execution guide](../benchmark-three-system-execution.md).

--- a/docs/shared-gpu-leases.md
+++ b/docs/shared-gpu-leases.md
@@ -1,0 +1,61 @@
+# Cooperative shared GPU usage board
+
+Use `scripts/gpu_lease.py` as a standalone Linux-host utility. It does not install
+KORA in a native inference server or alter model execution. All projects using the
+shared GPU must agree to consult and acquire the same board before launching work.
+
+Default state directory: `~/krako-resource-control`; override with
+`KRAKO_GPU_STATE`. All cooperating clients must use the same host account/state
+directory. This is not multi-user authentication or OS-level GPU isolation.
+
+## Operations
+
+```sh
+python3 scripts/gpu_lease.py status
+python3 scripts/gpu_lease.py acquire --project example --owner operator \
+  --purpose benchmark --minutes 20 --unit example-benchmark.service
+python3 scripts/gpu_lease.py heartbeat --lease-id ID
+python3 scripts/gpu_lease.py release --lease-id ID
+```
+
+Status reports declared owner/project/purpose, start, expected end, heartbeat and
+overdue state alongside actual GPU memory, utilization, PID and cgroup.
+`STATUS.json` and `STATUS.md` refresh on a status query; check the sample timestamp.
+`active.json` is the current lease, protected by a file lock and atomic replacement.
+`history.jsonl` records acquired, heartbeat and released events with elapsed lease
+duration. Duration includes setup and idle time; it is not measured GPU-hours.
+
+An optional `services.json` maps exact systemd service names to declared project/
+owner labels for existing long-running services. Unknown processes remain visibly
+unregistered. A GPU at zero utilization may still be occupied by a loaded model.
+
+## Conflict and handover rules
+
+- Concurrent acquisitions cannot both succeed.
+- An existing lease blocks acquisition even after its expected end. No automatic
+  stealing, expiry cleanup, process termination or service replacement occurs.
+- GPU processes without a lease also block acquisition.
+- `--handover-service exact.service` admits only observed processes in that exact
+  service cgroup. This flag does not authorize stopping that service.
+- A release requires the matching lease ID and no remaining GPU processes, except
+  the originally declared handover service via `--restored-service exact.service`.
+- The operator must verify restored service health/model before release; the utility
+  checks process ownership, not HTTP application readiness.
+- Lease IDs prevent accidental mismatched release, not malicious use by another
+  person with write access to the same state directory.
+
+Failing GPU observation fails the command. The utility never claims GPU availability
+merely because a lease file is absent. It currently observes NVIDIA compute-process
+records; it is not a comprehensive accounting system for graphics/MIG/multiple GPUs.
+
+## Adoption and limits
+
+Project-root operating instructions should require status, acquisition, recorded
+lease ID, progress heartbeats, owned-process shutdown/restoration, then release.
+Existing processes bypassing the convention are visible but not forcibly stopped.
+All old launchers are not automatically integrated by installing this script.
+
+Notification here means the shared board and project operating records. There are
+no external chat messages, email, queue, dashboard, billing or preemption.
+Tests cover concurrent acquisition, exact cgroup admission, stale-lease refusal,
+mismatched release and release history using an explicitly mocked observation.

--- a/examples/benchmarks/three-environment/systems.example.json
+++ b/examples/benchmarks/three-environment/systems.example.json
@@ -1,0 +1,100 @@
+{
+  "mp": {
+    "token_env": "KORA_BENCHMARK_TOKEN",
+    "identity": {
+      "model_repository": "Qwen/Qwen3-30B-A3B",
+      "model_revision": "ad44e777bcd18fa416d9da3bd8f70d33ebb85d39",
+      "artifact_sha256": "0d003f6662faee786ed5da3e31b29c978de5ae5d275c8794c606a7f3c01aa8f5",
+      "runtime_commit": "4d9176092d00586775af140581bb0b558ddc4389",
+      "quantization": "Q4_K_M",
+      "context_tokens": 4096,
+      "concurrency": 1,
+      "prefix_cache": "disabled",
+      "thinking": false,
+      "tokenizer_sha256": "aeb13307a71acd8fe81861d94ad54ab689df773318809eed3cbe794b4492dae4",
+      "template_source": "pinned-upstream-explicit-file",
+      "verification": "operator-must-verify-before-running",
+      "template_sha256": "a55ee1b1660128b7098723e0abcd92caa0788061051c62d51cbe87d9cf1974d8"
+    },
+    "model_worker": {
+      "url": "http://127.0.0.1:9181",
+      "worker_id": "mp"
+    },
+    "deterministic_worker": {
+      "url": "http://127.0.0.1:9181",
+      "worker_id": "mp"
+    }
+  },
+  "cluster": {
+    "token_env": "KORA_BENCHMARK_TOKEN",
+    "identity": {
+      "model_repository": "Qwen/Qwen3-30B-A3B",
+      "model_revision": "ad44e777bcd18fa416d9da3bd8f70d33ebb85d39",
+      "artifact_sha256": "0d003f6662faee786ed5da3e31b29c978de5ae5d275c8794c606a7f3c01aa8f5",
+      "runtime_commit": "4d9176092d00586775af140581bb0b558ddc4389",
+      "quantization": "Q4_K_M",
+      "context_tokens": 4096,
+      "concurrency": 1,
+      "prefix_cache": "disabled",
+      "thinking": false,
+      "tokenizer_sha256": "aeb13307a71acd8fe81861d94ad54ab689df773318809eed3cbe794b4492dae4",
+      "template_source": "pinned-upstream-explicit-file",
+      "verification": "operator-must-verify-before-running",
+      "template_sha256": "a55ee1b1660128b7098723e0abcd92caa0788061051c62d51cbe87d9cf1974d8"
+    },
+    "model_worker": {
+      "url": "http://127.0.0.1:9281",
+      "worker_id": "msm2-1"
+    },
+    "deterministic_worker": {
+      "url": "http://127.0.0.1:9282",
+      "worker_id": "msm2-2"
+    }
+  },
+  "h100": {
+    "backend": {
+      "url": "http://127.0.0.1:9283",
+      "model": "Qwen/Qwen3-30B-A3B",
+      "generation": {
+        "max_tokens": 128,
+        "temperature": 0.7,
+        "top_p": 0.8,
+        "top_k": 20,
+        "seed": 42,
+        "chat_template_kwargs": {
+          "enable_thinking": false
+        }
+      },
+      "identity": {
+        "model_repository": "Qwen/Qwen3-30B-A3B",
+        "model_revision": "ad44e777bcd18fa416d9da3bd8f70d33ebb85d39",
+        "quantization": "BF16",
+        "context_tokens": 4096,
+        "concurrency": 1,
+        "prefix_cache": "unknown",
+        "thinking": false,
+        "tokenizer_sha256": "aeb13307a71acd8fe81861d94ad54ab689df773318809eed3cbe794b4492dae4",
+        "template_source": "pinned-upstream-pending-native-validation",
+        "verification": "operator-must-verify-before-running",
+        "runtime": "vllm",
+        "kora_execution_control": false,
+        "template_sha256": "a55ee1b1660128b7098723e0abcd92caa0788061051c62d51cbe87d9cf1974d8"
+      }
+    },
+    "identity": {
+      "model_repository": "Qwen/Qwen3-30B-A3B",
+      "model_revision": "ad44e777bcd18fa416d9da3bd8f70d33ebb85d39",
+      "quantization": "BF16",
+      "context_tokens": 4096,
+      "concurrency": 1,
+      "prefix_cache": "unknown",
+      "thinking": false,
+      "tokenizer_sha256": "aeb13307a71acd8fe81861d94ad54ab689df773318809eed3cbe794b4492dae4",
+      "template_source": "pinned-upstream-pending-native-validation",
+      "verification": "operator-must-verify-before-running",
+      "runtime": "vllm",
+      "kora_execution_control": false,
+      "template_sha256": "a55ee1b1660128b7098723e0abcd92caa0788061051c62d51cbe87d9cf1974d8"
+    }
+  }
+}

--- a/examples/benchmarks/three-environment/worker-model.example.json
+++ b/examples/benchmarks/three-environment/worker-model.example.json
@@ -1,0 +1,35 @@
+{
+  "worker_id": "mp",
+  "port": 9181,
+  "backend": {
+    "url": "http://127.0.0.1:19180",
+    "model": "Qwen3-30B-A3B",
+    "generation": {
+      "max_tokens": 128,
+      "temperature": 0.7,
+      "top_p": 0.8,
+      "top_k": 20,
+      "seed": 42,
+      "chat_template_kwargs": {
+        "enable_thinking": false
+      },
+      "cache_prompt": false
+    },
+    "identity": {
+      "model_repository": "Qwen/Qwen3-30B-A3B",
+      "model_revision": "ad44e777bcd18fa416d9da3bd8f70d33ebb85d39",
+      "artifact_sha256": "0d003f6662faee786ed5da3e31b29c978de5ae5d275c8794c606a7f3c01aa8f5",
+      "runtime_commit": "4d9176092d00586775af140581bb0b558ddc4389",
+      "quantization": "Q4_K_M",
+      "context_tokens": 4096,
+      "concurrency": 1,
+      "prefix_cache": "disabled",
+      "thinking": false,
+      "tokenizer_sha256": "aeb13307a71acd8fe81861d94ad54ab689df773318809eed3cbe794b4492dae4",
+      "template_source": "pinned-upstream-explicit-file",
+      "verification": "operator-must-verify-before-running",
+      "template_sha256": "a55ee1b1660128b7098723e0abcd92caa0788061051c62d51cbe87d9cf1974d8"
+    },
+    "token_env": "KORA_BENCHMARK_TOKEN"
+  }
+}

--- a/kora/benchmarks/__init__.py
+++ b/kora/benchmarks/__init__.py
@@ -1,0 +1,1 @@
+"""Opt-in benchmark harness; separate from offline Solution contracts."""

--- a/kora/benchmarks/three_system.py
+++ b/kora/benchmarks/three_system.py
@@ -1,0 +1,284 @@
+"""Three-system fixture runner. H100 uses a native endpoint without KORA routing."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import time
+import uuid
+from pathlib import Path
+
+from .worker import VERSION, ModelBackend, WorkerError, digest, http_json
+
+
+def arithmetic(value):
+    if set(value) != {"quantity", "unit_price", "currency"}:
+        raise WorkerError("invalid-arithmetic-fields")
+    if value["currency"] != "KRW" or any(
+        type(value[k]) is not int or not 0 <= value[k] <= 10**9
+        for k in ("quantity", "unit_price")
+    ):
+        raise WorkerError("invalid-arithmetic-value")
+    return {"total": value["quantity"] * value["unit_price"], "currency": "KRW"}
+
+
+class Client:
+    def __init__(self, url, token, worker_id):
+        self.url, self.token, self.worker_id = url.rstrip("/"), token, worker_id
+        health = http_json(self.url + "/health", token=token, timeout=5)
+        if (
+            not isinstance(health, dict)
+            or health.get("worker_id") != worker_id
+            or health.get("schema_version") != VERSION
+        ):
+            raise WorkerError("worker-identity-mismatch")
+        self.boot_id = health["boot_id"]
+
+    def run(self, job_id, operation, value):
+        request = {
+            "schema_version": VERSION,
+            "boot_id": self.boot_id,
+            "job_id": job_id,
+            "operation": operation,
+            "input": value,
+            "input_hash": digest(value),
+        }
+        result = http_json(self.url + "/jobs", request, self.token, timeout=130)
+        if not isinstance(result, dict) or any(
+            result.get(k) != v
+            for k, v in {
+                "schema_version": VERSION,
+                "worker_id": self.worker_id,
+                "boot_id": self.boot_id,
+                "job_id": job_id,
+                "input_hash": digest(value),
+                "operation": operation,
+            }.items()
+        ):
+            raise WorkerError("result-identity-mismatch")
+        return result
+
+
+def execute_case(system, config, fixture, system_prompt, scenario, run_id, emit):
+    """Every outcome, including failed/unsupported runs, remains in the denominator."""
+    payload = {
+        "text": fixture["text"],
+        "structured_input": fixture["structured_input"],
+        "system_prompt": system_prompt,
+    }
+    result = {
+        "schema_version": "kora.benchmark.execution/v1",
+        "run_id": run_id,
+        "system_set": system,
+        "workload_id": fixture["id"],
+        "scenario": scenario,
+        "input_hash": digest(payload),
+        "status": "failed",
+        "quality_pass": False,
+        "nodes": [],
+        "configuration": config.get("identity", {}),
+        "model_calls_completed": 0,
+        "completion_tokens": 0,
+        "execution_location": "native-client-only"
+        if system == "h100" and scenario == "D"
+        else "native-client-and-endpoint"
+        if system == "h100"
+        else "kora-workers",
+    }
+    started = time.monotonic()
+    sequence = 0
+
+    def event(kind, **fields):
+        nonlocal sequence
+        sequence += 1
+        emit(
+            {
+                "schema_version": "kora.benchmark.event/v1",
+                "run_id": run_id,
+                "system_set": system,
+                "sequence": sequence,
+                "event_kind": kind,
+                "controller_elapsed_ms": (time.monotonic() - started) * 1000,
+                **fields,
+            }
+        )
+
+    event("started")
+    try:
+        if system == "h100":
+            backend = ModelBackend(**config["backend"])
+            # Fail before work on a mismatched model, even for the mixed baseline.
+            if scenario != "D":
+                backend.health()
+            deterministic = None
+            if scenario in ("D", "W"):
+                node_start = time.monotonic()
+                deterministic = arithmetic(fixture["structured_input"])
+                node = {
+                    "worker_id": "native-client",
+                    "activity": "deterministic",
+                    "status": "completed",
+                    "model_calls_completed": 0,
+                    "elapsed_ms": (time.monotonic() - node_start) * 1000,
+                    "output": deterministic,
+                }
+                result["nodes"].append(node)
+                event("node-completed", node=node)
+            model = None
+            if scenario in ("M", "W"):
+                event("node-started", node_id="model", activity="inference")
+                node_start = time.monotonic()
+                model = backend.generate(
+                    {"system": system_prompt, "text": fixture["text"]}
+                )
+                node = {
+                    "worker_id": "native-h100-endpoint",
+                    "activity": "inference",
+                    "status": "completed",
+                    "model_calls_completed": 1,
+                    "output": model,
+                    "elapsed_ms": (time.monotonic() - node_start) * 1000,
+                }
+                result["nodes"].append(node)
+                event("node-completed", node=node)
+        else:
+            token = os.environ[config["token_env"]]
+            model_cfg = config["model_worker"]
+            deterministic_cfg = config["deterministic_worker"]
+            if (
+                system == "cluster"
+                and model_cfg["worker_id"] == deterministic_cfg["worker_id"]
+            ):
+                raise WorkerError("cluster-requires-distinct-workers")
+            deterministic = model = None
+            for operation, value, worker_cfg in [
+                ("arithmetic", fixture["structured_input"], deterministic_cfg),
+                (
+                    "model",
+                    {"system": system_prompt, "text": fixture["text"]},
+                    model_cfg,
+                ),
+            ]:
+                if (scenario == "D" and operation == "model") or (
+                    scenario == "M" and operation == "arithmetic"
+                ):
+                    continue
+                client = Client(token=token, **worker_cfg)
+                event("node-started", node_id=operation, worker_id=client.worker_id)
+                node = client.run(run_id + ":" + operation, operation, value)
+                result["nodes"].append(node)
+                event(
+                    "node-completed"
+                    if node["status"] == "completed"
+                    else "node-failed",
+                    node=node,
+                )
+                if node["status"] != "completed":
+                    raise WorkerError(node.get("error", "worker-failed"), 502)
+                if operation == "arithmetic":
+                    deterministic = node["output"]
+                else:
+                    model = node["output"]
+        actual = dict(deterministic or {})
+        if model:
+            parsed = json.loads(model["text"])
+            if not isinstance(parsed, dict) or set(parsed) != {"category"}:
+                raise WorkerError("quality-invalid-model-schema")
+            actual.update(parsed)
+        expected = {}
+        if scenario in ("D", "W"):
+            expected.update(fixture["expected_deterministic_output"])
+        if scenario in ("M", "W"):
+            expected.update(fixture["expected_model_output"])
+        result.update(
+            status="completed", output=actual, quality_pass=actual == expected
+        )
+    except (WorkerError, ValueError, KeyError, TypeError) as exc:
+        result["error"] = (
+            exc.code if isinstance(exc, WorkerError) else "invalid-output-or-config"
+        )
+        event("failed", error=result["error"])
+    result["model_calls_completed"] = sum(
+        n.get("model_calls_completed", 0) for n in result["nodes"]
+    )
+    result["completion_tokens"] = sum(
+        n.get("output", {}).get("completion_tokens", 0) for n in result["nodes"]
+    )
+    result["controller_elapsed_ms"] = (time.monotonic() - started) * 1000
+    result["cluster_cooperation_observed"] = (
+        system == "cluster"
+        and scenario == "W"
+        and len({n["worker_id"] for n in result["nodes"] if n["status"] == "completed"})
+        == 2
+    )
+    event("finished", status=result["status"], quality_pass=result["quality_pass"])
+    return result
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--config", required=True)
+    parser.add_argument("--fixtures", required=True)
+    parser.add_argument("--output", required=True)
+    parser.add_argument("--scenario", choices=["D", "M", "W"], default="W")
+    parser.add_argument("--repetitions", type=int, default=1)
+    parser.add_argument("--case", default=None)
+    args = parser.parse_args()
+    if not 1 <= args.repetitions <= 20:
+        parser.error("repetitions must be 1..20")
+    config = json.loads(Path(args.config).read_text())
+    fixtures = json.loads(Path(args.fixtures).read_text())
+    if args.case and args.case not in [case["id"] for case in fixtures["cases"]]:
+        parser.error("unknown fixture case")
+    failed = False
+    output = Path(args.output)
+    output.mkdir(parents=True, exist_ok=False)
+    with (
+        (output / "events.jsonl").open("x") as events,
+        (output / "results.jsonl").open("x") as results,
+    ):
+
+        def emit(event):
+            events.write(json.dumps(event, ensure_ascii=False) + "\n")
+            events.flush()
+
+        print(
+            "system\tworkload\tstatus\tquality\telapsed_ms\tactual_output_tokens",
+            flush=True,
+        )
+        for repetition in range(args.repetitions):
+            for fixture in fixtures["cases"]:
+                if args.case and fixture["id"] != args.case:
+                    continue
+                for system in ("mp", "cluster", "h100"):
+                    result = execute_case(
+                        system,
+                        config[system],
+                        fixture,
+                        fixtures["system_prompt"],
+                        args.scenario,
+                        str(uuid.uuid4()),
+                        emit,
+                    )
+                    failed = failed or not result["quality_pass"]
+                    result["repetition"] = repetition
+                    results.write(json.dumps(result, ensure_ascii=False) + "\n")
+                    results.flush()
+                    label = (
+                        "h100-client-only"
+                        if system == "h100" and args.scenario == "D"
+                        else system
+                    )
+                    print(
+                        f"{label}\t{fixture['id']}\t{result['status']}\t{result['quality_pass']}\t"
+                        f"{result['controller_elapsed_ms']:.1f}\t{result['completion_tokens']}",
+                        flush=True,
+                    )
+
+    if failed:
+        raise SystemExit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/kora/benchmarks/worker.py
+++ b/kora/benchmarks/worker.py
@@ -1,0 +1,341 @@
+"""Bounded benchmark worker, loopback-only. Remote access requires an SSH tunnel.
+
+This harness does not register a network runtime with the offline Solution Host.
+The in-memory request ledger is deliberately not an exact-reuse cache: only the
+same job ID can retrieve its original outcome. A new ID always executes again.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import hmac
+import json
+import os
+import re
+import threading
+import time
+import uuid
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from urllib.error import HTTPError, URLError
+from urllib.parse import urlsplit
+from urllib.request import HTTPRedirectHandler, ProxyHandler, Request, build_opener
+
+LIMIT = 65536
+VERSION = "kora.benchmark.worker/v1"
+
+
+def encoded(value):
+    return json.dumps(
+        value,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+        allow_nan=False,
+    ).encode()
+
+
+def digest(value):
+    return hashlib.sha256(encoded(value)).hexdigest()
+
+
+class WorkerError(Exception):
+    def __init__(self, code, status=400):
+        super().__init__(code)
+        self.code, self.status = code, status
+
+
+class NoRedirect(HTTPRedirectHandler):
+    def redirect_request(self, *args, **kwargs):
+        raise WorkerError("redirect-refused", 502)
+
+
+def http_json(url, payload=None, token=None, timeout=120):
+    parsed = urlsplit(url)
+    if parsed.scheme != "http" or parsed.hostname != "127.0.0.1" or parsed.username:
+        raise WorkerError("loopback-or-ssh-tunnel-required")
+    headers = {"Content-Type": "application/json"}
+    if token:
+        headers["Authorization"] = "Bearer " + token
+    request = Request(
+        url, data=None if payload is None else encoded(payload), headers=headers
+    )
+    try:
+        with build_opener(ProxyHandler({}), NoRedirect()).open(
+            request, timeout=timeout
+        ) as response:
+            raw = response.read(LIMIT + 1)
+        if len(raw) > LIMIT:
+            raise WorkerError("response-too-large", 502)
+        return json.loads(raw)
+    except HTTPError as exc:
+        raise WorkerError("http-" + str(exc.code), 502) from exc
+    except (URLError, TimeoutError, OSError) as exc:
+        raise WorkerError("transport-outcome-unknown", 504) from exc
+    except (ValueError, UnicodeError) as exc:
+        raise WorkerError("invalid-backend-json", 502) from exc
+
+
+class ModelBackend:
+    """Fixed endpoint and model; a model alias alone is not artifact attestation."""
+
+    def __init__(
+        self, url, model, generation, identity, timeout=120, token=None, token_env=None
+    ):
+        self.url, self.model = url.rstrip("/"), model
+        self.generation, self.identity = generation, identity
+        self.timeout, self.token = (
+            timeout,
+            os.environ[token_env] if token_env else token,
+        )
+
+    def health(self):
+        result = http_json(self.url + "/v1/models", token=self.token, timeout=5)
+        if (
+            not isinstance(result, dict)
+            or not isinstance(result.get("data"), list)
+            or any(not isinstance(entry, dict) for entry in result["data"])
+        ):
+            raise WorkerError("invalid-model-list", 502)
+        if self.model not in [entry.get("id") for entry in result["data"]]:
+            raise WorkerError("model-mismatch", 409)
+        return {
+            "model": self.model,
+            "identity": self.identity,
+            "identity_source": "operator-config-plus-served-model-id",
+        }
+
+    def generate(self, payload):
+        if set(payload) != {"system", "text"} or any(
+            not isinstance(v, str) or len(v) > 8192 for v in payload.values()
+        ):
+            raise WorkerError("invalid-model-input")
+        self.health()
+        request = {
+            "model": self.model,
+            "messages": [
+                {"role": "system", "content": payload["system"]},
+                {"role": "user", "content": payload["text"]},
+            ],
+            "stream": False,
+            **self.generation,
+        }
+        result = http_json(
+            self.url + "/v1/chat/completions", request, self.token, self.timeout
+        )
+        if not isinstance(result, dict) or not isinstance(result.get("usage"), dict):
+            raise WorkerError("missing-engine-token-counts", 502)
+        usage = result["usage"]
+        if any(
+            type(usage.get(k)) is not int or usage[k] < 0
+            for k in ("prompt_tokens", "completion_tokens")
+        ):
+            raise WorkerError("missing-engine-token-counts", 502)
+        try:
+            choice = result["choices"][0]
+            content = choice["message"]["content"]
+            if not isinstance(content, str):
+                raise TypeError()
+        except (KeyError, IndexError, TypeError, ValueError) as exc:
+            raise WorkerError("invalid-completion", 502) from exc
+        return {
+            "text": content,
+            "finish_reason": choice.get("finish_reason"),
+            "prompt_tokens": usage["prompt_tokens"],
+            "completion_tokens": usage["completion_tokens"],
+            "token_source": "engine-reported",
+            "backend": {**self.identity, "generation": self.generation},
+        }
+
+
+class Worker:
+    def __init__(self, worker_id, token, operations, capacity=1024):
+        if not isinstance(token, str) or len(token) < 32:
+            raise ValueError("worker token must have at least 32 characters")
+        self.worker_id, self.token, self.operations = worker_id, token, operations
+        self.boot_id, self.started = str(uuid.uuid4()), time.monotonic()
+        self.capacity, self.jobs = capacity, {}
+        self.model_fault = False
+        self.lock = threading.Lock()
+
+    def health(self):
+        return {
+            "schema_version": VERSION,
+            "worker_id": self.worker_id,
+            "boot_id": self.boot_id,
+            "uptime_seconds": time.monotonic() - self.started,
+            "operations": sorted(self.operations),
+            "ledger_capacity": self.capacity,
+            "model_fault": self.model_fault,
+        }
+
+    def execute(self, request):
+        required = {
+            "schema_version",
+            "boot_id",
+            "job_id",
+            "operation",
+            "input",
+            "input_hash",
+        }
+        if not isinstance(request, dict) or set(request) != required:
+            raise WorkerError("invalid-request")
+        if request["schema_version"] != VERSION or request["boot_id"] != self.boot_id:
+            raise WorkerError("worker-incarnation-mismatch", 409)
+        job = request["job_id"]
+        if not isinstance(job, str) or not re.fullmatch(r"[A-Za-z0-9_.:-]{1,128}", job):
+            raise WorkerError("invalid-job-id")
+        operation = request["operation"]
+        if not isinstance(operation, str) or operation not in self.operations:
+            raise WorkerError("unsupported-operation")
+        if (
+            not isinstance(request["input"], dict)
+            or digest(request["input"]) != request["input_hash"]
+        ):
+            raise WorkerError("input-hash-mismatch")
+        fingerprint = digest(request)
+        with self.lock:
+            old = self.jobs.get(job)
+            if old:
+                if old[0] != fingerprint:
+                    raise WorkerError("job-id-conflict", 409)
+                if old[1] is None:
+                    raise WorkerError("job-in-progress", 409)
+                return {**old[1], "duplicate_delivery": True}
+            if operation == "model" and self.model_fault:
+                raise WorkerError("model-recovery-required", 503)
+            if len(self.jobs) >= self.capacity:
+                raise WorkerError("ledger-full", 503)
+            if any(item[1] is None for item in self.jobs.values()):
+                raise WorkerError("worker-busy", 503)
+            self.jobs[job] = (fingerprint, None)
+        start = time.monotonic()
+        result = {
+            "schema_version": VERSION,
+            "worker_id": self.worker_id,
+            "boot_id": self.boot_id,
+            "job_id": job,
+            "input_hash": request["input_hash"],
+            "operation": operation,
+            "duplicate_delivery": False,
+            "model_calls_completed": 0,
+            "activity": "inference" if operation == "model" else "deterministic",
+        }
+        try:
+            output = self.operations[operation](request["input"])
+            result.update(status="completed", output=output)
+            result["model_calls_completed"] = int(operation == "model")
+        except WorkerError as exc:
+            result.update(status="failed", error=exc.code)
+            if operation == "model":
+                result["model_execution_outcome"] = "unknown-or-not-started"
+        except Exception:  # noqa: BLE001 - retain a terminal outcome for trusted operation faults
+            result.update(status="failed", error="operation-failed")
+            if operation == "model":
+                result["model_execution_outcome"] = "unknown-or-not-started"
+        result["elapsed_ms"] = (time.monotonic() - start) * 1000
+        with self.lock:
+            if operation == "model" and result["status"] == "failed":
+                self.model_fault = True
+            self.jobs[job] = (fingerprint, result)
+        return result
+
+
+def make_server(worker, port=0):
+    class Handler(BaseHTTPRequestHandler):
+        def log_message(self, *args):
+            pass
+
+        def respond(self, status, value):
+            body = encoded(value)
+            self.send_response(status)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(body)))
+            self.send_header("Connection", "close")
+            self.end_headers()
+            self.wfile.write(body)
+
+        def authorized(self):
+            supplied = self.headers.get("Authorization", "")
+            return hmac.compare_digest(
+                supplied.encode(), ("Bearer " + worker.token).encode()
+            )
+
+        def do_GET(self):
+            if not self.authorized():
+                return self.respond(401, {"error": "unauthorized"})
+            if self.path != "/health":
+                return self.respond(404, {"error": "not-found"})
+            self.respond(200, worker.health())
+
+        def do_POST(self):
+            self.connection.settimeout(5)
+            if not self.authorized():
+                return self.respond(401, {"error": "unauthorized"})
+            if self.path != "/jobs":
+                return self.respond(404, {"error": "not-found"})
+            try:
+                lengths = self.headers.get_all("Content-Length", [])
+                if self.headers.get("Transfer-Encoding") or len(lengths) != 1:
+                    raise WorkerError("invalid-framing")
+                length = int(lengths[0])
+                if not 0 < length <= LIMIT:
+                    raise WorkerError("request-too-large", 413)
+                raw = self.rfile.read(length)
+                if len(raw) != length:
+                    raise WorkerError("incomplete-request")
+                request = json.loads(
+                    raw, parse_constant=lambda _: (_ for _ in ()).throw(ValueError())
+                )
+                self.respond(200, worker.execute(request))
+            except WorkerError as exc:
+                self.respond(exc.status, {"error": exc.code})
+            except (ValueError, UnicodeError, TimeoutError):
+                self.respond(400, {"error": "invalid-json-or-framing"})
+
+    class BoundedServer(ThreadingHTTPServer):
+        slots = threading.BoundedSemaphore(8)
+
+        def process_request(self, request, client_address):
+            if not self.slots.acquire(blocking=False):
+                self.shutdown_request(request)
+                return
+            try:
+                super().process_request(request, client_address)
+            except Exception:
+                self.slots.release()
+                raise
+
+        def process_request_thread(self, request, client_address):
+            try:
+                request.settimeout(5)
+                super().process_request_thread(request, client_address)
+            finally:
+                self.slots.release()
+
+    server = BoundedServer(("127.0.0.1", port), Handler)
+    server.daemon_threads = True
+    return server
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--config", required=True)
+    args = parser.parse_args()
+    with open(args.config) as handle:
+        config = json.load(handle)
+    token = os.environ["KORA_BENCHMARK_TOKEN"]
+    # Fixture logic remains in the benchmark package, never in Core.
+    from .three_system import arithmetic
+
+    operations = {"arithmetic": arithmetic}
+    if config.get("backend"):
+        operations["model"] = ModelBackend(**config["backend"]).generate
+    worker = Worker(config["worker_id"], token, operations)
+    server = make_server(worker, config["port"])
+    print(json.dumps(worker.health()), flush=True)
+    server.serve_forever()
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/gpu_lease.py
+++ b/scripts/gpu_lease.py
@@ -1,0 +1,215 @@
+#!/usr/bin/env python3
+"""Cooperative single-GPU lease and live usage board. Never kills workloads."""
+
+import argparse
+import datetime as dt
+import fcntl
+import getpass
+import json
+import os
+import subprocess
+import time
+import uuid
+from pathlib import Path
+
+ROOT = Path(
+    os.environ.get("KRAKO_GPU_STATE", str(Path.home() / "krako-resource-control"))
+)
+
+
+def stamp(t):
+    return dt.datetime.fromtimestamp(t, dt.timezone.utc).isoformat()
+
+
+def observe():
+    gpu = subprocess.check_output(
+        [
+            "nvidia-smi",
+            "--query-gpu=uuid,name,memory.total,memory.used,utilization.gpu",
+            "--format=csv,noheader,nounits",
+        ],
+        text=True,
+        timeout=10,
+    ).strip()
+    raw = subprocess.check_output(
+        [
+            "nvidia-smi",
+            "--query-compute-apps=pid,used_memory",
+            "--format=csv,noheader,nounits",
+        ],
+        text=True,
+        timeout=10,
+    )
+    jobs = []
+    for line in raw.splitlines():
+        pid, memory = [x.strip() for x in line.split(",")]
+        try:
+            group = Path("/proc", pid, "cgroup").read_text().strip()
+        except FileNotFoundError:
+            continue
+        jobs.append({"pid": int(pid), "memory_mib": memory, "cgroup": group})
+    return {"sampled_at": stamp(time.time()), "gpu_csv": gpu, "processes": jobs}
+
+
+def check_busy(sample, allowed):
+    # Exact cgroup component membership; never accept substring service names.
+    unexpected = [
+        p
+        for p in sample["processes"]
+        if not allowed or allowed not in p["cgroup"].split(":")[-1].split("/")
+    ]
+    if unexpected:
+        raise RuntimeError("unregistered-or-unapproved GPU processes; no takeover")
+
+
+def write_json(path, value):
+    temp = path.with_suffix(".tmp")
+    with temp.open("w") as f:
+        json.dump(value, f, indent=2)
+        f.flush()
+        os.fsync(f.fileno())
+    os.replace(temp, path)
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    sub = parser.add_subparsers(dest="action", required=True)
+    sub.add_parser("status")
+    ac = sub.add_parser("acquire")
+    ac.add_argument("--project", required=True)
+    ac.add_argument("--owner", required=True)
+    ac.add_argument("--purpose", required=True)
+    ac.add_argument("--minutes", type=int, required=True)
+    ac.add_argument("--unit", required=True)
+    ac.add_argument("--handover-service", default="")
+    for action in ["heartbeat", "release"]:
+        p = sub.add_parser(action)
+        p.add_argument("--lease-id", required=True)
+        if action == "release":
+            p.add_argument("--restored-service", default="")
+    args = parser.parse_args()
+    ROOT.mkdir(parents=True, exist_ok=True)
+    with (ROOT / "board.lock").open("a") as lock:
+        fcntl.flock(lock, fcntl.LOCK_EX)
+        path = ROOT / "active.json"
+        lease = json.loads(path.read_text()) if path.exists() else None
+        sample = observe()
+        now = time.time()
+        registry_path = ROOT / "services.json"
+        registry = (
+            json.loads(registry_path.read_text()) if registry_path.exists() else {}
+        )
+        for process in sample["processes"]:
+            components = process["cgroup"].split(":")[-1].split("/")
+            service = next((x for x in components if x.endswith(".service")), None)
+            process["service"] = service
+            if lease and lease["unit"] in components:
+                process["declared_project"] = lease["project"]
+                process["declared_owner"] = lease["owner"]
+            else:
+                process.update(
+                    registry.get(
+                        service,
+                        {
+                            "declared_project": "unregistered",
+                            "declared_owner": "unknown",
+                        },
+                    )
+                )
+        board = {
+            "lease": lease,
+            "overdue": bool(lease and now > lease["expected_end_epoch"]),
+            "observed": sample,
+            "note": "Unleased GPU processes are occupied, never free. Cooperative, not GPU isolation.",
+        }
+        if args.action == "status":
+            write_json(ROOT / "STATUS.json", board)
+            lines = [
+                "# H100 usage status",
+                "",
+                "Sampled: " + sample["sampled_at"],
+                "",
+                "GPU: " + sample["gpu_csv"],
+                "",
+            ]
+            if lease:
+                lines += [
+                    "Project: " + lease["project"],
+                    "Owner: " + lease["owner"],
+                    "Purpose: " + lease["purpose"],
+                    "Started: " + lease["started_at"],
+                    "Expected end: " + lease["expected_end"],
+                    "Elapsed minutes: "
+                    + str(round((now - lease["started_epoch"]) / 60, 1)),
+                    "Overdue: " + str(board["overdue"]),
+                ]
+            else:
+                lines += [
+                    "No declared lease. Inspect observed processes before acquiring."
+                ]
+            lines += [
+                "",
+                "Observed processes:",
+                json.dumps(sample["processes"], indent=2),
+            ]
+            (ROOT / "STATUS.md").write_text("\n".join(lines) + "\n")
+            print(json.dumps(board, indent=2))
+            return
+        if args.action == "acquire":
+            if lease:
+                raise RuntimeError(
+                    "lease exists; expired leases are not automatically stolen"
+                )
+            if not 1 <= args.minutes <= 240:
+                raise RuntimeError("minutes must be 1..240")
+            check_busy(sample, args.handover_service)
+            lease = {
+                "schema_version": 1,
+                "lease_id": str(uuid.uuid4()),
+                "project": args.project,
+                "owner": args.owner,
+                "unix_user": getpass.getuser(),
+                "purpose": args.purpose,
+                "unit": args.unit,
+                "started_at": stamp(now),
+                "started_epoch": now,
+                "expected_end": stamp(now + 60 * args.minutes),
+                "expected_end_epoch": now + 60 * args.minutes,
+                "heartbeat_at": stamp(now),
+                "handover_service": args.handover_service,
+            }
+            write_json(path, lease)
+        else:
+            if not lease or lease["lease_id"] != args.lease_id:
+                raise RuntimeError("lease ownership mismatch")
+            if args.action == "heartbeat":
+                lease["heartbeat_at"] = stamp(now)
+                write_json(path, lease)
+            else:
+                if (
+                    args.restored_service
+                    and args.restored_service != lease["handover_service"]
+                ):
+                    raise RuntimeError("unexpected restored service")
+                check_busy(sample, args.restored_service)
+                lease["ended_at"] = stamp(now)
+                lease["elapsed_seconds"] = now - lease["started_epoch"]
+                path.unlink()
+        record = {
+            "event": args.action,
+            "at": stamp(now),
+            "lease": lease,
+            "observed": sample,
+        }
+        with (ROOT / "history.jsonl").open("a") as history:
+            history.write(json.dumps(record) + "\n")
+            history.flush()
+            os.fsync(history.fileno())
+        print(json.dumps(record, indent=2))
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except (RuntimeError, OSError, ValueError, subprocess.SubprocessError) as exc:
+        raise SystemExit(str(exc))

--- a/tests/test_benchmark_worker.py
+++ b/tests/test_benchmark_worker.py
@@ -1,0 +1,303 @@
+import threading
+
+import pytest
+
+from kora.benchmarks.three_system import Client, arithmetic, execute_case
+from kora.benchmarks.worker import (
+    VERSION,
+    ModelBackend,
+    Worker,
+    WorkerError,
+    digest,
+    http_json,
+    make_server,
+)
+
+TOKEN = "t" * 40
+
+
+def request(worker, job="j1", value=None):
+    value = value or {"quantity": 2, "unit_price": 5, "currency": "KRW"}
+    return {
+        "schema_version": VERSION,
+        "boot_id": worker.boot_id,
+        "job_id": job,
+        "operation": "arithmetic",
+        "input": value,
+        "input_hash": digest(value),
+    }
+
+
+def test_duplicates_conflicts_and_new_jobs():
+    calls = []
+
+    def calculate(value):
+        calls.append(value)
+        return arithmetic(value)
+
+    worker = Worker("test", TOKEN, {"arithmetic": calculate}, capacity=2)
+    first = worker.execute(request(worker))
+    assert first["model_calls_completed"] == 0
+    assert worker.execute(request(worker))["duplicate_delivery"]
+    assert len(calls) == 1
+    changed = request(worker, value={"quantity": 3, "unit_price": 5, "currency": "KRW"})
+    with pytest.raises(WorkerError, match="job-id-conflict"):
+        worker.execute(changed)
+    worker.execute(request(worker, "j2"))
+    assert len(calls) == 2
+    with pytest.raises(WorkerError, match="ledger-full"):
+        worker.execute(request(worker, "j3"))
+
+
+def test_restart_and_hash_fail_closed():
+    worker = Worker("test", TOKEN, {"arithmetic": arithmetic})
+    r = request(worker)
+    r["input"]["quantity"] = 3
+    with pytest.raises(WorkerError, match="input-hash-mismatch"):
+        worker.execute(r)
+    other = Worker("test", TOKEN, {"arithmetic": arithmetic})
+    with pytest.raises(WorkerError, match="worker-incarnation-mismatch"):
+        other.execute(request(worker))
+
+
+def test_failure_retained_no_repeat_inference():
+    calls = []
+
+    def fail(value):
+        calls.append(value)
+        raise WorkerError("transport-outcome-unknown")
+
+    worker = Worker("test", TOKEN, {"model": fail})
+    r = request(worker)
+    r["operation"] = "model"
+    result = worker.execute(r)
+    assert result["status"] == "failed"
+    assert result["model_calls_completed"] == 0
+    assert result["model_execution_outcome"] == "unknown-or-not-started"
+    assert worker.execute(r)["duplicate_delivery"]
+    assert len(calls) == 1
+    r["job_id"] = "new"
+    with pytest.raises(WorkerError, match="model-recovery-required"):
+        worker.execute(r)
+
+
+def test_inflight_duplicate_does_not_execute_twice():
+    entered, release = threading.Event(), threading.Event()
+
+    def slow(value):
+        entered.set()
+        release.wait(3)
+        return arithmetic(value)
+
+    worker = Worker("test", TOKEN, {"arithmetic": slow})
+    thread = threading.Thread(target=lambda: worker.execute(request(worker)))
+    thread.start()
+    assert entered.wait(2)
+    try:
+        with pytest.raises(WorkerError, match="job-in-progress"):
+            worker.execute(request(worker))
+        with pytest.raises(WorkerError, match="worker-busy"):
+            worker.execute(request(worker, "j2"))
+    finally:
+        release.set()
+        thread.join()
+
+
+def test_authenticated_loopback_transport():
+    worker = Worker("test", TOKEN, {"arithmetic": arithmetic})
+    server = make_server(worker)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    url = "http://127.0.0.1:" + str(server.server_port)
+    try:
+        with pytest.raises(WorkerError, match="http-401"):
+            http_json(url + "/health")
+        client = Client(url, TOKEN, "test")
+        result = client.run(
+            "j1", "arithmetic", {"quantity": 3, "unit_price": 7, "currency": "KRW"}
+        )
+        assert result["output"]["total"] == 21
+        with pytest.raises(WorkerError, match="worker-identity-mismatch"):
+            Client(url, TOKEN, "different")
+    finally:
+        server.shutdown()
+        server.server_close()
+
+
+@pytest.mark.parametrize(
+    "url", ["http://example.com", "https://127.0.0.1", "http://user@127.0.0.1"]
+)
+def test_non_loopback_endpoints_rejected(url):
+    with pytest.raises(WorkerError, match="loopback-or-ssh-tunnel-required"):
+        http_json(url)
+
+
+def test_h100_model_mismatch_before_completion(monkeypatch):
+    import kora.benchmarks.worker as module
+
+    calls = []
+
+    def fake(url, *args, **kwargs):
+        calls.append(url)
+        return {"data": [{"id": "other-model"}]}
+
+    monkeypatch.setattr(module, "http_json", fake)
+    backend = ModelBackend("http://127.0.0.1:1", "pinned-model", {}, {})
+    with pytest.raises(WorkerError, match="model-mismatch"):
+        backend.generate({"system": "system", "text": "text"})
+    assert len(calls) == 1 and calls[0].endswith("/v1/models")
+
+
+def test_model_counts_and_malformed_usage(monkeypatch):
+    import kora.benchmarks.worker as module
+
+    response = {
+        "choices": [
+            {"message": {"content": '{"category":"billing"}'}, "finish_reason": "stop"}
+        ],
+        "usage": {"prompt_tokens": 10, "completion_tokens": 6},
+    }
+
+    def fake(url, *args, **kwargs):
+        return {"data": [{"id": "pinned"}]} if url.endswith("/models") else response
+
+    monkeypatch.setattr(module, "http_json", fake)
+    backend = ModelBackend("http://127.0.0.1:1", "pinned", {}, {"revision": "test"})
+    assert backend.generate({"system": "s", "text": "t"})["completion_tokens"] == 6
+    response["usage"]["completion_tokens"] = None
+    with pytest.raises(WorkerError, match="missing-engine-token-counts"):
+        backend.generate({"system": "s", "text": "t"})
+
+
+@pytest.mark.parametrize("quantity", [True, -1, 1.1, "2", 10**10])
+def test_arithmetic_bounds(quantity):
+    with pytest.raises(WorkerError):
+        arithmetic({"quantity": quantity, "unit_price": 2, "currency": "KRW"})
+
+
+def test_failed_quality_keeps_generated_counts(monkeypatch):
+    monkeypatch.setattr(ModelBackend, "health", lambda self: {})
+    monkeypatch.setattr(
+        ModelBackend,
+        "generate",
+        lambda self, p: {"text": "invalid json", "completion_tokens": 3},
+    )
+    fixture = {
+        "id": "f",
+        "text": "t",
+        "structured_input": {},
+        "expected_model_output": {"category": "billing"},
+    }
+    events = []
+    result = execute_case(
+        "h100",
+        {
+            "backend": {
+                "url": "http://127.0.0.1:1",
+                "model": "x",
+                "generation": {},
+                "identity": {},
+            }
+        },
+        fixture,
+        "s",
+        "M",
+        "r",
+        events.append,
+    )
+    assert result["status"] == "failed" and not result["quality_pass"]
+    assert result["completion_tokens"] == 3 and result["model_calls_completed"] == 1
+    assert [e["sequence"] for e in events] == list(range(1, len(events) + 1))
+
+
+def test_http_body_limit_and_invalid_framing():
+    from http.client import HTTPConnection
+
+    worker = Worker("test", TOKEN, {"arithmetic": arithmetic})
+    server = make_server(worker)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        for headers, expected in [
+            ({"Content-Length": "65537"}, 413),
+            ({"Transfer-Encoding": "chunked"}, 400),
+        ]:
+            connection = HTTPConnection("127.0.0.1", server.server_port, timeout=2)
+            connection.request(
+                "POST", "/jobs", headers={"Authorization": "Bearer " + TOKEN, **headers}
+            )
+            response = connection.getresponse()
+            assert response.status == expected
+            response.read()
+            connection.close()
+        assert not worker.jobs
+    finally:
+        server.shutdown()
+        server.server_close()
+
+
+def test_three_system_contract_with_explicit_mock_models(monkeypatch):
+    output = {"text": '{"category":"billing"}', "completion_tokens": 6}
+    monkeypatch.setattr(ModelBackend, "health", lambda self: {})
+    monkeypatch.setattr(ModelBackend, "generate", lambda self, payload: dict(output))
+    monkeypatch.setenv("TEST_WORKER_TOKEN", TOKEN)
+    servers = []
+    try:
+        refs = {}
+        for name in ("mp", "a", "b"):
+            worker = Worker(
+                name, TOKEN, {"arithmetic": arithmetic, "model": lambda p: dict(output)}
+            )
+            server = make_server(worker)
+            servers.append(server)
+            threading.Thread(target=server.serve_forever, daemon=True).start()
+            refs[name] = {
+                "url": "http://127.0.0.1:" + str(server.server_port),
+                "worker_id": name,
+            }
+        config = {
+            "mp": {
+                "token_env": "TEST_WORKER_TOKEN",
+                "model_worker": refs["mp"],
+                "deterministic_worker": refs["mp"],
+            },
+            "cluster": {
+                "token_env": "TEST_WORKER_TOKEN",
+                "model_worker": refs["a"],
+                "deterministic_worker": refs["b"],
+            },
+            "h100": {
+                "backend": {
+                    "url": "http://127.0.0.1:1",
+                    "model": "mock",
+                    "generation": {},
+                    "identity": {"mock": True},
+                }
+            },
+        }
+        fixture = {
+            "id": "f",
+            "text": "fixture",
+            "structured_input": {"quantity": 2, "unit_price": 5, "currency": "KRW"},
+            "expected_deterministic_output": {"total": 10, "currency": "KRW"},
+            "expected_model_output": {"category": "billing"},
+        }
+        rows = [
+            execute_case(
+                name, config[name], fixture, "system", "W", name, lambda e: None
+            )
+            for name in ("mp", "cluster", "h100")
+        ]
+        assert all(row["quality_pass"] for row in rows)
+        assert len({row["input_hash"] for row in rows}) == 1
+        assert all(row["model_calls_completed"] == 1 for row in rows)
+        assert rows[1]["cluster_cooperation_observed"]
+        deterministic = execute_case(
+            "cluster", config["cluster"], fixture, "system", "D", "d", lambda e: None
+        )
+        assert deterministic["model_calls_completed"] == 0
+        assert not deterministic["cluster_cooperation_observed"]
+    finally:
+        for server in servers:
+            server.shutdown()
+            server.server_close()

--- a/tests/test_shared_gpu_lease.py
+++ b/tests/test_shared_gpu_lease.py
@@ -1,0 +1,90 @@
+import importlib.util
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+SPEC = importlib.util.spec_from_file_location(
+    "lease", Path(__file__).resolve().parents[1] / "scripts" / "gpu_lease.py"
+)
+lease = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(lease)
+
+
+class LeaseTests(unittest.TestCase):
+    def test_busy_and_exact_service(self):
+        sample = {"processes": [{"cgroup": "0::/system.slice/real.service"}]}
+        for allowed in ["", "other.service", "real"]:
+            with self.assertRaises(RuntimeError):
+                lease.check_busy(sample, allowed)
+        lease.check_busy(sample, "real.service")
+
+    def test_concurrent_and_stale_ownership(self):
+        with tempfile.TemporaryDirectory() as directory:
+            env = dict(
+                os.environ,
+                KRAKO_GPU_STATE=directory,
+                PYTHONPATH=str(Path(__file__).resolve().parents[1] / "scripts"),
+            )
+            code = "import gpu_lease as m; m.observe=lambda:{'processes':[]}; m.main()"
+            prefix = [sys.executable, "-c", code]
+            acquire = prefix + [
+                "acquire",
+                "--project",
+                "test",
+                "--owner",
+                "test",
+                "--purpose",
+                "test",
+                "--minutes",
+                "1",
+                "--unit",
+                "test.service",
+            ]
+            processes = [
+                subprocess.Popen(
+                    acquire, env=env, stdout=subprocess.PIPE, stderr=subprocess.PIPE
+                )
+                for _ in range(2)
+            ]
+            for process in processes:
+                process.communicate(timeout=10)
+            self.assertEqual(sorted(p.returncode for p in processes), [0, 1])
+            path = Path(directory, "active.json")
+            data = json.loads(path.read_text())
+            data["expected_end_epoch"] = 0
+            path.write_text(json.dumps(data))
+            self.assertNotEqual(
+                subprocess.run(
+                    acquire, env=env, capture_output=True, check=False
+                ).returncode,
+                0,
+            )
+            bad = prefix + ["release", "--lease-id", "wrong"]
+            self.assertNotEqual(
+                subprocess.run(
+                    bad, env=env, capture_output=True, check=False
+                ).returncode,
+                0,
+            )
+            good = prefix + ["release", "--lease-id", data["lease_id"]]
+            self.assertEqual(
+                subprocess.run(
+                    good, env=env, capture_output=True, check=False
+                ).returncode,
+                0,
+            )
+            self.assertFalse(path.exists())
+            events = [
+                json.loads(x)
+                for x in Path(directory, "history.jsonl").read_text().splitlines()
+            ]
+            self.assertEqual([x["event"] for x in events], ["acquire", "release"])
+            self.assertGreaterEqual(events[-1]["lease"]["elapsed_seconds"], 0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
Add authenticated, bounded benchmark workers and three-system D/M/W execution. Report actual model activity and preserve failures. Native H100 is a direct baseline without KORA routing. Add standalone cooperative GPU usage leases with project/owner/purpose/duration and observed process/resource status.

## Validation
725 tests and Ruff passed. Prior isolated source installation and offline smoke passed. Live M/W: six cases x five repetitions, each of the three systems passes 30/30 per scenario; 54/54 warmups pass. Cluster W observes both workers. The authorized temporary native service window ended with original service health/model verified and lease released.

## Scope and evidence
Benchmark modules, tests, configuration, guide/report, and standalone GPU helper/docs/tests. Existing Core/Solution contracts unchanged. BF16 native versus Q4_K_M local and short classification fixtures are not hardware-only, broad quality, H100 parity, cost or throughput proof. Cooperative leases are not OS isolation or a scheduler; no external notifications.

## Review and repairs
Passes: protocol, transport hardening, local acceptance, native acceptance, operations helper, final lint/report. Repairs covered authentication/bounds/ledger identity, readiness and explicit upstream template, CUDA/ninja paths in the new native process, and exact cgroup matching. Failed attempts remain in private diagnostics.

## Approval packet
Classification: needs-cto-review. Risk: medium (remote execution/resource coordination). Review worker contracts, failure accounting, cooperative lease semantics and bounded evidence. Local and native model execution plus temporary handover were user authorized. Original service restored; unrelated projects preserved. No credentials, private endpoints, raw host logs or weights committed. No external provider calls, release or settings changes. PR open only, NOT merged; merge requires separate approval.
