### PR TITLE
Add capability-aware task tier recommendation

### DIFF
--- a/kora/solution/__init__.py
+++ b/kora/solution/__init__.py
@@ -23,6 +23,12 @@ from .contracts import (
     validate_contract_instance,
 )
 from .host import LocalSolutionHost, SolutionHostError
+from .orchestration import (
+    CapabilityTier,
+    TaskContract,
+    TierRecommendation,
+    recommend_capability_tier,
+)
 from .reference_runtime import (
     DOCUMENT_PDF_CAPABILITIES,
     DOCUMENT_PDF_CAPABILITY,
@@ -63,9 +69,10 @@ __all__ = [
     "SUPPORTED_API_VERSION",
     "CapabilityRegistryError",
     "CapabilityRuntime",
+    "CapabilityTier",
+    "DocumentPdfReferenceRuntime",
     "LocalCapabilityRegistry",
     "LocalSolutionHost",
-    "DocumentPdfReferenceRuntime",
     "ReferenceRuntime",
     "ReferenceRuntimeError",
     "ResolvedRuntime",
@@ -76,11 +83,14 @@ __all__ = [
     "SolutionHostError",
     "SolutionValidationError",
     "SolutionValidationIssue",
+    "TaskContract",
+    "TierRecommendation",
+    "default_reference_runtimes",
+    "document_pdf_runtime_available",
     "integrity_file_digests",
     "package_digest",
     "package_file_digests",
-    "default_reference_runtimes",
-    "document_pdf_runtime_available",
+    "recommend_capability_tier",
     "run_solution_conformance",
     "scaffold_solution",
     "validate_contract_instance",

--- a/kora/solution/orchestration.py
+++ b/kora/solution/orchestration.py
@@ -1,0 +1,77 @@
+"""Deterministic capability-tier recommendation for bounded task contracts."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import IntEnum
+
+
+class CapabilityTier(IntEnum):
+    """Provider-neutral execution capability classes, ordered by capability."""
+
+    L0_DETERMINISTIC = 0
+    L1_LOCAL_BOUNDED = 1
+    L2_LOCAL_STRONG = 2
+    L3_FRONTIER = 3
+    L4_HIGHEST_REASONING = 4
+
+
+@dataclass(frozen=True)
+class TaskContract:
+    """Bounded routing facts known before execution begins."""
+
+    objective_verification: bool = False
+    repetitive_or_inspection: bool = False
+    bounded_implementation: bool = False
+    complex_cross_component: bool = False
+    architecture_or_ambiguous: bool = False
+    high_risk: bool = False
+
+
+@dataclass(frozen=True)
+class TierRecommendation:
+    """Stable tier decision plus a machine-readable reason code."""
+
+    tier: CapabilityTier
+    reason_code: str
+
+
+def recommend_capability_tier(contract: TaskContract) -> TierRecommendation:
+    """Recommend the lowest safe capability tier from explicit contract facts.
+
+    High-risk or architecture/ambiguity flags dominate lower-tier hints. The
+    function performs no I/O and names no model or provider.
+    """
+
+    if contract.high_risk:
+        return TierRecommendation(CapabilityTier.L4_HIGHEST_REASONING, "high_risk")
+    if contract.architecture_or_ambiguous:
+        return TierRecommendation(
+            CapabilityTier.L4_HIGHEST_REASONING,
+            "architecture_or_ambiguous",
+        )
+    if contract.complex_cross_component:
+        return TierRecommendation(CapabilityTier.L3_FRONTIER, "complex_cross_component")
+    if contract.bounded_implementation:
+        if contract.objective_verification:
+            return TierRecommendation(
+                CapabilityTier.L2_LOCAL_STRONG,
+                "bounded_implementation_verified",
+            )
+        return TierRecommendation(
+            CapabilityTier.L3_FRONTIER,
+            "bounded_implementation_unverified",
+        )
+    if contract.repetitive_or_inspection:
+        return TierRecommendation(CapabilityTier.L1_LOCAL_BOUNDED, "bounded_routine")
+    if contract.objective_verification:
+        return TierRecommendation(CapabilityTier.L0_DETERMINISTIC, "objective_deterministic")
+    return TierRecommendation(CapabilityTier.L3_FRONTIER, "unverified_default")
+
+
+__all__ = [
+    "CapabilityTier",
+    "TaskContract",
+    "TierRecommendation",
+    "recommend_capability_tier",
+]

--- a/tests/test_solution_orchestration.py
+++ b/tests/test_solution_orchestration.py
@@ -1,0 +1,63 @@
+from kora.solution import CapabilityTier, TaskContract, recommend_capability_tier
+
+
+def test_objective_deterministic_work_routes_l0():
+    result = recommend_capability_tier(TaskContract(objective_verification=True))
+    assert result.tier is CapabilityTier.L0_DETERMINISTIC
+    assert result.reason_code == "objective_deterministic"
+
+
+def test_bounded_routine_routes_l1():
+    result = recommend_capability_tier(TaskContract(repetitive_or_inspection=True))
+    assert result.tier is CapabilityTier.L1_LOCAL_BOUNDED
+    assert result.reason_code == "bounded_routine"
+
+
+def test_verified_bounded_implementation_routes_l2():
+    result = recommend_capability_tier(
+        TaskContract(bounded_implementation=True, objective_verification=True)
+    )
+    assert result.tier is CapabilityTier.L2_LOCAL_STRONG
+    assert result.reason_code == "bounded_implementation_verified"
+
+
+def test_unverified_bounded_implementation_escalates_l3():
+    result = recommend_capability_tier(TaskContract(bounded_implementation=True))
+    assert result.tier is CapabilityTier.L3_FRONTIER
+    assert result.reason_code == "bounded_implementation_unverified"
+
+
+def test_complex_cross_component_routes_l3():
+    result = recommend_capability_tier(TaskContract(complex_cross_component=True))
+    assert result.tier is CapabilityTier.L3_FRONTIER
+    assert result.reason_code == "complex_cross_component"
+
+
+def test_architecture_routes_l4():
+    result = recommend_capability_tier(TaskContract(architecture_or_ambiguous=True))
+    assert result.tier is CapabilityTier.L4_HIGHEST_REASONING
+    assert result.reason_code == "architecture_or_ambiguous"
+
+
+def test_high_risk_prevents_unsafe_downrouting():
+    result = recommend_capability_tier(
+        TaskContract(
+            high_risk=True,
+            repetitive_or_inspection=True,
+            bounded_implementation=True,
+            objective_verification=True,
+        )
+    )
+    assert result.tier is CapabilityTier.L4_HIGHEST_REASONING
+    assert result.reason_code == "high_risk"
+
+
+def test_same_contract_is_stable():
+    contract = TaskContract(bounded_implementation=True, objective_verification=True)
+    assert recommend_capability_tier(contract) == recommend_capability_tier(contract)
+
+
+def test_unknown_unverified_work_fails_upward():
+    result = recommend_capability_tier(TaskContract())
+    assert result.tier is CapabilityTier.L3_FRONTIER
+    assert result.reason_code == "unverified_default"


### PR DESCRIPTION
## S6 / Task028 — capability-aware orchestration primitive

This is the first bounded implementation slice for capability-aware intelligence orchestration.

### Scope
- provider-neutral L0-L4 capability tiers;
- immutable bounded `TaskContract`;
- deterministic, side-effect-free tier recommendation;
- high-risk and architecture/ambiguity fail upward to the highest reasoning tier;
- bounded implementation routes local-strong only when objective verification exists;
- unknown/unverified work fails upward rather than being forced local.

### Validation
- targeted orchestration tests: 9 passed;
- Ruff: PASS;
- compileall: PASS;
- `git diff --check`: PASS;
- full repository regression: 798 passed;
- changed-file private-path / credential / prohibited assistant-tool-name scan: PASS.

### Evidence boundary
This PR is mechanism/implementation evidence only. It does not establish a frontier-token reduction percentage, customer savings, production readiness, autonomous software engineering, local-model superiority, or general frontier replacement. A separately measured realistic frontier-heavy control versus KORA orchestration run is still required for economics evidence.
